### PR TITLE
config/UI 磨き込み: フォントを環境設定に露出＋環境設定をタブ化

### DIFF
--- a/Sources/MrEditor/EditorFont.swift
+++ b/Sources/MrEditor/EditorFont.swift
@@ -1,32 +1,70 @@
 import AppKit
 
-/// エディタ本文の等幅フォントとサイズ（グローバル・永続化）。
-/// ⌘+ / ⌘- / ⌘0 でサイズを変え、起動をまたいで保持する。
+/// エディタ本文の等幅フォント（種別・サイズ）をグローバルに保持し永続化する。
+/// ⌘+ / ⌘- / ⌘0 でサイズを変え、環境設定(⌘,)で種別＋サイズを選べる。
+/// 変更は `.mrEditorFontChanged` で全ウィンドウのビューアへ通知する。
 enum EditorFont {
     static let defaultSize: CGFloat = 12
     static let minSize: CGFloat = 9
     static let maxSize: CGFloat = 28
     private static let sizeKey = "MrEditor.fontSize"
+    private static let nameKey = "MrEditor.fontName"
+
+    /// フォント名が未指定・生成不能のときに先頭から試す既定候補。
+    private static let fallbackNames = ["SF Mono", "Menlo", "Monaco", "Courier"]
 
     private static var size: CGFloat = {
         let v = UserDefaults.standard.double(forKey: sizeKey)
         return v > 0 ? CGFloat(v) : defaultSize
     }()
 
-    static var currentSize: CGFloat { size }
+    /// 選択中のフォント名（nil＝システム既定の等幅にフォールバック）。
+    private static var name: String? = UserDefaults.standard.string(forKey: nameKey)
 
-    /// サイズを設定（min/max にクランプし永続化）。クランプ後の値を返す。
+    static var currentSize: CGFloat { size }
+    static var currentName: String? { name }
+
+    /// サイズを設定（min/max にクランプし永続化・通知）。クランプ後の値を返す。
     @discardableResult
     static func setSize(_ newSize: CGFloat) -> CGFloat {
         let clamped = min(max(minSize, newSize), maxSize)
         size = clamped
         UserDefaults.standard.set(Double(clamped), forKey: sizeKey)
+        NotificationCenter.default.post(name: .mrEditorFontChanged, object: nil)
         return clamped
     }
 
+    /// フォント名を設定（nil＝システム既定へ戻す）。永続化・通知する。
+    static func setName(_ newName: String?) {
+        name = newName
+        let d = UserDefaults.standard
+        if let n = newName { d.set(n, forKey: nameKey) } else { d.removeObject(forKey: nameKey) }
+        NotificationCenter.default.post(name: .mrEditorFontChanged, object: nil)
+    }
+
     static func current() -> NSFont {
-        if let f = NSFont(name: "SF Mono", size: size) { return f }
-        if let f = NSFont(name: "Menlo", size: size) { return f }
+        if let n = name, let f = NSFont(name: n, size: size) { return f }
+        for n in fallbackNames { if let f = NSFont(name: n, size: size) { return f } }
         return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
     }
+
+    /// 選択肢として提示する等幅フォントファミリ名（表示名でソート）。
+    /// システム全体から `isFixedPitch` のものを拾い、既定候補も併せて含める。
+    static func availableMonospaceFamilies() -> [String] {
+        var names = Set<String>()
+        for family in NSFontManager.shared.availableFontFamilies {
+            if let f = NSFont(name: family, size: defaultSize), f.isFixedPitch {
+                names.insert(family)
+            }
+        }
+        for n in fallbackNames where NSFont(name: n, size: defaultSize) != nil {
+            names.insert(n)
+        }
+        return names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}
+
+extension Notification.Name {
+    /// エディタフォント（種別・サイズ）が変わったとき（開いている全ビューアへ反映）。
+    static let mrEditorFontChanged = Notification.Name("MrEditor.fontChanged")
 }

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -52,9 +52,12 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         setupContent()
         NotificationCenter.default.addObserver(self, selector: #selector(lineWrapChanged),
                                                name: .mrEditorLineWrapChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(fontChanged),
+                                               name: .mrEditorFontChanged, object: nil)
     }
 
     @objc private func lineWrapChanged() { viewers.forEach { $0.applyLineWrap() } }
