### PR TITLE
編集機能の仕上げ（Slice 3）＋ 巨大ファイル編集の基盤（PieceTable B0）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ testdata/
 # macOS
 .DS_Store
 
+# エディタ
+.vscode/
+
 # Xcode
 build/
 DerivedData/

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
+        ),
+        .testTarget(
+            name: "MrEditorTests",
+            dependencies: ["MrEditor"],
+            path: "Tests/MrEditorTests"
         )
     ]
 )

--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -45,6 +45,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return c
     }
 
+    @objc private func newDocument(_ sender: Any?) {
+        ensureController().newDocument()
+    }
+
     @objc private func openDocument(_ sender: Any?) {
         ensureController().openDocument(sender)
     }
@@ -111,6 +115,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         followItem?.state = on ? .on : .off
     }
 
+    // MARK: - メニュー有効/無効
+
+    /// アクティブなドキュメントの能力に応じてメニュー項目を有効/無効にする。
+    /// （target nil の編集系＝Undo/Cut 等は NSTextView が自動で検証する。）
+    func validateMenuItem(_ item: NSMenuItem) -> Bool {
+        guard let c = windowController else { return true }
+        switch item.action {
+        case #selector(performSave(_:)), #selector(performSaveAs(_:)):
+            return c.canSave
+        case #selector(performFind(_:)), #selector(performFindNext(_:)), #selector(performFindPrev(_:)):
+            return c.canSearch
+        case #selector(performFollow(_:)):
+            item.state = c.isFollowingActive ? .on : .off
+            return c.canFollow
+        case #selector(performGoToLine(_:)), #selector(performCloseDocument(_:)):
+            return c.hasActiveDocument
+        default:
+            return true
+        }
+    }
+
     // MARK: - メニュー
 
     private func buildMenu() {
@@ -135,6 +160,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         mainMenu.addItem(fileMenuItem)
         let fileMenu = NSMenu(title: L("menu.file"))
         fileMenuItem.submenu = fileMenu
+        let newItem = NSMenuItem(title: L("menu.new"),
+                                 action: #selector(newDocument(_:)), keyEquivalent: "n")
+        newItem.target = self
+        fileMenu.addItem(newItem)
         let openItem = NSMenuItem(title: L("menu.open"),
                                   action: #selector(openDocument(_:)), keyEquivalent: "o")
         openItem.target = self

--- a/Sources/MrEditor/Core/PieceTable.swift
+++ b/Sources/MrEditor/Core/PieceTable.swift
@@ -1,0 +1,338 @@
+import Foundation
+
+/// piece table のバイト供給源（原本ファイル or テスト用インメモリ）。
+/// 全文をメモリに載せないため、必要な範囲だけ `read` で取り出す。
+protocol PieceSource {
+    var count: Int { get }
+    /// 範囲 `r`（ファイル内にクランプ）を生バイトで返す。
+    func read(_ r: Range<Int>) -> [UInt8]
+}
+
+/// インメモリのバイト供給源（テスト・小バッファ用）。
+struct InMemorySource: PieceSource {
+    private let bytes: [UInt8]
+    init(_ bytes: [UInt8]) { self.bytes = bytes }
+    var count: Int { bytes.count }
+    func read(_ r: Range<Int>) -> [UInt8] {
+        let lo = max(0, r.lowerBound), hi = min(bytes.count, r.upperBound)
+        guard lo < hi else { return [] }
+        return Array(bytes[lo..<hi])
+    }
+}
+
+/// 決定的な擬似乱数（treap の優先度用。木の形だけに影響し、正しさには無関係）。
+private struct SplitMix64: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+/// バイト空間で文書を表す piece table。
+///
+/// 原本（不変・mmap など）と追記バッファ（入力分）の2供給源を、ピース列として
+/// 並べて論理文書を表現する。途中挿入は「ピースを分割して差し込む」だけで、
+/// 以降の全バイトをシフトしない。ピースは treap（split / merge）で平衡を保ち、
+/// 各ノードに部分木のバイト数・改行数を集計しておくことで、行↔バイト変換を
+/// O(log n) で解く。
+///
+/// 行分割はバイト 0x0A のみ（UTF-8 / Shift-JIS / EUC-JP のいずれも 0x0A は
+/// マルチバイト文字の途中に現れない）。行数の数え方は `LineIndex.displayLineCount`
+/// と整合（空文書=0、末尾に改行が無ければその行も1行と数える）。
+final class PieceTable {
+    private enum Source { case original, add }
+
+    private struct Piece {
+        var source: Source
+        var start: Int      // 供給源内の開始バイト
+        var length: Int     // バイト長
+        var newlines: Int   // この範囲に含まれる 0x0A の数（生成時に確定）
+    }
+
+    private final class Node {
+        var piece: Piece
+        var priority: UInt64
+        var left: Node?
+        var right: Node?
+        var subtreeBytes: Int
+        var subtreeNewlines: Int
+        init(_ piece: Piece, priority: UInt64) {
+            self.piece = piece
+            self.priority = priority
+            self.subtreeBytes = piece.length
+            self.subtreeNewlines = piece.newlines
+        }
+    }
+
+    private let original: PieceSource
+    private var add: [UInt8] = []
+    private var root: Node?
+    private var rng = SplitMix64(seed: 0x1234_5678_9ABC_DEF0)
+
+    /// 改行走査・部分読み取りのチャンク幅（巨大ピースを一度に読まないため）。
+    private let scanChunk = 64 * 1024
+
+    /// 原本から初期化する。`originalNewlines` を渡せば初回スキャンを省略できる（B1で利用）。
+    init(original: PieceSource, originalNewlines: Int? = nil) {
+        self.original = original
+        if original.count > 0 {
+            let nl = originalNewlines ?? countNewlines(in: .original, 0..<original.count)
+            let piece = Piece(source: .original, start: 0, length: original.count, newlines: nl)
+            root = Node(piece, priority: rng.next())
+        }
+    }
+
+    /// テスト用：バイト列から直接作る。
+    convenience init(bytes: [UInt8]) {
+        self.init(original: InMemorySource(bytes))
+    }
+
+    // MARK: - 集計
+
+    var byteCount: Int { root?.subtreeBytes ?? 0 }
+
+    /// 論理行数（空=0、末尾に改行が無ければ最終行も数える）。
+    var lineCount: Int {
+        let n = byteCount
+        guard n > 0 else { return 0 }
+        let nl = root?.subtreeNewlines ?? 0
+        let lastIsNewline = bytes(in: (n - 1)..<n).first == 0x0A
+        return nl + (lastIsNewline ? 0 : 1)
+    }
+
+    private func bytesOf(_ n: Node?) -> Int { n?.subtreeBytes ?? 0 }
+    private func newlinesOf(_ n: Node?) -> Int { n?.subtreeNewlines ?? 0 }
+
+    private func update(_ n: Node) {
+        n.subtreeBytes = bytesOf(n.left) + n.piece.length + bytesOf(n.right)
+        n.subtreeNewlines = newlinesOf(n.left) + n.piece.newlines + newlinesOf(n.right)
+    }
+
+    // MARK: - 編集
+
+    /// `offset` バイト目に `bytes` を挿入する。
+    func insert(_ bytes: [UInt8], at offset: Int) {
+        guard !bytes.isEmpty else { return }
+        let clamped = min(max(0, offset), byteCount)
+        let addStart = add.count
+        add.append(contentsOf: bytes)
+        let piece = Piece(source: .add, start: addStart,
+                          length: bytes.count, newlines: countNewlines(bytes))
+        let (l, r) = split(root, at: clamped)
+        let mid = Node(piece, priority: rng.next())
+        root = merge(merge(l, mid), r)
+    }
+
+    /// `range` のバイトを削除する。
+    func delete(_ range: Range<Int>) {
+        let lo = max(0, range.lowerBound), hi = min(byteCount, range.upperBound)
+        guard lo < hi else { return }
+        let (l, rest) = split(root, at: lo)
+        let (_, r) = split(rest, at: hi - lo)
+        root = merge(l, r)
+    }
+
+    // MARK: - 読み出し
+
+    /// `range` のバイトを取り出す。
+    func bytes(in range: Range<Int>) -> [UInt8] {
+        let lo = max(0, range.lowerBound), hi = min(byteCount, range.upperBound)
+        guard lo < hi else { return [] }
+        var out: [UInt8] = []
+        out.reserveCapacity(hi - lo)
+        collect(root, base: 0, lo: lo, hi: hi, into: &out)
+        return out
+    }
+
+    private func collect(_ node: Node?, base: Int, lo: Int, hi: Int, into out: inout [UInt8]) {
+        guard let node = node else { return }
+        let nodeStart = base + bytesOf(node.left)
+        let nodeEnd = nodeStart + node.piece.length
+        if lo < nodeStart {
+            collect(node.left, base: base, lo: lo, hi: hi, into: &out)
+        }
+        if lo < nodeEnd && hi > nodeStart {
+            let a = max(lo, nodeStart) - nodeStart
+            let b = min(hi, nodeEnd) - nodeStart
+            out.append(contentsOf: read(node.piece.source,
+                                        (node.piece.start + a)..<(node.piece.start + b)))
+        }
+        if hi > nodeEnd {
+            collect(node.right, base: nodeEnd, lo: lo, hi: hi, into: &out)
+        }
+    }
+
+    // MARK: - 行 ↔ バイト
+
+    /// 行 `line`（0始まり）の内容バイト範囲（終端の 0x0A は含めない）。
+    /// CRLF の CR 除去は呼び出し側（描画）で行う。
+    func byteRange(ofLine line: Int) -> Range<Int> {
+        let total = lineCount
+        guard total > 0, line >= 0, line < total else { return 0..<0 }
+        let nl = root?.subtreeNewlines ?? 0
+        let start = (line == 0) ? 0 : afterNewline(line - 1)
+        let end = (line < nl) ? afterNewline(line) - 1 : byteCount
+        return start..<max(start, end)
+    }
+
+    /// 行 `line`（0始まり）の先頭バイトオフセット。
+    func byteOffset(ofLineStart line: Int) -> Int {
+        let total = lineCount
+        let clamped = min(max(0, line), total)
+        if clamped == 0 { return 0 }
+        let nl = root?.subtreeNewlines ?? 0
+        if clamped - 1 < nl { return afterNewline(clamped - 1) }
+        return byteCount
+    }
+
+    /// バイトオフセット `off` を含む行（0始まり）＝ `[0, off)` の改行数。
+    func line(ofByteOffset off: Int) -> Int {
+        let target = min(max(0, off), byteCount)
+        var node = root
+        var count = 0
+        var base = 0
+        while let n = node {
+            let nodeStart = base + bytesOf(n.left)
+            let nodeEnd = nodeStart + n.piece.length
+            if target <= nodeStart {
+                node = n.left
+            } else if target >= nodeEnd {
+                count += newlinesOf(n.left) + n.piece.newlines
+                base = nodeEnd
+                node = n.right
+            } else {
+                count += newlinesOf(n.left)
+                let within = target - nodeStart
+                count += countNewlines(in: n.piece.source,
+                                       n.piece.start..<(n.piece.start + within))
+                break
+            }
+        }
+        return count
+    }
+
+    /// `j` 番目（0始まり）の改行の直後のバイトオフセット。前提: 0 <= j < 改行数。
+    private func afterNewline(_ j: Int) -> Int {
+        var node = root
+        var j = j
+        var base = 0
+        while let n = node {
+            let leftNL = newlinesOf(n.left)
+            if j < leftNL {
+                node = n.left
+            } else {
+                let inThisOrRight = j - leftNL
+                let nodeStart = base + bytesOf(n.left)
+                if inThisOrRight < n.piece.newlines {
+                    let local = nthNewlineOffset(in: n.piece, ordinal: inThisOrRight)
+                    return nodeStart + local + 1
+                }
+                j = inThisOrRight - n.piece.newlines
+                base = nodeStart + n.piece.length
+                node = n.right
+            }
+        }
+        return byteCount   // 到達しない
+    }
+
+    // MARK: - treap（split / merge）
+
+    /// バイト位置 `k` で木を二分する。`k` がピース内部に落ちればそのピースを割る。
+    private func split(_ node: Node?, at k: Int) -> (Node?, Node?) {
+        guard let node = node else { return (nil, nil) }
+        let leftBytes = bytesOf(node.left)
+        if k <= leftBytes {
+            let (l, r) = split(node.left, at: k)
+            node.left = r
+            update(node)
+            return (l, node)
+        } else if k >= leftBytes + node.piece.length {
+            let (l, r) = split(node.right, at: k - leftBytes - node.piece.length)
+            node.right = l
+            update(node)
+            return (node, r)
+        } else {
+            // k がこのノードのピース内部 → ピースを2つに割る
+            let offsetInPiece = k - leftBytes
+            let leftPiece = subPiece(node.piece, 0, offsetInPiece)
+            let rightPiece = subPiece(node.piece, offsetInPiece, node.piece.length - offsetInPiece)
+            let leftTree = merge(node.left, Node(leftPiece, priority: rng.next()))
+            let rightTree = merge(Node(rightPiece, priority: rng.next()), node.right)
+            return (leftTree, rightTree)
+        }
+    }
+
+    /// 位置順に隣接する2つの treap を結合する（`a` の全キー < `b` の全キー）。
+    private func merge(_ a: Node?, _ b: Node?) -> Node? {
+        guard let a = a else { return b }
+        guard let b = b else { return a }
+        if a.priority > b.priority {
+            a.right = merge(a.right, b)
+            update(a)
+            return a
+        } else {
+            b.left = merge(a, b.left)
+            update(b)
+            return b
+        }
+    }
+
+    /// ピースの部分ピースを作る（改行数は部分範囲を走査して数え直す）。
+    private func subPiece(_ p: Piece, _ from: Int, _ len: Int) -> Piece {
+        let r = (p.start + from)..<(p.start + from + len)
+        return Piece(source: p.source, start: p.start + from, length: len,
+                     newlines: countNewlines(in: p.source, r))
+    }
+
+    // MARK: - バイト供給・改行走査
+
+    private func read(_ s: Source, _ r: Range<Int>) -> [UInt8] {
+        switch s {
+        case .original:
+            return original.read(r)
+        case .add:
+            let lo = max(0, r.lowerBound), hi = min(add.count, r.upperBound)
+            guard lo < hi else { return [] }
+            return Array(add[lo..<hi])
+        }
+    }
+
+    private func countNewlines(_ bytes: [UInt8]) -> Int {
+        var c = 0
+        for b in bytes where b == 0x0A { c += 1 }
+        return c
+    }
+
+    /// 供給源の範囲をチャンク読みしながら 0x0A を数える（巨大範囲でもメモリ O(1)）。
+    private func countNewlines(in s: Source, _ range: Range<Int>) -> Int {
+        var count = 0
+        var pos = range.lowerBound
+        while pos < range.upperBound {
+            let len = min(scanChunk, range.upperBound - pos)
+            count += countNewlines(read(s, pos..<(pos + len)))
+            pos += len
+        }
+        return count
+    }
+
+    /// ピース内で `ordinal` 番目（0始まり）の 0x0A のピース内オフセットを返す。
+    private func nthNewlineOffset(in piece: Piece, ordinal: Int) -> Int {
+        var remaining = ordinal
+        var pos = 0
+        while pos < piece.length {
+            let len = min(scanChunk, piece.length - pos)
+            let chunk = read(piece.source, (piece.start + pos)..<(piece.start + pos + len))
+            for (i, b) in chunk.enumerated() where b == 0x0A {
+                if remaining == 0 { return pos + i }
+                remaining -= 1
+            }
+            pos += len
+        }
+        return max(0, piece.length - 1)   // 到達しない
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -19,9 +19,13 @@ final class DropView: NSView {
 final class MainWindowController: NSWindowController, NSWindowDelegate {
     private let statusBar = StatusBarView()
     private let searchBar = SearchBarView()
+    private let readOnlyBanner = ReadOnlyBanner()
 
     private let sidebar = SidebarView()
     private let viewerContainer = DropView()
+
+    /// 読み取り専用バナーを当セッション中は二度と出さない（× で閉じられたら true）。
+    private var readOnlyBannerDismissed = false
 
     /// 開いているファイル（1ファイル＝1ペイン。表示を切り替えるだけ）。
     private var viewers: [DocumentPane] = []
@@ -101,6 +105,20 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         searchBar.onCaseToggle = { [weak self] on in self?.activeViewer?.setCaseSensitive(on) }
         searchBar.onRegexToggle = { [weak self] on in self?.activeViewer?.setRegexMode(on) }
         searchBar.onFilterToggle = { [weak self] on in self?.activeViewer?.setFilterMode(on) }
+
+        // 読み取り専用バナー（本文領域の左上に浮かべる。大ファイルを開いたときだけ表示）
+        readOnlyBanner.translatesAutoresizingMaskIntoConstraints = false
+        readOnlyBanner.isHidden = true
+        readOnlyBanner.onClose = { [weak self] in
+            self?.readOnlyBannerDismissed = true
+            self?.readOnlyBanner.isHidden = true
+        }
+        content.addSubview(readOnlyBanner)
+        NSLayoutConstraint.activate([
+            readOnlyBanner.topAnchor.constraint(equalTo: viewerContainer.topAnchor, constant: 10),
+            readOnlyBanner.leadingAnchor.constraint(equalTo: viewerContainer.leadingAnchor, constant: 14),
+            readOnlyBanner.heightAnchor.constraint(equalToConstant: ReadOnlyBanner.height),
+        ])
     }
 
     // MARK: - ドキュメント管理
@@ -116,6 +134,28 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         }
 
         let v = makePane(for: url)
+        install(v)
+        guard v.open(url: url) else { v.removeFromSuperview(); return }
+        NSDocumentController.shared.noteNewRecentDocumentURL(url)
+        viewers.append(v)
+        reloadSidebar()
+        activate(viewers.count - 1)
+    }
+
+    /// 空の新規ドキュメントを作って開く（パスは保存時に確定）。
+    func newDocument() {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        let v = EditableViewer()
+        install(v)
+        v.newDocument()
+        viewers.append(v)
+        reloadSidebar()
+        activate(viewers.count - 1)
+    }
+
+    /// ペインを本文領域に敷き詰めて配置し、ハンドラを繋ぐ（初期は非表示）。
+    private func install(_ v: DocumentPane) {
         v.translatesAutoresizingMaskIntoConstraints = false
         v.isHidden = true
         wire(v)
@@ -126,11 +166,6 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             v.trailingAnchor.constraint(equalTo: viewerContainer.trailingAnchor),
             v.bottomAnchor.constraint(equalTo: viewerContainer.bottomAnchor),
         ])
-        guard v.open(url: url) else { v.removeFromSuperview(); return }
-        NSDocumentController.shared.noteNewRecentDocumentURL(url)
-        viewers.append(v)
-        reloadSidebar()
-        activate(viewers.count - 1)
     }
 
     /// ファイルサイズで開くペインを決める（小＝編集、大＝読み取り専用ビューア）。
@@ -143,8 +178,26 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func reloadSidebar() {
-        sidebar.reload(names: viewers.map { $0.fileURL?.lastPathComponent ?? "—" }, active: activeIndex)
+        sidebar.reload(names: viewers.map { displayName(of: $0) }, active: activeIndex)
     }
+
+    /// サイドバー／タイトル用の表示名（未保存の新規ドキュメントは「名称未設定」）。
+    private func displayName(of v: DocumentPane) -> String {
+        v.fileURL?.lastPathComponent ?? L("doc.untitled")
+    }
+
+    // MARK: - アクティブなドキュメントの能力（メニュー検証用）
+
+    /// 編集・保存できるドキュメントが開いているか。
+    var canSave: Bool { activeViewer is EditableViewer }
+    /// 検索できるドキュメントが開いているか。
+    var canSearch: Bool { activeViewer?.supportsSearch ?? false }
+    /// 末尾追従できるドキュメントが開いているか。
+    var canFollow: Bool { activeViewer?.supportsFollow ?? false }
+    /// 何かドキュメントが開いているか。
+    var hasActiveDocument: Bool { activeIndex >= 0 }
+    /// アクティブなドキュメントが末尾追従中か。
+    var isFollowingActive: Bool { activeViewer?.isFollowing ?? false }
 
     /// 各ビューアにステータス/検索/ドロップのハンドラを繋ぐ（アクティブな時だけ反映）。
     private func wire(_ v: DocumentPane) {
@@ -179,9 +232,16 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         let v = viewers[index]
         v.reEmitState()                            // ステータスバーを現在の状態に更新
         sidebar.setActive(index)
-        window?.title = (v.fileURL?.lastPathComponent ?? AppInfo.name) + " — " + AppInfo.name
+        window?.title = displayName(of: v) + " — " + AppInfo.name
         updateEditedState()
+        updateReadOnlyBanner()
         v.focusContent()
+    }
+
+    /// 読み取り専用バナーの表示可否を更新する（大ファイル＝編集不可のときだけ出す）。
+    private func updateReadOnlyBanner() {
+        let isReadOnly = activeViewer != nil && !(activeViewer is EditableViewer)
+        readOnlyBanner.isHidden = !(isReadOnly && !readOnlyBannerDismissed)
     }
 
     /// アクティブなドキュメントを閉じる（なければウィンドウを閉じる）。未保存なら確認する。
@@ -198,7 +258,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     private func confirmClose(_ pane: DocumentPane, _ completion: @escaping (Bool) -> Void) {
         guard let e = pane as? EditableViewer, e.isDirty, let win = window else { completion(true); return }
         let alert = NSAlert()
-        alert.messageText = L("close.unsavedTitle", e.fileURL?.lastPathComponent ?? "")
+        alert.messageText = L("close.unsavedTitle", displayName(of: e))
         alert.informativeText = L("close.unsavedMessage")
         alert.addButton(withTitle: L("common.save"))       // .alertFirstButtonReturn
         alert.addButton(withTitle: L("common.cancel"))     // .alertSecondButtonReturn
@@ -224,6 +284,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             window?.title = AppInfo.name
             statusBar.setPlaceholder()
             updateEditedState()
+            updateReadOnlyBanner()
         } else {
             activeIndex = min(idx, viewers.count - 1)
             reloadSidebar()
@@ -248,7 +309,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         if let url = e.fileURL { NSDocumentController.shared.noteNewRecentDocumentURL(url) }
         reloadSidebar()
         if activeViewer === e {
-            window?.title = (e.fileURL?.lastPathComponent ?? AppInfo.name) + " — " + AppInfo.name
+            window?.title = displayName(of: e) + " — " + AppInfo.name
         }
         updateEditedState()
     }

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
 "menu.hide" = "Hide %@";
 "menu.quit" = "Quit %@";
 "menu.file" = "File";
+"menu.new" = "New";
 "menu.open" = "Open…";
 "menu.openRecent" = "Open Recent";
 "menu.recentEmpty" = "No Recent Files";
@@ -22,6 +23,10 @@
 "common.saveAll" = "Save All";
 "common.dontSave" = "Don’t Save";
 "common.discard" = "Discard";
+
+/* Document */
+"doc.untitled" = "Untitled";
+"readonly.banner" = "Read-only — this file is too large to edit.";
 
 /* Status bar */
 "status.placeholder" = "Drag a file here, or press ⌘O to open";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -5,6 +5,7 @@
 "menu.hide" = "%@ を隠す";
 "menu.quit" = "%@ を終了";
 "menu.file" = "ファイル";
+"menu.new" = "新規";
 "menu.open" = "開く…";
 "menu.openRecent" = "最近使った項目を開く";
 "menu.recentEmpty" = "最近使った項目はありません";
@@ -22,6 +23,10 @@
 "common.saveAll" = "すべて保存";
 "common.dontSave" = "保存しない";
 "common.discard" = "破棄";
+
+/* ドキュメント */
+"doc.untitled" = "名称未設定";
+"readonly.banner" = "読み取り専用 — このファイルは大きすぎて編集できません。";
 
 /* ステータスバー */
 "status.placeholder" = "ファイルをドラッグ、または ⌘O で開く";

--- a/Sources/MrEditor/UI/ReadOnlyBanner.swift
+++ b/Sources/MrEditor/UI/ReadOnlyBanner.swift
@@ -1,0 +1,69 @@
+import AppKit
+
+/// 大ファイルを読み取り専用で開いていることを知らせる小さな帯。
+/// `MainWindowController` が本文領域の左上に浮かべ、× で閉じられる。
+final class ReadOnlyBanner: NSView {
+    /// × を押したとき。
+    var onClose: (() -> Void)?
+
+    static let height: CGFloat = 26
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.systemYellow.withAlphaComponent(0.16).cgColor
+        layer?.cornerRadius = 7
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.systemYellow.withAlphaComponent(0.30).cgColor
+
+        let icon = NSImageView()
+        icon.image = NSImage(systemSymbolName: "lock.fill", accessibilityDescription: nil)
+        icon.contentTintColor = .secondaryLabelColor
+        icon.translatesAutoresizingMaskIntoConstraints = false
+
+        let label = NSTextField(labelWithString: L("readonly.banner"))
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .secondaryLabelColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let close = NSButton()
+        close.translatesAutoresizingMaskIntoConstraints = false
+        close.isBordered = false
+        close.bezelStyle = .inline
+        close.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: L("common.cancel"))
+        close.imageScaling = .scaleProportionallyDown
+        close.contentTintColor = .secondaryLabelColor
+        close.target = self
+        close.action = #selector(closeTapped)
+
+        addSubview(icon)
+        addSubview(label)
+        addSubview(close)
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 12),
+            icon.heightAnchor.constraint(equalToConstant: 12),
+
+            label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            close.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 10),
+            close.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            close.centerYAnchor.constraint(equalTo: centerYAnchor),
+            close.widthAnchor.constraint(equalToConstant: 14),
+            close.heightAnchor.constraint(equalToConstant: 14),
+        ])
+    }
+
+    @objc private func closeTapped() { onClose?() }
+}

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -106,6 +106,18 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         return true
     }
 
