### PR TITLE
編集機能の基盤を追加（小ファイルの編集と保存）

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -27,6 +27,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return true
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard let c = windowController else { return .terminateNow }
+        return c.confirmTerminate() ? .terminateNow : .terminateCancel
+    }
+
     // Finder からの「で開く」/ ファイルドロップ（複数可）
     func application(_ application: NSApplication, open urls: [URL]) {
         let c = ensureController()
@@ -54,6 +59,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func performCloseDocument(_ sender: Any?) {
         if let c = windowController { c.closeActiveDocument() } else { NSApp.keyWindow?.performClose(nil) }
     }
+
+    @objc private func performSave(_ sender: Any?) { windowController?.saveActiveDocument() }
+    @objc private func performSaveAs(_ sender: Any?) { windowController?.saveActiveDocumentAs() }
 
     @objc private func performGoToLine(_ sender: Any?) { windowController?.promptGoToLine() }
 
@@ -139,6 +147,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         fileMenu.addItem(recentItem)
         self.recentMenu = recent
         fileMenu.addItem(.separator())
+        let saveItem = NSMenuItem(title: L("menu.save"),
+                                  action: #selector(performSave(_:)), keyEquivalent: "s")
+        saveItem.target = self
+        fileMenu.addItem(saveItem)
+        let saveAsItem = NSMenuItem(title: L("menu.saveAs"),
+                                    action: #selector(performSaveAs(_:)), keyEquivalent: "S")
+        saveAsItem.keyEquivalentModifierMask = [.command, .shift]
+        saveAsItem.target = self
+        fileMenu.addItem(saveAsItem)
+        fileMenu.addItem(.separator())
         let closeItem = NSMenuItem(title: L("menu.close"),
                                    action: #selector(performCloseDocument(_:)), keyEquivalent: "w")
         closeItem.target = self
@@ -149,10 +167,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         mainMenu.addItem(editMenuItem)
         let editMenu = NSMenu(title: "Edit")
         editMenuItem.submenu = editMenu
-        // コピー（⌘C）: target nil でレスポンダチェーン（DocumentView.copy）へ。
+        // アンドゥ／リドゥ（⌘Z / ⌘⇧Z）: target nil でレスポンダチェーン（NSTextView）へ。
+        let undoItem = NSMenuItem(title: L("menu.undo"),
+                                  action: Selector(("undo:")), keyEquivalent: "z")
+        editMenu.addItem(undoItem)
+        let redoItem = NSMenuItem(title: L("menu.redo"),
+                                  action: Selector(("redo:")), keyEquivalent: "Z")
+        redoItem.keyEquivalentModifierMask = [.command, .shift]
+        editMenu.addItem(redoItem)
+        editMenu.addItem(.separator())
+        // 切り取り／コピー／貼り付け／全選択: target nil でレスポンダチェーンへ
+        // （編集ペインは NSTextView、ビューアはコピーのみ DocumentView が処理）。
+        let cutItem = NSMenuItem(title: L("menu.cut"),
+                                 action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(cutItem)
         let copyItem = NSMenuItem(title: L("menu.copy"),
                                   action: #selector(NSText.copy(_:)), keyEquivalent: "c")
         editMenu.addItem(copyItem)
+        let pasteItem = NSMenuItem(title: L("menu.paste"),
+                                   action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(pasteItem)
+        let selectAllItem = NSMenuItem(title: L("menu.selectAll"),
+                                       action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenu.addItem(selectAllItem)
         editMenu.addItem(.separator())
         let findItem = NSMenuItem(title: L("menu.find"),
                                   action: #selector(performFind(_:)), keyEquivalent: "f")

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -16,17 +16,17 @@ final class DropView: NSView {
 }
 
 /// メインウィンドウ。左に開いているドキュメントの縦リスト、右に本文＋ステータスバー。
-final class MainWindowController: NSWindowController {
+final class MainWindowController: NSWindowController, NSWindowDelegate {
     private let statusBar = StatusBarView()
     private let searchBar = SearchBarView()
 
     private let sidebar = SidebarView()
     private let viewerContainer = DropView()
 
-    /// 開いているファイル（1ファイル＝1ビューア。表示を切り替えるだけ）。
-    private var viewers: [LargeFileViewer] = []
+    /// 開いているファイル（1ファイル＝1ペイン。表示を切り替えるだけ）。
+    private var viewers: [DocumentPane] = []
     private var activeIndex = -1
-    private var activeViewer: LargeFileViewer? {
+    private var activeViewer: DocumentPane? {
         (activeIndex >= 0 && activeIndex < viewers.count) ? viewers[activeIndex] : nil
     }
 
@@ -44,8 +44,12 @@ final class MainWindowController: NSWindowController {
         window.setFrameAutosaveName("MrEditorMainWindow")
         window.tabbingMode = .disallowed
         self.init(window: window)
+        window.delegate = self
         setupContent()
     }
+
+    /// 未保存変更でウィンドウを閉じる際の二重確認を抑止するフラグ。
+    private var forceClose = false
 
     private func setupContent() {
         guard let content = window?.contentView else { return }
@@ -111,7 +115,7 @@ final class MainWindowController: NSWindowController {
             activate(i); return
         }
 
-        let v = LargeFileViewer()
+        let v = makePane(for: url)
         v.translatesAutoresizingMaskIntoConstraints = false
         v.isHidden = true
         wire(v)
@@ -129,12 +133,21 @@ final class MainWindowController: NSWindowController {
         activate(viewers.count - 1)
     }
 
+    /// ファイルサイズで開くペインを決める（小＝編集、大＝読み取り専用ビューア）。
+    private func makePane(for url: URL) -> DocumentPane {
+        let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
+        if let size, size <= EditableViewer.sizeThreshold {
+            return EditableViewer()
+        }
+        return LargeFileViewer()
+    }
+
     private func reloadSidebar() {
         sidebar.reload(names: viewers.map { $0.fileURL?.lastPathComponent ?? "—" }, active: activeIndex)
     }
 
     /// 各ビューアにステータス/検索/ドロップのハンドラを繋ぐ（アクティブな時だけ反映）。
-    private func wire(_ v: LargeFileViewer) {
+    private func wire(_ v: DocumentPane) {
         v.onStateChange = { [weak self, weak v] state in
             guard let self, self.activeViewer === v else { return }
             self.statusBar.update(state)
@@ -144,6 +157,17 @@ final class MainWindowController: NSWindowController {
             self.searchBar.setCount(current: cur, total: tot, searching: searching, progress: prog, invalid: invalid)
         }
         v.onDropFiles = { [weak self] urls in urls.forEach { self?.open(url: $0) } }
+        if let e = v as? EditableViewer {
+            e.onDirtyChange = { [weak self, weak e] dirty in
+                guard let self, self.activeViewer === e else { return }
+                self.window?.isDocumentEdited = dirty
+            }
+        }
+    }
+
+    /// タイトルバーの編集済みドット（active なペインの未保存状態を反映）。
+    private func updateEditedState() {
+        window?.isDocumentEdited = (activeViewer as? EditableViewer)?.isDirty ?? false
     }
 
     /// 指定インデックスのドキュメントをアクティブにする。
@@ -156,24 +180,119 @@ final class MainWindowController: NSWindowController {
         v.reEmitState()                            // ステータスバーを現在の状態に更新
         sidebar.setActive(index)
         window?.title = (v.fileURL?.lastPathComponent ?? AppInfo.name) + " — " + AppInfo.name
+        updateEditedState()
         v.focusContent()
     }
 
-    /// アクティブなドキュメントを閉じる（なければウィンドウを閉じる）。
+    /// アクティブなドキュメントを閉じる（なければウィンドウを閉じる）。未保存なら確認する。
     func closeActiveDocument() {
         guard activeIndex >= 0 else { window?.performClose(nil); return }
+        let pane = viewers[activeIndex]
+        confirmClose(pane) { [weak self] proceed in
+            guard let self, proceed else { return }
+            self.removePane(pane)
+        }
+    }
+
+    /// 未保存なら確認シートを出し、閉じてよいか（保存/破棄=true、キャンセル=false）を返す。
+    private func confirmClose(_ pane: DocumentPane, _ completion: @escaping (Bool) -> Void) {
+        guard let e = pane as? EditableViewer, e.isDirty, let win = window else { completion(true); return }
+        let alert = NSAlert()
+        alert.messageText = L("close.unsavedTitle", e.fileURL?.lastPathComponent ?? "")
+        alert.informativeText = L("close.unsavedMessage")
+        alert.addButton(withTitle: L("common.save"))       // .alertFirstButtonReturn
+        alert.addButton(withTitle: L("common.cancel"))     // .alertSecondButtonReturn
+        alert.addButton(withTitle: L("common.dontSave"))   // .alertThirdButtonReturn
+        alert.beginSheetModal(for: win) { resp in
+            switch resp {
+            case .alertFirstButtonReturn: completion(e.save())
+            case .alertThirdButtonReturn: completion(true)
+            default: completion(false)
+            }
+        }
+    }
+
+    /// ペインを実際に閉じる（確認済み前提）。
+    private func removePane(_ pane: DocumentPane) {
+        guard let idx = viewers.firstIndex(where: { $0 === pane }) else { return }
         if !searchBar.isHidden { hideSearch() }
-        let v = viewers.remove(at: activeIndex)
+        let v = viewers.remove(at: idx)
         v.removeFromSuperview()
         if viewers.isEmpty {
             activeIndex = -1
             reloadSidebar()
             window?.title = AppInfo.name
             statusBar.setPlaceholder()
+            updateEditedState()
         } else {
-            activeIndex = min(activeIndex, viewers.count - 1)
+            activeIndex = min(idx, viewers.count - 1)
             reloadSidebar()
             activate(activeIndex)
+        }
+    }
+
+    // MARK: - 保存
+
+    func saveActiveDocument() {
+        guard let e = activeViewer as? EditableViewer else { NSSound.beep(); return }
+        if e.save() { afterSave(e) }
+    }
+
+    func saveActiveDocumentAs() {
+        guard let e = activeViewer as? EditableViewer else { NSSound.beep(); return }
+        if e.saveAs() { afterSave(e) }
+    }
+
+    /// 保存後の UI 更新（保存先変更でファイル名が変わりうる）。
+    private func afterSave(_ e: EditableViewer) {
+        if let url = e.fileURL { NSDocumentController.shared.noteNewRecentDocumentURL(url) }
+        reloadSidebar()
+        if activeViewer === e {
+            window?.title = (e.fileURL?.lastPathComponent ?? AppInfo.name) + " — " + AppInfo.name
+        }
+        updateEditedState()
+    }
+
+    // MARK: - NSWindowDelegate
+
+    /// ウィンドウを閉じる前に未保存のドキュメントを確認する。
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        if forceClose { return true }
+        let dirty = viewers.compactMap { $0 as? EditableViewer }.filter { $0.isDirty }
+        if dirty.isEmpty { return true }
+        let alert = NSAlert()
+        alert.messageText = L("close.unsavedAllTitle", dirty.count)
+        alert.informativeText = L("close.unsavedMessage")
+        alert.addButton(withTitle: L("common.saveAll"))    // .alertFirstButtonReturn
+        alert.addButton(withTitle: L("common.cancel"))     // .alertSecondButtonReturn
+        alert.addButton(withTitle: L("common.discard"))    // .alertThirdButtonReturn
+        alert.beginSheetModal(for: sender) { [weak self] resp in
+            guard let self else { return }
+            switch resp {
+            case .alertFirstButtonReturn:
+                if dirty.allSatisfy({ $0.save() }) { self.forceClose = true; sender.close() }
+            case .alertThirdButtonReturn:
+                self.forceClose = true; sender.close()
+            default: break
+            }
+        }
+        return false
+    }
+
+    /// アプリ終了前の未保存確認（同期）。終了してよければ true。
+    func confirmTerminate() -> Bool {
+        let dirty = viewers.compactMap { $0 as? EditableViewer }.filter { $0.isDirty }
+        if dirty.isEmpty { return true }
+        let alert = NSAlert()
+        alert.messageText = L("close.unsavedAllTitle", dirty.count)
+        alert.informativeText = L("close.unsavedMessage")
+        alert.addButton(withTitle: L("common.saveAll"))
+        alert.addButton(withTitle: L("common.cancel"))
+        alert.addButton(withTitle: L("common.discard"))
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return dirty.allSatisfy { $0.save() }
+        case .alertThirdButtonReturn: return true
+        default: return false
         }
     }
 
@@ -181,7 +300,7 @@ final class MainWindowController: NSWindowController {
 
     @discardableResult
     func toggleFollow() -> Bool {
-        guard let v = activeViewer else { return false }
+        guard let v = activeViewer, v.supportsFollow else { NSSound.beep(); return false }
         v.setFollowMode(!v.isFollowing)
         return v.isFollowing
     }
@@ -220,7 +339,7 @@ final class MainWindowController: NSWindowController {
     }
 
     func showSearch() {
-        guard activeViewer != nil else { return }
+        guard let v = activeViewer, v.supportsSearch else { NSSound.beep(); return }
         searchBar.isHidden = false
         searchBar.focusField()
     }

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -9,7 +9,19 @@
 "menu.openRecent" = "Open Recent";
 "menu.recentEmpty" = "No Recent Files";
 "menu.clearRecent" = "Clear Menu";
+"menu.save" = "Save";
+"menu.saveAs" = "Save As…";
 "menu.close" = "Close";
+
+/* Save / unsaved confirmation */
+"save.encodingFallback" = "Some characters can’t be represented in %@, so the file will be saved as UTF-8.";
+"close.unsavedTitle" = "Save changes to “%@”?";
+"close.unsavedAllTitle" = "You have unsaved changes in %d document(s). Save them?";
+"close.unsavedMessage" = "Your changes will be lost if you don’t save them.";
+"common.save" = "Save";
+"common.saveAll" = "Save All";
+"common.dontSave" = "Don’t Save";
+"common.discard" = "Discard";
 
 /* Status bar */
 "status.placeholder" = "Drag a file here, or press ⌘O to open";
@@ -28,7 +40,12 @@
 "common.cancel" = "Cancel";
 
 /* Edit */
+"menu.undo" = "Undo";
+"menu.redo" = "Redo";
+"menu.cut" = "Cut";
 "menu.copy" = "Copy";
+"menu.paste" = "Paste";
+"menu.selectAll" = "Select All";
 
 /* Search */
 "menu.find" = "Find…";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -9,7 +9,19 @@
 "menu.openRecent" = "最近使った項目を開く";
 "menu.recentEmpty" = "最近使った項目はありません";
 "menu.clearRecent" = "メニューを消去";
+"menu.save" = "保存";
+"menu.saveAs" = "別名で保存…";
 "menu.close" = "閉じる";
+
+/* 保存・未保存確認 */
+"save.encodingFallback" = "%@ で表現できない文字が含まれるため、UTF-8 で保存します。";
+"close.unsavedTitle" = "“%@” の変更を保存しますか？";
+"close.unsavedAllTitle" = "%d 件のドキュメントに未保存の変更があります。保存しますか？";
+"close.unsavedMessage" = "保存しないと変更内容は失われます。";
+"common.save" = "保存";
+"common.saveAll" = "すべて保存";
+"common.dontSave" = "保存しない";
+"common.discard" = "破棄";
 
 /* ステータスバー */
 "status.placeholder" = "ファイルをドラッグ、または ⌘O で開く";
@@ -28,7 +40,12 @@
 "common.cancel" = "キャンセル";
 
 /* 編集 */
+"menu.undo" = "取り消す";
+"menu.redo" = "やり直す";
+"menu.cut" = "カット";
 "menu.copy" = "コピー";
+"menu.paste" = "ペースト";
+"menu.selectAll" = "すべてを選択";
 
 /* 検索 */
 "menu.find" = "検索…";

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -1,0 +1,61 @@
+import AppKit
+
+/// 1 ドキュメント＝1 ペインの共通インターフェース。
+///
+/// 大ファイルは読み取り専用の `LargeFileViewer`（mmap + スパース索引）、
+/// 小ファイルは全読み込み編集の `EditableViewer`（NSTextView）が担う。
+/// `MainWindowController` は具体型を意識せず、このプロトコル越しに扱う。
+///
+/// 検索・追従・行ジャンプは `LargeFileViewer` 固有の機能。編集ペインでは
+/// 既定実装（no-op）に委ね、`supportsSearch` / `supportsFollow` で能力を申告する。
+protocol DocumentPane: NSView {
+    /// 開いているファイル（サイドバー／タイトル表示用）。
+    var fileURL: URL? { get }
+
+    /// ステータスバー更新の通知。
+    var onStateChange: ((ViewerState) -> Void)? { get set }
+    /// 検索状態の通知（検索バーの件数表示用）。編集ペインでは未使用。
+    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)? { get set }
+    /// ファイルがドロップされたとき（新規ドキュメントとして開くのはコントローラ側）。
+    var onDropFiles: (([URL]) -> Void)? { get set }
+
+    /// ファイルを開く。失敗時は false。
+    @discardableResult func open(url: URL) -> Bool
+    /// 現在の状態を `onStateChange` に再送信する（ドキュメント切替時のステータスバー更新用）。
+    func reEmitState()
+    /// 本文へフォーカスを戻す。
+    func focusContent()
+    /// 現在のグローバルフォントサイズを自身の表示へ反映する。
+    func applyCurrentFontSize()
+
+    /// 検索・フィルタに対応するか（検索バーを出してよいか）。
+    var supportsSearch: Bool { get }
+    /// 末尾追従（tail -f）に対応するか。
+    var supportsFollow: Bool { get }
+
+    // 検索／追従／行ジャンプ（編集ペインでは既定で no-op）。
+    func setSearchQuery(_ q: String)
+    func setCaseSensitive(_ on: Bool)
+    func setRegexMode(_ on: Bool)
+    func setFilterMode(_ on: Bool)
+    func findNext()
+    func findPrev()
+    func setFollowMode(_ on: Bool)
+    var isFollowing: Bool { get }
+    func goToLine(_ line1Based: Int)
+}
+
+extension DocumentPane {
+    var supportsSearch: Bool { true }
+    var supportsFollow: Bool { true }
+
+    func setSearchQuery(_ q: String) {}
+    func setCaseSensitive(_ on: Bool) {}
+    func setRegexMode(_ on: Bool) {}
+    func setFilterMode(_ on: Bool) {}
+    func findNext() {}
+    func findPrev() {}
+    func setFollowMode(_ on: Bool) {}
+    var isFollowing: Bool { false }
+    func goToLine(_ line1Based: Int) {}
+}

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -1,0 +1,203 @@
+import AppKit
+
+/// 小ファイル用の編集ペイン。ファイル全体をメモリに読み込み、`NSTextView` で
+/// 編集する（アンドゥ・IME・選択・標準コピーは AppKit 標準機能に委ねる）。
+///
+/// 大ファイルは `LargeFileViewer`（mmap + スパース索引・読み取り専用）が担う。
+/// 振り分けの閾値は `EditableViewer.sizeThreshold`。
+final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
+    /// この閾値以下のファイルを編集ペインで開く（超過は読み取り専用ビューア）。
+    static let sizeThreshold = 8 * 1024 * 1024
+
+    private let scrollView = NSScrollView()
+    private let textView = NSTextView()
+
+    private(set) var fileURL: URL?
+    private var encoding: DetectedEncoding = .utf8
+    private var byteSize = 0
+
+    /// 未保存の変更があるか。
+    private(set) var isDirty = false
+    /// 変更状態が変わったときの通知（タイトルバーの edited 表示用）。
+    var onDirtyChange: ((Bool) -> Void)?
+
+    var onStateChange: ((ViewerState) -> Void)?
+    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)?   // 編集ペインでは未使用
+    var onDropFiles: (([URL]) -> Void)?
+
+    // 編集ペインは検索バー／末尾追従を出さない。
+    var supportsSearch: Bool { false }
+    var supportsFollow: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.borderType = .noBorder
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.font = LargeFileViewer.editorFont()
+        textView.textContainerInset = NSSize(width: 4, height: 6)
+
+        // 横スクロールせず、テキストコンテナの幅をビューに追従させる（ワードラップ）。
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.delegate = self
+
+        scrollView.documentView = textView
+        addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    override var isFlipped: Bool { true }
+
+    // MARK: - ファイルを開く
+
+    @discardableResult
+    func open(url: URL) -> Bool {
+        guard let data = try? Data(contentsOf: url) else {
+            NSSound.beep()
+            return false
+        }
+        let detected = EncodingDetector.detect(data.prefix(64 * 1024))
+        // 検出エンコードでデコード。失敗時は UTF-8 置換デコードへフォールバック。
+        let text: String
+        if let s = String(data: data, encoding: detected.stringEncoding) {
+            text = s
+        } else {
+            text = String(decoding: data, as: UTF8.self)
+        }
+        self.fileURL = url
+        self.encoding = detected
+        self.byteSize = data.count
+        textView.string = text
+        textView.undoManager?.removeAllActions()   // 読み込みはアンドゥ対象にしない
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        setDirty(false)
+        emitState()
+        return true
+    }
+
+    // MARK: - 保存
+
+    /// 変更状態を更新し、変化があれば通知する。
+    private func setDirty(_ value: Bool) {
+        guard value != isDirty else { return }
+        isDirty = value
+        onDirtyChange?(value)
+    }
+
+    /// 既存パスへ保存（パスが無ければ saveAs）。成功で true。
+    @discardableResult
+    func save() -> Bool {
+        guard let url = fileURL else { return saveAs() }
+        return write(to: url)
+    }
+
+    /// 保存先を選んで保存（NSSavePanel）。成功で true。
+    @discardableResult
+    func saveAs() -> Bool {
+        let panel = NSSavePanel()
+        if let url = fileURL {
+            panel.directoryURL = url.deletingLastPathComponent()
+            panel.nameFieldStringValue = url.lastPathComponent
+        }
+        guard panel.runModal() == .OK, let url = panel.url else { return false }
+        return write(to: url)
+    }
+
+    /// 現在のテキストを検出エンコードで原子的に書き出す。
+    /// 検出エンコードで表現できない文字が増えていれば UTF-8 にフォールバックする。
+    private func write(to url: URL) -> Bool {
+        let s = textView.string
+        var enc = encoding
+        var data = s.data(using: enc.stringEncoding)
+        if data == nil {
+            let original = enc.displayName
+            enc = .utf8
+            data = s.data(using: .utf8)
+            let a = NSAlert()
+            a.messageText = L("save.encodingFallback", original)
+            a.runModal()
+        }
+        guard let data else { NSSound.beep(); return false }
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            NSAlert(error: error).runModal()
+            return false
+        }
+        encoding = enc
+        fileURL = url
+        byteSize = data.count
+        setDirty(false)
+        emitState()
+        return true
+    }
+
+    // MARK: - NSTextViewDelegate
+
+    func textDidChange(_ notification: Notification) {
+        setDirty(true)
+        emitState()   // 行数・状態を更新
+    }
+
+    // MARK: - DocumentPane
+
+    func reEmitState() { emitState() }
+
+    func focusContent() {
+        window?.makeFirstResponder(textView)
+    }
+
+    func applyCurrentFontSize() {
+        textView.font = LargeFileViewer.editorFont()
+    }
+
+    private func emitState() {
+        let state = ViewerState(
+            encodingName: encoding.displayName,
+            lineCount: lineCount(of: textView.string),
+            lineCountIsExact: true,
+            fileSize: byteSize,
+            indexProgress: 1.0
+        )
+        onStateChange?(state)
+    }
+
+    /// 行数（末尾に改行がなければその行も 1 行として数える）。空文字列は 0 行。
+    private func lineCount(of s: String) -> Int {
+        if s.isEmpty { return 0 }
+        var count = 0
+        for ch in s where ch == "\n" { count += 1 }
+        return s.hasSuffix("\n") ? count : count + 1
+    }
+}

--- a/Sources/MrEditor/Viewer/LargeFileViewer.swift
+++ b/Sources/MrEditor/Viewer/LargeFileViewer.swift
@@ -13,7 +13,7 @@ struct ViewerState {
 ///
 /// NSScrollView の巨大 documentView は使わず、固定サイズの `DocumentView` と
 /// 自前の `NSScroller`（単位＝行）で任意サイズへスケールさせる。
-final class LargeFileViewer: NSView {
+final class LargeFileViewer: NSView, DocumentPane {
     private let documentView = DocumentView()
     private let scroller = NSScroller(frame: NSRect(x: 0, y: 0, width: 16, height: 100))
 


### PR DESCRIPTION
読み取り専用ビューアに編集機能を載せる第一弾。1.0 マイルストーン（CRUD）へ向けた基盤です。

## 方針
- **サイズ分岐**：8MB 以下は編集ペイン（`NSTextView` 全読み込み）、超過は従来の読み取り専用ビューア（mmap + スパース索引）。
- 両ペインを `DocumentPane` プロトコルで抽象化。検索・追従・行ジャンプは編集ペインでは no-op 既定実装に委ね、`supportsSearch`/`supportsFollow` で能力申告。

## 変更点
**Slice 1 — 振り分け＋編集ペイン表示**
- `DocumentPane`：両ペイン共通インターフェース
- `EditableViewer`：全読み込み・検出エンコードでデコード（`EncodingDetector` 再利用）
- `MainWindowController`：`viewers: [DocumentPane]`、`makePane(for:)` でサイズ分岐

**Slice 2 — 保存**
- dirty 追跡（`textDidChange`）→ タイトルバー編集ドット（`isDocumentEdited`）
- ⌘S 保存 / ⌘⇧S 別名で保存（原子的書き戻し、表現不能時は UTF-8 フォールバック）
- 未保存クローズ（⌘W）・ウィンドウクローズ・終了（⌘Q）の確認シート
- メニュー：保存・別名で保存・取り消す・やり直す・カット・ペースト・全選択
- ローカライズ（en/ja）追加

## 動作確認（実機）
- 小ファイル→編集ペイン／50MB→読み取り専用ビューア の振り分け、サイドバー切替、ステータスバー、キャレット表示すべて正常
- **custom-draw 合成バグは発生せず**（標準 NSTextView はサイドバー等と共存）
- ⌘S でディスクへ書き戻り（5180→5197B、ハッシュ変化、日本語 UTF-8 無事）、保存後に編集ドット消灯

## 未対応（Slice 3 予定）
- 新規ファイル（⌘N）
- 大ファイルの読み取り専用バナー表示
- 編集ペインで検索メニューが無効なときの見え方調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)