+    @objc private func fontChanged() { viewers.forEach { $0.applyCurrentFontSize() } }
 
     /// 未保存変更でウィンドウを閉じる際の二重確認を抑止するフラグ。
     private var forceClose = false
@@ -538,8 +541,8 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     func zoomReset() { applyFontSize(EditorFont.defaultSize) }
 
     private func applyFontSize(_ size: CGFloat) {
+        // setSize が .mrEditorFontChanged を投げ、全ウィンドウが applyCurrentFontSize で反映する。
         EditorFont.setSize(size)
-        viewers.forEach { $0.applyCurrentFontSize() }
     }
 
     /// 行番号ジャンプのダイアログ。

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,12 @@
 /* Preferences */
 "menu.preferences" = "Preferences…";
 "prefs.title" = "Preferences";
+"prefs.general" = "General";
+"prefs.display" = "Display";
+"prefs.font" = "Font";
+"prefs.font.system" = "System Default (Monospaced)";
+"prefs.font.size" = "Size";
+"prefs.font.pt" = "pt";
 "prefs.saveProgress" = "While saving";
 "prefs.saveProgress.hint" = "Saving a huge file takes a while. Choose whether to keep working during the save, or wait on a sheet.";
 "prefs.lineWrap" = "Long lines";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -58,6 +58,12 @@
 /* 環境設定 */
 "menu.preferences" = "環境設定…";
 "prefs.title" = "環境設定";
+"prefs.general" = "一般";
+"prefs.display" = "表示";
+"prefs.font" = "フォント";
+"prefs.font.system" = "システム既定（等幅）";
+"prefs.font.size" = "サイズ";
+"prefs.font.pt" = "pt";
 "prefs.saveProgress" = "保存中の表示";
 "prefs.saveProgress.hint" = "巨大ファイルの保存には時間がかかります。表示中も操作を続けるか、シートで待つかを選べます。";
 "prefs.lineWrap" = "長い行";

--- a/Sources/MrEditor/UI/PreferencesWindowController.swift
+++ b/Sources/MrEditor/UI/PreferencesWindowController.swift
@@ -1,28 +1,79 @@
 import AppKit
 
-/// 環境設定ウィンドウ（⌘,）。今は「保存中の表示」の切替のみ。
-/// 将来ここにフォント等の設定を集約する。
+/// 環境設定ウィンドウ（⌘,）。macOS 標準のツールバータブ構成。
+/// 「一般」＝保存中の表示、「表示」＝フォント＋長い行。
+/// 設定項目が増えても各ペイン VC を足すだけで済むよう、`NSTabViewController`
+/// の `.toolbar` スタイルに委ねている。
 final class PreferencesWindowController: NSWindowController {
-    private var statusBarRadio: NSButton!
-    private var sheetRadio: NSButton!
-    private var noWrapRadio: NSButton!
-    private var wrapRadio: NSButton!
 
     convenience init() {
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 460, height: 300),
-                              styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        let tabs = NSTabViewController()
+        tabs.tabStyle = .toolbar
+
+        let general = GeneralPaneViewController()
+        general.title = L("prefs.general")
+        let generalItem = NSTabViewItem(viewController: general)
+        generalItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)
+        tabs.addTabViewItem(generalItem)
+
+        let display = DisplayPaneViewController()
+        display.title = L("prefs.display")
+        let displayItem = NSTabViewItem(viewController: display)
+        displayItem.image = NSImage(systemSymbolName: "textformat", accessibilityDescription: nil)
+        tabs.addTabViewItem(displayItem)
+
+        let window = NSWindow(contentViewController: tabs)
+        window.styleMask = [.titled, .closable]
         window.title = L("prefs.title")
         window.isReleasedWhenClosed = false
         self.init(window: window)
-        buildUI()
         window.center()
     }
 