+    /// 空の新規ドキュメントとして初期化する（パス未確定。保存時に確定する）。
+    func newDocument() {
+        fileURL = nil
+        encoding = .utf8
+        byteSize = 0
+        textView.string = ""
+        textView.undoManager?.removeAllActions()
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        setDirty(false)
+        emitState()
+    }
+
     // MARK: - 保存
 
     /// 変更状態を更新し、変化があれば通知する。

--- a/Tests/MrEditorTests/PieceTableTests.swift
+++ b/Tests/MrEditorTests/PieceTableTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import MrEditor
+
+/// piece table の参照実装（プレーンな `[UInt8]` を直接編集する単純モデル）。
+/// fuzz テストで `PieceTable` の結果と突き合わせる正解側。
+private struct NaiveDoc {
+    var bytes: [UInt8] = []
+
+    mutating func insert(_ b: [UInt8], at off: Int) {
+        bytes.insert(contentsOf: b, at: min(max(0, off), bytes.count))
+    }
+    mutating func delete(_ r: Range<Int>) {
+        let lo = max(0, r.lowerBound), hi = min(bytes.count, r.upperBound)
+        if lo < hi { bytes.removeSubrange(lo..<hi) }
+    }
+
+    private var starts: [Int] {
+        var s = [0]
+        for (i, b) in bytes.enumerated() where b == 0x0A { s.append(i + 1) }
+        return s
+    }
+    private var newlineCount: Int { starts.count - 1 }
+
+    var lineCount: Int {
+        guard !bytes.isEmpty else { return 0 }
+        return newlineCount + (bytes.last == 0x0A ? 0 : 1)
+    }
+
+    func byteRange(ofLine line: Int) -> Range<Int> {
+        let lc = lineCount
+        guard line >= 0, line < lc else { return 0..<0 }
+        let s = starts
+        let start = s[line]
+        let end = (line < newlineCount) ? s[line + 1] - 1 : bytes.count
+        return start..<max(start, end)
+    }
+
+    func byteOffset(ofLineStart line: Int) -> Int {
+        let lc = lineCount
+        let clamped = min(max(0, line), lc)
+        if clamped == 0 { return 0 }
+        let s = starts
+        return (clamped - 1 < newlineCount) ? s[clamped] : bytes.count
+    }
+
+    func line(ofByteOffset off: Int) -> Int {
+        let t = min(max(0, off), bytes.count)
+        var c = 0
+        for i in 0..<t where bytes[i] == 0x0A { c += 1 }
+        return c
+    }
+}
+
+/// テスト用の決定的 PRNG（再現可能な fuzz のため）。
+private struct LCG: RandomNumberGenerator {
+    var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state = state &* 6364136223846793005 &+ 1442695040888963407
+        return state
+    }
+}
+
+final class PieceTableTests: XCTestCase {
+
+    private func bytes(_ s: String) -> [UInt8] { Array(s.utf8) }
+
+    // MARK: - 単体
+
+    func testEmpty() {
+        let t = PieceTable(bytes: [])
+        XCTAssertEqual(t.byteCount, 0)
+        XCTAssertEqual(t.lineCount, 0)
+        XCTAssertEqual(t.bytes(in: 0..<0), [])
+        XCTAssertEqual(t.byteRange(ofLine: 0), 0..<0)
+    }
+
+    func testInitialContent() {
+        let t = PieceTable(bytes: bytes("abc\ndef\nghi"))
+        XCTAssertEqual(t.byteCount, 11)
+        XCTAssertEqual(t.lineCount, 3)
+        XCTAssertEqual(t.bytes(in: 0..<11), bytes("abc\ndef\nghi"))
+        XCTAssertEqual(t.byteRange(ofLine: 0), 0..<3)
+        XCTAssertEqual(t.byteRange(ofLine: 1), 4..<7)
+        XCTAssertEqual(t.byteRange(ofLine: 2), 8..<11)
+    }
+
+    func testInsertHeadMidTail() {
+        let t = PieceTable(bytes: bytes("Hello"))
+        t.insert(bytes(">> "), at: 0)          // head
+        t.insert(bytes("-"), at: 5)            // mid: ">> He|llo"
+        t.insert(bytes("!"), at: t.byteCount)  // tail
+        XCTAssertEqual(t.bytes(in: 0..<t.byteCount), bytes(">> He-llo!"))
+    }
+
+    func testInsertNewlinesUpdatesLineCount() {
+        let t = PieceTable(bytes: bytes("oneline"))
+        XCTAssertEqual(t.lineCount, 1)
+        t.insert(bytes("\ntwo\nthree"), at: t.byteCount)
+        XCTAssertEqual(t.lineCount, 3)
+        XCTAssertEqual(t.byteRange(ofLine: 1), 8..<11)   // "two"
+    }
+
+    func testDeleteAcrossPieces() {
+        let t = PieceTable(bytes: bytes("abcdef"))
+        t.insert(bytes("XYZ"), at: 3)          // "abcXYZdef"
+        t.delete(2..<7)                         // remove "cXYZd" → "abef"
+        XCTAssertEqual(t.bytes(in: 0..<t.byteCount), bytes("abef"))
+        XCTAssertEqual(t.byteCount, 4)
+    }
+
+    func testDeleteNewlineMergesLines() {
+        let t = PieceTable(bytes: bytes("a\nb\nc"))
+        XCTAssertEqual(t.lineCount, 3)
+        t.delete(1..<2)                         // remove first "\n" → "ab\nc"
+        XCTAssertEqual(t.lineCount, 2)
+        XCTAssertEqual(t.byteRange(ofLine: 0), 0..<2)   // "ab"
+    }
+
+    func testTrailingNewlineSemantics() {
+        XCTAssertEqual(PieceTable(bytes: bytes("a\n")).lineCount, 1)
+        XCTAssertEqual(PieceTable(bytes: bytes("a\nb")).lineCount, 2)
+        XCTAssertEqual(PieceTable(bytes: bytes("a\n\n")).lineCount, 2)
+    }
+
+    func testLineOffsetRoundTrip() {
+        let t = PieceTable(bytes: bytes("alpha\nbeta\ngamma\n"))
+        for line in 0..<t.lineCount {
+            let start = t.byteOffset(ofLineStart: line)
+            XCTAssertEqual(t.line(ofByteOffset: start), line)
+        }
+    }
+
+    // MARK: - fuzz（参照実装と突き合わせ）
+
+    func testFuzzAgainstNaive() {
+        let alphabet: [UInt8] = Array("ab\n".utf8)   // 改行を多めに混ぜる
+        for seed in UInt64(1)...8 {
+            var rng = LCG(seed: seed)
+            var naive = NaiveDoc()
+            // 初期コンテンツ
+            let initLen = Int.random(in: 0...40, using: &rng)
+            let initBytes = (0..<initLen).map { _ in alphabet.randomElement(using: &rng)! }
+            naive.bytes = initBytes
+            let table = PieceTable(bytes: initBytes)
+
+            for _ in 0..<3000 {
+                let n = naive.bytes.count
+                if n > 0 && Int.random(in: 0...2, using: &rng) == 0 {
+                    // delete
+                    let lo = Int.random(in: 0..<n, using: &rng)
+                    let hi = Int.random(in: lo...n, using: &rng)
+                    naive.delete(lo..<hi)
+                    table.delete(lo..<hi)
+                } else {
+                    // insert
+                    let off = Int.random(in: 0...n, using: &rng)
+                    let len = Int.random(in: 1...6, using: &rng)
+                    let b = (0..<len).map { _ in alphabet.randomElement(using: &rng)! }
+                    naive.insert(b, at: off)
+                    table.insert(b, at: off)
+                }
+
+                // 構造不変条件を毎回突き合わせ
+                XCTAssertEqual(table.byteCount, naive.bytes.count, "byteCount seed=\(seed)")
+                XCTAssertEqual(table.bytes(in: 0..<table.byteCount), naive.bytes, "content seed=\(seed)")
+                XCTAssertEqual(table.lineCount, naive.lineCount, "lineCount seed=\(seed)")
+                for line in 0..<table.lineCount {
+                    XCTAssertEqual(table.byteRange(ofLine: line),
+                                   naive.byteRange(ofLine: line),
+                                   "byteRange line=\(line) seed=\(seed)")
+                }
+                // ランダムなオフセットの行解決
+                if naive.bytes.count > 0 {
+                    let off = Int.random(in: 0...naive.bytes.count, using: &rng)
+                    XCTAssertEqual(table.line(ofByteOffset: off),
+                                   naive.line(ofByteOffset: off),
+                                   "line(ofByteOffset:\(off)) seed=\(seed)")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要
編集機能の仕上げ（Slice 3）と、巨大ファイル編集の基盤（piece table コア = B0）を追加します。

## Slice 3 — 編集1.0の仕上げ
- **新規ファイル（⌘N）**: 空の untitled 編集ペインを生成し、保存時にパス確定。未保存ドキュメントは「名称未設定」表示（サイドバー/タイトル/未保存確認シート）。
- **読み取り専用バナー**: 大ファイルをアクティブにすると本文左上に表示、× で当セッション中は非表示。
- **メニュー検証**: 保存=編集時のみ / 検索=検索対応時のみ / 末尾追従=追従時のみ などを有効化。
- **ローカライズ(en/ja)**: `menu.new` / `doc.untitled` / `readonly.banner`。

## 巨大ファイル編集の基盤（B0）
全読み込み（NSTextView）方式は GB級で破綻するため、**mmap 原本に piece table を被せ、全文をメモリに載せずに任意サイズを編集する**方式の第一段。今回はデータ構造コアのみ（UI・入力・保存は B1 以降）。

- `Core/PieceTable.swift`: byte ドメインの piece table。原本＋追記バッファの2供給源を treap(split/merge)で並べ、部分木にバイト数・改行数を集計して行↔バイト変換を O(log n)。行分割は 0x0A のみ（UTF-8/SJIS/EUC で安全）、行数意味論は既存 `displayLineCount` と整合。
- `Tests/MrEditorTests/PieceTableTests.swift`: 単体9件 + fuzz（8seed×3000ops をナイーブ参照実装と突き合わせ）。
- `Package.swift`: テストターゲット追加。

## ロードマップ（別PR）
B1 描画 → B2 入力(NSTextInputClient/IME/Undo) → B3 保存 → B4 統合。

## テスト
- `swift build` 成功
- `swift test` 全緑（9 tests、fuzz 含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