-    private func buildUI() {
-        guard let content = window?.contentView else { return }
+    /// ウィンドウを最前面に出す（無ければ生成済みのものを再利用）。
+    func show() {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
 
-        let heading = NSTextField(labelWithString: L("prefs.saveProgress"))
-        heading.font = .boldSystemFont(ofSize: 13)
+// MARK: - 共通ヘルパ
+
+private func heading(_ key: String) -> NSTextField {
+    let f = NSTextField(labelWithString: L(key))
+    f.font = .boldSystemFont(ofSize: 13)
+    return f
+}
+
+private func makeStack(_ views: [NSView]) -> NSStackView {
+    let stack = NSStackView(views: views)
+    stack.orientation = .vertical
+    stack.alignment = .leading
+    stack.spacing = 10
+    stack.edgeInsets = NSEdgeInsets(top: 20, left: 24, bottom: 20, right: 24)
+    return stack
+}
+
+private func pin(_ stack: NSStackView, in root: NSView) {
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    root.addSubview(stack)
+    NSLayoutConstraint.activate([
+        stack.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+        stack.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+        stack.topAnchor.constraint(equalTo: root.topAnchor),
+        stack.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+    ])
+}
+
+// MARK: - 一般ペイン（保存中の表示）
+
+private final class GeneralPaneViewController: NSViewController {
+    private var statusBarRadio: NSButton!
+    private var sheetRadio: NSButton!
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 200))
 
         statusBarRadio = NSButton(radioButtonWithTitle: L("menu.saveProgress.statusBar"),
                                   target: self, action: #selector(radioChanged(_:)))
@@ -33,30 +84,10 @@ final class PreferencesWindowController: NSWindowController {
         hint.font = .systemFont(ofSize: 11)
         hint.textColor = .secondaryLabelColor
 
-        let wrapHeading = NSTextField(labelWithString: L("prefs.lineWrap"))
-        wrapHeading.font = .boldSystemFont(ofSize: 13)
-        noWrapRadio = NSButton(radioButtonWithTitle: L("prefs.lineWrap.off"),
-                               target: self, action: #selector(wrapChanged(_:)))
-        wrapRadio = NSButton(radioButtonWithTitle: L("prefs.lineWrap.on"),
-                             target: self, action: #selector(wrapChanged(_:)))
-
-        let sep = NSBox(); sep.boxType = .separator
-
-        let stack = NSStackView(views: [heading, statusBarRadio, sheetRadio, hint,
-                                        sep, wrapHeading, noWrapRadio, wrapRadio])
-        stack.orientation = .vertical
-        stack.alignment = .leading
-        stack.spacing = 10
-        stack.edgeInsets = NSEdgeInsets(top: 20, left: 24, bottom: 20, right: 24)
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        content.addSubview(stack)
-        NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: content.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: content.trailingAnchor),
-            stack.topAnchor.constraint(equalTo: content.topAnchor),
-            hint.widthAnchor.constraint(lessThanOrEqualToConstant: 400),
-            sep.widthAnchor.constraint(equalToConstant: 400),
-        ])
+        let stack = makeStack([heading("prefs.saveProgress"), statusBarRadio, sheetRadio, hint])
+        hint.widthAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
+        pin(stack, in: root)
+        self.view = root
         syncRadios()
     }
 
@@ -64,25 +95,111 @@ final class PreferencesWindowController: NSWindowController {
         let s = AppSettings.saveProgressStyle
         statusBarRadio.state = (s == .statusBar) ? .on : .off
         sheetRadio.state = (s == .sheet) ? .on : .off
-        noWrapRadio.state = AppSettings.lineWrap ? .off : .on
-        wrapRadio.state = AppSettings.lineWrap ? .on : .off
     }
 
     @objc private func radioChanged(_ sender: NSButton) {
         AppSettings.saveProgressStyle = (sender === sheetRadio) ? .sheet : .statusBar
         syncRadios()
     }
+}
+
+// MARK: - 表示ペイン（フォント＋長い行）
+
+private final class DisplayPaneViewController: NSViewController {
+    private var fontPopup: NSPopUpButton!
+    private var sizePopup: NSPopUpButton!
+    private var sample: NSTextField!
+    private var noWrapRadio: NSButton!
+    private var wrapRadio: NSButton!
+
+    /// nil（システム既定）を表す先頭項目の tag。
+    private static let systemDefaultTag = -1
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 320))
+
+        // --- フォント種別 ---
+        fontPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+        let systemItem = NSMenuItem(title: L("prefs.font.system"), action: nil, keyEquivalent: "")
+        systemItem.tag = Self.systemDefaultTag
+        fontPopup.menu?.addItem(systemItem)
+        fontPopup.menu?.addItem(.separator())
+        for name in EditorFont.availableMonospaceFamilies() {
+            fontPopup.addItem(withTitle: name)
+        }
+        fontPopup.target = self
+        fontPopup.action = #selector(fontPicked(_:))
+
+        // --- サイズ ---
+        sizePopup = NSPopUpButton(frame: .zero, pullsDown: false)
+        for s in Int(EditorFont.minSize)...Int(EditorFont.maxSize) {
+            sizePopup.addItem(withTitle: "\(s)")
+            sizePopup.lastItem?.tag = s
+        }
+        sizePopup.target = self
+        sizePopup.action = #selector(sizePicked(_:))
+        let sizeLabel = NSTextField(labelWithString: L("prefs.font.size"))
+        let ptLabel = NSTextField(labelWithString: L("prefs.font.pt"))
+        ptLabel.textColor = .secondaryLabelColor
+
+        let fontRow = NSStackView(views: [fontPopup, sizeLabel, sizePopup, ptLabel])
+        fontRow.orientation = .horizontal
+        fontRow.spacing = 8
+        fontRow.alignment = .firstBaseline
+
+        // --- ライブサンプル ---
+        sample = NSTextField(labelWithString: "AaBbYy 0123 ()=>{} 日本語ログ")
+        sample.textColor = .secondaryLabelColor
+        sample.lineBreakMode = .byTruncatingTail
+
+        // --- 長い行 ---
+        noWrapRadio = NSButton(radioButtonWithTitle: L("prefs.lineWrap.off"),
+                               target: self, action: #selector(wrapChanged(_:)))
+        wrapRadio = NSButton(radioButtonWithTitle: L("prefs.lineWrap.on"),
+                             target: self, action: #selector(wrapChanged(_:)))
+
+        let sep = NSBox(); sep.boxType = .separator
+
+        let stack = makeStack([heading("prefs.font"), fontRow, sample,
+                               sep, heading("prefs.lineWrap"), noWrapRadio, wrapRadio])
+        sep.widthAnchor.constraint(equalToConstant: 400).isActive = true
+        pin(stack, in: root)
+        self.view = root
+        sync()
+    }
+
+    private func sync() {
+        // フォント種別
+        if let name = EditorFont.currentName, fontPopup.itemTitles.contains(name) {
+            fontPopup.selectItem(withTitle: name)
+        } else {
+            fontPopup.selectItem(withTag: Self.systemDefaultTag)
+        }
+        // サイズ
+        sizePopup.selectItem(withTag: Int(EditorFont.currentSize))
+        // 長い行
+        noWrapRadio.state = AppSettings.lineWrap ? .off : .on
+        wrapRadio.state = AppSettings.lineWrap ? .on : .off
+        // サンプルを現在のフォントで描く
+        sample.font = EditorFont.current()
+    }
+
+    @objc private func fontPicked(_ sender: NSPopUpButton) {
+        if sender.selectedItem?.tag == Self.systemDefaultTag {
+            EditorFont.setName(nil)
+        } else {
+            EditorFont.setName(sender.titleOfSelectedItem)
+        }
+        sync()
+    }
+
+    @objc private func sizePicked(_ sender: NSPopUpButton) {
+        EditorFont.setSize(CGFloat(sender.selectedTag()))
+        sync()
+    }
 
     @objc private func wrapChanged(_ sender: NSButton) {
         AppSettings.lineWrap = (sender === wrapRadio)
-        syncRadios()
-    }
-
-    /// ウィンドウを最前面に出す（無ければ生成済みのものを再利用）。
-    func show() {
-        syncRadios()
-        showWindow(nil)
-        window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        sync()
     }
 }

--- a/Tests/MrEditorTests/EditorFontTests.swift
+++ b/Tests/MrEditorTests/EditorFontTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import AppKit
+@testable import MrEditor
+
+/// `EditorFont` の種別・サイズの永続化と、変更通知・等幅列挙を検証する。
+/// UserDefaults.standard を触るため、各テストで元の値へ復元する。
+final class EditorFontTests: XCTestCase {
+
+    private var savedSize: CGFloat!
+    private var savedName: String?
+
+    override func setUp() {
+        super.setUp()
+        savedSize = EditorFont.currentSize
+        savedName = EditorFont.currentName
+    }
+
+    override func tearDown() {
+        EditorFont.setSize(savedSize)
+        EditorFont.setName(savedName)
+        super.tearDown()
+    }
+
+    func testSizeClampsToRange() {
+        XCTAssertEqual(EditorFont.setSize(1000), EditorFont.maxSize)
+        XCTAssertEqual(EditorFont.setSize(1), EditorFont.minSize)
+        XCTAssertEqual(EditorFont.setSize(14), 14)
+        XCTAssertEqual(EditorFont.currentSize, 14)
+    }
+
+    func testNameDrivesCurrentFont() {
+        EditorFont.setName("Menlo")
+        EditorFont.setSize(15)
+        let f = EditorFont.current()
+        XCTAssertEqual(f.familyName, "Menlo")
+        XCTAssertEqual(f.pointSize, 15)
+    }
+
+    func testNilNameFallsBackToMonospace() {
+        EditorFont.setName(nil)
+        XCTAssertNil(EditorFont.currentName)
+        // フォールバック鎖のいずれか（or システム等幅）で必ずフォントが得られる。
+        XCTAssertTrue(EditorFont.current().isFixedPitch)
+    }
+
+    func testUnknownNameFallsBack() {
+        EditorFont.setName("No Such Font 12345")
+        // 生成不能名でもクラッシュせずフォールバックする。
+        XCTAssertNotNil(EditorFont.current())
+    }
+
+    func testAvailableFamiliesAreMonospacedAndSorted() {
+        let families = EditorFont.availableMonospaceFamilies()
+        XCTAssertFalse(families.isEmpty)
+        // 全て等幅で生成できる。
+        for name in families {
+            let f = NSFont(name: name, size: 12)
+            XCTAssertNotNil(f, "family \(name) should instantiate")
+            XCTAssertTrue(f?.isFixedPitch ?? false, "family \(name) should be monospaced")
+        }
+        // 大小無視でソート済み。
+        XCTAssertEqual(families, families.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+    }
+
+    func testChangePostsNotification() {
+        let sizeExp = expectation(forNotification: .mrEditorFontChanged, object: nil)
+        EditorFont.setSize(16)
+        wait(for: [sizeExp], timeout: 1)
+
+        let nameExp = expectation(forNotification: .mrEditorFontChanged, object: nil)
+        EditorFont.setName("Menlo")
+        wait(for: [nameExp], timeout: 1)
+    }
+}


### PR DESCRIPTION
## 概要
1.0 直前の config/UI 磨き込み。設定の窓口を環境設定(⌘,)へ集約する第一弾として、**フォント設定を環境設定に露出**し、**環境設定を macOS 標準のツールバータブ構成**へ刷新した。

## 変更点
- **EditorFont**: フォント種別(`fontName`)を永続化（従来はサイズのみ）。`current()` は 選択名 →（SF Mono/Menlo/Monaco/Courier フォールバック）→ システム等幅 の順で解決。`availableMonospaceFamilies()` でシステム全体の等幅フォントを列挙。変更時に `.mrEditorFontChanged` を発火。
- **MainWindowController**: `.mrEditorFontChanged` を観測して全ビューアへ反映。ズーム(⌘+/⌘-/⌘0)も通知経由に一本化し、**複数ウィンドウで同期**するようになった（従来はアクティブ窓のみ）。
- **PreferencesWindowController**: ラジオ直書き → `NSTabViewController(.toolbar)`。**一般**＝保存中の表示 / **表示**＝フォント（種別＋サイズ＋ライブサンプル）＋長い行。項目追加はペイン VC を足すだけの構造に。
- **localization**: ja/en に `prefs.general` `prefs.display` `prefs.font*` を追加。

## テスト
- `EditorFontTests` 6件追加（クランプ／名前駆動／フォールバック／等幅列挙／通知）。
- `swift build` クリーン、`swift test` = **67 green（1 skip＝ゲート付き 10GB）**。
- GUI 実機で環境設定を開き、両タブの描画・ツールバー切替・フォント欄・ライブサンプルを目視確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)