### PR TITLE
外観テーマ: 配色 config 化＋周辺UI連動＋サイドバー閉じる/未保存色分け

### DIFF
--- a/Sources/MrEditor/EditorTheme.swift
+++ b/Sources/MrEditor/EditorTheme.swift
@@ -1,0 +1,195 @@
+import AppKit
+
+/// 本文エリアの配色（5 色）と、周辺 UI（chrome）の配色をまとめたもの。
+/// 大ファイル（`DocumentView` 自前描画）と小ファイル（`NSTextView`）の両経路、
+/// 検索ヒット描画、およびサイドバー/ガター/ステータス/検索パネル/タイトルバーで同じ色を使う。
+struct EditorColorTheme {
+    // MARK: 本文エリア
+    /// 本文の文字色。
+    var foreground: NSColor
+    /// 本文の背景色。
+    var background: NSColor
+    /// キャレット行を淡く強調する帯の色（alpha 付き）。
+    var currentLine: NSColor
+    /// 選択範囲の背景色。
+    var selection: NSColor
+    /// 検索ヒットの背景色（alpha 付き）。
+    var searchMatch: NSColor
+
+    // MARK: 周辺 UI（chrome）
+    /// サイドバー/ガター/ステータス/検索パネル/タイトルバーの背景。
+    var chromeBackground: NSColor
+    /// サイドバー行など主要ラベルの文字色。
+    var chromeText: NSColor
+    /// ステータスバー・行番号など副次ラベルの文字色。
+    var chromeSecondaryText: NSColor
+    /// 選択中サイドバー行の背景。
+    var chromeActiveBackground: NSColor
+    /// 選択中サイドバー行のラベル色。
+    var chromeActiveText: NSColor
+    /// 区切り線の色。
+    var separator: NSColor
+    /// 未保存ドキュメントの目印色（サイドバーの●と×）。
+    var dirtyIndicator: NSColor
+    /// 窓に強制するアピアランス（framework コントロール/タイトル文字/スクロールバーの明暗を揃える）。
+    /// nil＝OS 追従（system プリセット）。
+    var appearanceName: NSAppearance.Name?
+}
+
+/// 配色プリセット。`system` はセマンティック色でライト/ダーク自動追従、
+/// 固定プリセットは sRGB 固定色（追従しない）、`custom` はユーザ指定の 5 色。
+enum ThemePreset: String, CaseIterable {
+    case system
+    case solarizedDark
+    case solarizedLight
+    case monokai
+    case custom
+}
+
+/// エディタ本文＋周辺 UI の配色をグローバルに保持し永続化する。フォント（`EditorFont`）と同様に
+/// UserDefaults へ保存し、変更は既存の `.mrEditorDisplayChanged` で全ビューア/ウィンドウへ通知する。
+enum EditorTheme {
+    private static let defaults = UserDefaults.standard
+    private static let presetKey = "MrEditor.themePreset"
+    /// custom 時の各色（NSKeyedArchiver で Data 化して alpha/colorspace を保つ）。
+    private static let customPrefix = "MrEditor.themeCustom."
+
+    /// custom 時にユーザが指定する色。本文 5 色＋未保存の目印色。周辺 UI 色はここから派生させる。
+    enum ColorKey: String, CaseIterable {
+        case foreground, background, currentLine, selection, searchMatch, dirtyIndicator
+    }
+
+    // MARK: - プリセット選択
+
+    static var preset: ThemePreset {
+        get { ThemePreset(rawValue: defaults.string(forKey: presetKey) ?? "") ?? .system }
+        set { defaults.set(newValue.rawValue, forKey: presetKey); postChanged() }
+    }
+
+    // MARK: - 現在の配色
+
+    /// 現在の配色。preset に応じて固定色／セマンティック色／custom 保存色を返す。
+    static func current() -> EditorColorTheme {
+        switch preset {
+        case .custom: return customTheme()
+        default:      return builtin(preset)
+        }
+    }
+
+    /// プリセットの色定義（プレビュー用にも使う）。`custom` は現在の custom 保存色。
+    static func builtin(_ preset: ThemePreset) -> EditorColorTheme {
+        switch preset {
+        case .system:
+            // 既存ハードコード値と一致（既定で現状と完全一致・周辺 UI もセマンティックで自動追従）。
+            return EditorColorTheme(
+                foreground: .textColor,
+                background: .textBackgroundColor,
+                currentLine: NSColor.textColor.withAlphaComponent(0.06),
+                selection: .selectedTextBackgroundColor,
+                searchMatch: NSColor.systemYellow.withAlphaComponent(0.45),
+                chromeBackground: .windowBackgroundColor,
+                chromeText: .labelColor,
+                chromeSecondaryText: .secondaryLabelColor,
+                chromeActiveBackground: .selectedContentBackgroundColor,
+                chromeActiveText: .white,
+                separator: .separatorColor,
+                dirtyIndicator: .systemOrange,
+                appearanceName: nil)
+        case .solarizedDark:
+            return themed(fg: hex(0x93A1A1), bg: hex(0x002B36),
+                          currentLine: hex(0xFFFFFF, 0.06), selection: hex(0x274642),
+                          searchMatch: hex(0xB58900, 0.45), dirty: .systemOrange)
+        case .solarizedLight:
+            return themed(fg: hex(0x586E75), bg: hex(0xFDF6E3),
+                          currentLine: hex(0x000000, 0.05), selection: hex(0xD6CFB8),
+                          searchMatch: hex(0xB58900, 0.40), dirty: .systemOrange)
+        case .monokai:
+            return themed(fg: hex(0xF8F8F2), bg: hex(0x272822),
+                          currentLine: hex(0xFFFFFF, 0.06), selection: hex(0x49483E),
+                          searchMatch: hex(0xE6DB74, 0.40), dirty: .systemOrange)
+        case .custom:
+            return customTheme()
+        }
+    }
+
+    // MARK: - カスタム色
+
+    /// custom の 1 色を設定し、preset を `.custom` に切り替えて通知する。
+    static func setCustomColor(_ key: ColorKey, _ color: NSColor) {
+        if let data = try? NSKeyedArchiver.archivedData(withRootObject: color, requiringSecureCoding: true) {
+            defaults.set(data, forKey: customPrefix + key.rawValue)
+        }
+        // custom へ切り替え（postChanged はここで一度だけ）。
+        defaults.set(ThemePreset.custom.rawValue, forKey: presetKey)
+        postChanged()
+    }
+
+    /// custom の 1 色を読む。未設定なら system プリセットの対応色にフォールバック。
+    static func customColor(_ key: ColorKey) -> NSColor {
+        if let data = defaults.data(forKey: customPrefix + key.rawValue),
+           let color = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSColor.self, from: data) {
+            return color
+        }
+        let sys = builtin(.system)
+        switch key {
+        case .foreground:    return sys.foreground
+        case .background:    return sys.background
+        case .currentLine:   return sys.currentLine
+        case .selection:     return sys.selection
+        case .searchMatch:   return sys.searchMatch
+        case .dirtyIndicator: return sys.dirtyIndicator
+        }
+    }
+
+    private static func customTheme() -> EditorColorTheme {
+        themed(fg: customColor(.foreground), bg: customColor(.background),
+               currentLine: customColor(.currentLine), selection: customColor(.selection),
+               searchMatch: customColor(.searchMatch), dirty: customColor(.dirtyIndicator))
+    }
+
+    // MARK: - 周辺 UI 色の派生
+
+    /// 本文 5 色から周辺 UI（chrome）色を派生させてテーマを組み立てる。
+    /// chrome は前景と背景の混色で作るため、ダーク系は自然に少し明るく、ライト系は少し暗くなる。
+    private static func themed(fg: NSColor, bg: NSColor, currentLine: NSColor,
+                              selection: NSColor, searchMatch: NSColor, dirty: NSColor) -> EditorColorTheme {
+        let bgS = bg.usingColorSpace(.sRGB) ?? bg
+        let fgS = fg.usingColorSpace(.sRGB) ?? fg
+        func blend(_ t: CGFloat) -> NSColor { mix(bgS, fgS, t) }
+        // 相対輝度（sRGB 近似）で明暗を判定し、窓アピアランスを決める。
+        let lum = 0.2126 * bgS.redComponent + 0.7152 * bgS.greenComponent + 0.0722 * bgS.blueComponent
+        return EditorColorTheme(
+            foreground: fg, background: bg,
+            currentLine: currentLine, selection: selection, searchMatch: searchMatch,
+            // 本文（メイン）から明確に濃淡を付けるため、chrome は前景寄りに 0.14 混色する。
+            chromeBackground: blend(0.14),
+            chromeText: blend(0.90),
+            chromeSecondaryText: blend(0.58),
+            chromeActiveBackground: blend(0.28),
+            chromeActiveText: blend(0.98),
+            separator: blend(0.26),
+            dirtyIndicator: dirty,
+            appearanceName: lum < 0.5 ? .darkAqua : .aqua)
+    }
+
+    /// 2 色を成分ごとに t で線形補間（alpha は 1 固定）。
+    private static func mix(_ a: NSColor, _ b: NSColor, _ t: CGFloat) -> NSColor {
+        NSColor(srgbRed: a.redComponent + (b.redComponent - a.redComponent) * t,
+                green: a.greenComponent + (b.greenComponent - a.greenComponent) * t,
+                blue: a.blueComponent + (b.blueComponent - a.blueComponent) * t,
+                alpha: 1.0)
+    }
+
+    // MARK: - ヘルパ
+
+    private static func hex(_ rgb: Int, _ alpha: CGFloat = 1.0) -> NSColor {
+        NSColor(srgbRed: CGFloat((rgb >> 16) & 0xFF) / 255,
+                green: CGFloat((rgb >> 8) & 0xFF) / 255,
+                blue: CGFloat(rgb & 0xFF) / 255,
+                alpha: alpha)
+    }
+
+    private static func postChanged() {
+        NotificationCenter.default.post(name: .mrEditorDisplayChanged, object: nil)
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -60,7 +60,29 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
 
     @objc private func lineWrapChanged() { viewers.forEach { $0.applyLineWrap() } }
     @objc private func fontChanged() { viewers.forEach { $0.applyCurrentFontSize() } }
-    @objc private func displayChanged() { viewers.forEach { $0.applyDisplaySettings() } }
+    @objc private func displayChanged() {
+        viewers.forEach { $0.applyDisplaySettings() }
+        applyChrome()
+    }
+
+    /// 周辺 UI（タイトルバー・サイドバー・ステータス・検索パネル）へテーマを適用する。
+    /// ダーク/ライト系テーマでは窓のアピアランスも合わせ、framework コントロール
+    /// （検索フィールド・スクロールバー・タイトル文字・信号ボタン）の明暗を揃える。
+    private func applyChrome() {
+        let theme = EditorTheme.current()
+        if let name = theme.appearanceName {
+            window?.appearance = NSAppearance(named: name)
+            window?.titlebarAppearsTransparent = true
+            window?.backgroundColor = theme.chromeBackground
+        } else {
+            window?.appearance = nil
+            window?.titlebarAppearsTransparent = false
+            window?.backgroundColor = .windowBackgroundColor
+        }
+        sidebar.applyTheme()
+        statusBar.applyTheme()
+        searchBar.applyTheme()
+    }
 
     /// 未保存変更でウィンドウを閉じる際の二重確認を抑止するフラグ。
     private var forceClose = false
@@ -72,6 +94,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         // サイドバー（開いているドキュメント一覧）
         sidebar.translatesAutoresizingMaskIntoConstraints = false
         sidebar.onSelect = { [weak self] i in self?.activate(i) }
+        sidebar.onClose = { [weak self] i in self?.closeDocument(at: i) }
 
         viewerContainer.translatesAutoresizingMaskIntoConstraints = false
         viewerContainer.onDropFiles = { [weak self] urls in urls.forEach { self?.open(url: $0) } }
@@ -131,6 +154,8 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             readOnlyBanner.leadingAnchor.constraint(equalTo: viewerContainer.leadingAnchor, constant: 14),
             readOnlyBanner.heightAnchor.constraint(equalToConstant: ReadOnlyBanner.height),
         ])
+
+        applyChrome()   // 永続化されたテーマを起動時に反映する。
     }
 
     // MARK: - ドキュメント管理
@@ -191,7 +216,9 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     private func reloadSidebar() {
-        sidebar.reload(names: viewers.map { displayName(of: $0) }, active: activeIndex)
+        sidebar.reload(names: viewers.map { displayName(of: $0) },
+                       dirty: viewers.map { $0.isDirty },
+                       active: activeIndex)
     }
 
     /// サイドバー／タイトル用の表示名（未保存の新規ドキュメントは「名称未設定」）。
@@ -229,8 +256,13 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         }
         v.onDropFiles = { [weak self] urls in urls.forEach { self?.open(url: $0) } }
         v.onDirtyChange = { [weak self, weak v] dirty in
-            guard let self, self.activeViewer === v else { return }
-            self.window?.isDocumentEdited = dirty
+            guard let self, let v else { return }
+            // どのペインの未保存状態でもサイドバーの目印を更新する。
+            if let idx = self.viewers.firstIndex(where: { $0 === v }) {
+                self.sidebar.setDirty(idx, dirty)
+            }
+            // タイトルバーの編集済みドットはアクティブなペインのみ反映。
+            if self.activeViewer === v { self.window?.isDocumentEdited = dirty }
         }
     }
 
@@ -264,6 +296,16 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     func closeActiveDocument() {
         guard activeIndex >= 0 else { window?.performClose(nil); return }
         let pane = viewers[activeIndex]
+        confirmClose(pane) { [weak self] proceed in
+            guard let self, proceed else { return }
+            self.removePane(pane)
+        }
+    }
+
+    /// 指定インデックスのドキュメントを閉じる（サイドバーの × から）。未保存なら確認する。
+    func closeDocument(at index: Int) {
+        guard index >= 0, index < viewers.count else { return }
+        let pane = viewers[index]
         confirmClose(pane) { [weak self] proceed in
             guard let self, proceed else { return }
             self.removePane(pane)

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 
 /* Document */
 "doc.untitled" = "Untitled";
+"sidebar.close" = "Close";
 "readonly.banner" = "Read-only — this file is too large to edit.";
 
 /* Status bar */
@@ -80,6 +81,19 @@
 "prefs.lineWrap" = "Long lines";
 "prefs.lineWrap.off" = "Don’t wrap (scroll horizontally)";
 "prefs.lineWrap.on" = "Wrap to width";
+"prefs.colors" = "Colors";
+"prefs.theme" = "Theme";
+"prefs.theme.system" = "System (Automatic)";
+"prefs.theme.solarizedDark" = "Solarized Dark";
+"prefs.theme.solarizedLight" = "Solarized Light";
+"prefs.theme.monokai" = "Monokai";
+"prefs.theme.custom" = "Custom";
+"prefs.color.foreground" = "Text";
+"prefs.color.background" = "Background";
+"prefs.color.currentLine" = "Current line";
+"prefs.color.selection" = "Selection";
+"prefs.color.searchMatch" = "Search match";
+"prefs.color.dirtyIndicator" = "Unsaved marker";
 "gotoLine.prompt" = "Go to line:";
 "gotoLine.go" = "Go";
 "common.cancel" = "Cancel";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -36,6 +36,7 @@
 
 /* ドキュメント */
 "doc.untitled" = "名称未設定";
+"sidebar.close" = "閉じる";
 "readonly.banner" = "読み取り専用 — このファイルは大きすぎて編集できません。";
 
 /* ステータスバー */
@@ -80,6 +81,19 @@
 "prefs.lineWrap" = "長い行";
 "prefs.lineWrap.off" = "折り返さない（横スクロール）";
 "prefs.lineWrap.on" = "内容の幅で折り返す";
+"prefs.colors" = "配色";
+"prefs.theme" = "テーマ";
+"prefs.theme.system" = "システム（自動）";
+"prefs.theme.solarizedDark" = "Solarized Dark";
+"prefs.theme.solarizedLight" = "Solarized Light";
+"prefs.theme.monokai" = "Monokai";
+"prefs.theme.custom" = "カスタム";
+"prefs.color.foreground" = "文字";
+"prefs.color.background" = "背景";
+"prefs.color.currentLine" = "現在の行";
+"prefs.color.selection" = "選択範囲";
+"prefs.color.searchMatch" = "検索ヒット";
+"prefs.color.dirtyIndicator" = "未保存の目印";
 "gotoLine.prompt" = "移動先の行番号:";
 "gotoLine.go" = "移動";
 "common.cancel" = "キャンセル";

--- a/Sources/MrEditor/UI/PreferencesWindowController.swift
+++ b/Sources/MrEditor/UI/PreferencesWindowController.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 /// 環境設定ウィンドウ（⌘,）。macOS 標準のツールバータブ構成。
-/// 「一般」＝保存中の表示、「表示」＝フォント＋長い行。
+/// 「一般」＝保存中の表示、「表示」＝フォント＋本文体裁＋長い行、「配色」＝本文エリアのテーマ。
 /// 設定項目が増えても各ペイン VC を足すだけで済むよう、`NSTabViewController`
 /// の `.toolbar` スタイルに委ねている。
 final class PreferencesWindowController: NSWindowController {
@@ -21,6 +21,12 @@ final class PreferencesWindowController: NSWindowController {
         let displayItem = NSTabViewItem(viewController: display)
         displayItem.image = NSImage(systemSymbolName: "textformat", accessibilityDescription: nil)
         tabs.addTabViewItem(displayItem)
+
+        let colors = ColorsPaneViewController()
+        colors.title = L("prefs.colors")
+        let colorsItem = NSTabViewItem(viewController: colors)
+        colorsItem.image = NSImage(systemSymbolName: "paintpalette", accessibilityDescription: nil)
+        tabs.addTabViewItem(colorsItem)
 
         let window = NSWindow(contentViewController: tabs)
         window.styleMask = [.titled, .closable]
@@ -266,6 +272,98 @@ private final class DisplayPaneViewController: NSViewController {
 
     @objc private func wrapChanged(_ sender: NSButton) {
         AppSettings.lineWrap = (sender === wrapRadio)
+        sync()
+    }
+}
+
+// MARK: - 配色ペイン（本文エリアのテーマ）
+
+private final class ColorsPaneViewController: NSViewController {
+    private var themePopup: NSPopUpButton!
+    private var sample: NSTextField!
+    /// custom 時のみ表示する 5 色の個別ピッカー行をまとめた領域。
+    private var customStack: NSStackView!
+    private var wells: [EditorTheme.ColorKey: NSColorWell] = [:]
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 380))
+
+        // --- テーマ選択 ---
+        themePopup = NSPopUpButton(frame: .zero, pullsDown: false)
+        for (i, p) in ThemePreset.allCases.enumerated() {
+            themePopup.addItem(withTitle: L("prefs.theme.\(p.rawValue)"))
+            themePopup.lastItem?.tag = i
+        }
+        themePopup.target = self
+        themePopup.action = #selector(themePicked(_:))
+        let themeRow = NSStackView(views: [label("prefs.theme"), themePopup])
+        themeRow.orientation = .horizontal
+        themeRow.spacing = 8
+        themeRow.alignment = .firstBaseline
+
+        // --- ライブサンプル（前景/背景色を反映して見せる） ---
+        sample = NSTextField(labelWithString: "AaBbYy 0123 ()=>{} 日本語ログ")
+        sample.drawsBackground = true
+        sample.isBezeled = true
+        sample.lineBreakMode = .byTruncatingTail
+        sample.font = EditorFont.current()
+
+        // --- custom 用の 5 色ピッカー ---
+        var rows: [NSView] = []
+        for key in EditorTheme.ColorKey.allCases {
+            let well = NSColorWell()
+            well.translatesAutoresizingMaskIntoConstraints = false
+            well.widthAnchor.constraint(equalToConstant: 44).isActive = true
+            well.heightAnchor.constraint(equalToConstant: 22).isActive = true
+            well.target = self
+            well.action = #selector(colorPicked(_:))
+            well.tag = EditorTheme.ColorKey.allCases.firstIndex(of: key)!
+            wells[key] = well
+            let row = NSStackView(views: [well, label("prefs.color.\(key.rawValue)")])
+            row.orientation = .horizontal
+            row.spacing = 8
+            row.alignment = .centerY
+            rows.append(row)
+        }
+        customStack = NSStackView(views: rows)
+        customStack.orientation = .vertical
+        customStack.alignment = .leading
+        customStack.spacing = 8
+
+        let sep = NSBox(); sep.boxType = .separator
+        sep.widthAnchor.constraint(equalToConstant: 400).isActive = true
+
+        let stack = makeStack([heading("prefs.theme"), themeRow, sample, sep, customStack])
+        sample.widthAnchor.constraint(equalToConstant: 400).isActive = true
+        pin(stack, in: root)
+        self.view = root
+        sync()
+    }
+
+    private func label(_ key: String) -> NSTextField { NSTextField(labelWithString: L(key)) }
+
+    private func sync() {
+        let idx = ThemePreset.allCases.firstIndex(of: EditorTheme.preset) ?? 0
+        themePopup.selectItem(withTag: idx)
+        let theme = EditorTheme.current()
+        // サンプルへ配色を反映。
+        sample.textColor = theme.foreground
+        sample.backgroundColor = theme.background
+        // ピッカーは custom 時のみ表示。各 well へ現在色を反映。
+        customStack.isHidden = (EditorTheme.preset != .custom)
+        for key in EditorTheme.ColorKey.allCases {
+            wells[key]?.color = EditorTheme.customColor(key)
+        }
+    }
+
+    @objc private func themePicked(_ sender: NSPopUpButton) {
+        EditorTheme.preset = ThemePreset.allCases[sender.selectedTag()]
+        sync()
+    }
+
+    @objc private func colorPicked(_ sender: NSColorWell) {
+        let key = EditorTheme.ColorKey.allCases[sender.tag]
+        EditorTheme.setCustomColor(key, sender.color)   // preset を .custom に切替＆通知
         sync()
     }
 }

--- a/Sources/MrEditor/UI/SearchBarView.swift
+++ b/Sources/MrEditor/UI/SearchBarView.swift
@@ -53,7 +53,6 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         (field.cell as? NSSearchFieldCell)?.searchButtonCell?.isTransparent = false
 
         countLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
-        countLabel.textColor = .secondaryLabelColor
         countLabel.alignment = .right
         countLabel.setContentHuggingPriority(.required, for: .horizontal)
 
@@ -145,9 +144,13 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     }
 
     private func applyColors() {
-        layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
-        layer?.borderColor = NSColor.separatorColor.cgColor
+        let theme = EditorTheme.current()
+        layer?.backgroundColor = theme.chromeBackground.cgColor
+        layer?.borderColor = theme.separator.cgColor
+        countLabel.textColor = theme.chromeSecondaryText
     }
+    /// 配色（テーマ）を検索パネルへ適用する（内部の検索フィールド・ボタンは窓アピアランスに追従）。
+    func applyTheme() { applyColors() }
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         effectiveAppearance.performAsCurrentDrawingAppearance { applyColors() }

--- a/Sources/MrEditor/UI/SidebarView.swift
+++ b/Sources/MrEditor/UI/SidebarView.swift
@@ -8,6 +8,8 @@ import AppKit
 /// contentView の最前面側に置く（StatusBar / SearchBar と同じ作り）。
 final class SidebarView: NSView {
     var onSelect: ((Int) -> Void)?
+    /// 行の × でそのドキュメントを閉じる要求。
+    var onClose: ((Int) -> Void)?
 
     private let stack = NSStackView()
     private var rows: [SidebarRow] = []
@@ -17,7 +19,6 @@ final class SidebarView: NSView {
 
     private func setup() {
         wantsLayer = true
-        layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
 
         stack.orientation = .vertical
         stack.alignment = .leading
@@ -33,9 +34,9 @@ final class SidebarView: NSView {
 
         // 右端の区切り線（サブレイヤ）
         let sep = CALayer()
-        sep.backgroundColor = NSColor.separatorColor.cgColor
         layer?.addSublayer(sep)
         separator = sep
+        applyTheme()
     }
 
     private var separator: CALayer?
@@ -45,13 +46,18 @@ final class SidebarView: NSView {
     }
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        effectiveAppearance.performAsCurrentDrawingAppearance {
-            layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
-            separator?.backgroundColor = NSColor.separatorColor.cgColor
-        }
+        effectiveAppearance.performAsCurrentDrawingAppearance { applyTheme() }
     }
 
-    func reload(names: [String], active: Int) {
+    /// 配色（テーマ）を背景・区切り線・各行へ適用する。
+    func applyTheme() {
+        let theme = EditorTheme.current()
+        layer?.backgroundColor = theme.chromeBackground.cgColor
+        separator?.backgroundColor = theme.separator.cgColor
+        rows.forEach { $0.applyTheme(theme) }
+    }
+
+    func reload(names: [String], dirty: [Bool], active: Int) {
         rows.forEach { stack.removeArrangedSubview($0); $0.removeFromSuperview() }
         rows.removeAll()
         for (i, name) in names.enumerated() {
@@ -59,7 +65,9 @@ final class SidebarView: NSView {
             row.index = i
             row.label.stringValue = name
             row.onClick = { [weak self] idx in self?.onSelect?(idx) }
+            row.onClose = { [weak self] idx in self?.onClose?(idx) }
             row.setActive(i == active)
+            row.setDirty(i < dirty.count ? dirty[i] : false)
             stack.addArrangedSubview(row)
             row.leadingAnchor.constraint(equalTo: stack.leadingAnchor, constant: stack.edgeInsets.left).isActive = true
             row.trailingAnchor.constraint(equalTo: stack.trailingAnchor, constant: -stack.edgeInsets.right).isActive = true
@@ -70,35 +78,103 @@ final class SidebarView: NSView {
     func setActive(_ index: Int) {
         for (i, r) in rows.enumerated() { r.setActive(i == index) }
     }
+
+    /// 指定行の未保存表示を更新する（編集/保存のたびに呼ぶ。行を作り直さない）。
+    func setDirty(_ index: Int, _ dirty: Bool) {
+        guard index >= 0, index < rows.count else { return }
+        rows[index].setDirty(dirty)
+    }
 }
 
-/// サイドバーの 1 行（layer 背景＋ラベル）。
+/// サイドバーの 1 行（layer 背景＋未保存ドット＋ラベル＋閉じるボタン）。
 final class SidebarRow: NSView {
     let label = NSTextField(labelWithString: "")
+    private let closeButton = NSButton()
+    /// 未保存インジケータ（左端の小さな●。保存済みでは非表示）。
+    private let dirtyDot = NSView()
     var index = 0
     var onClick: ((Int) -> Void)?
+    /// × ボタンでこの行を閉じる要求。
+    var onClose: ((Int) -> Void)?
 
     init() {
         super.init(frame: .zero)
         wantsLayer = true
         layer?.cornerRadius = 5
+
+        dirtyDot.wantsLayer = true
+        dirtyDot.layer?.cornerRadius = 3
+        dirtyDot.isHidden = true
+        dirtyDot.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(dirtyDot)
+
         label.lineBreakMode = .byTruncatingMiddle
         label.font = .systemFont(ofSize: 12)
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
+
+        closeButton.isBordered = false
+        closeButton.imagePosition = .imageOnly
+        closeButton.imageScaling = .scaleProportionallyDown
+        closeButton.setButtonType(.momentaryChange)
+        closeButton.toolTip = L("sidebar.close")
+        closeButton.target = self
+        closeButton.action = #selector(closeTapped)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(closeButton)
+
         NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 9),
-            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            // 左端に未保存ドット用の固定コラム（保存済み/未で名前の左位置がズレないよう常に確保）。
+            dirtyDot.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 9),
+            dirtyDot.centerYAnchor.constraint(equalTo: centerYAnchor),
+            dirtyDot.widthAnchor.constraint(equalToConstant: 6),
+            dirtyDot.heightAnchor.constraint(equalToConstant: 6),
+            label.leadingAnchor.constraint(equalTo: dirtyDot.trailingAnchor, constant: 6),
+            label.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -6),
             label.centerYAnchor.constraint(equalTo: centerYAnchor),
             heightAnchor.constraint(equalToConstant: 26),
+            closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -7),
+            closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            closeButton.widthAnchor.constraint(equalToConstant: 16),
+            closeButton.heightAnchor.constraint(equalToConstant: 16),
         ])
     }
     required init?(coder: NSCoder) { fatalError() }
 
     override func mouseDown(with event: NSEvent) { onClick?(index) }
+    @objc private func closeTapped() { onClose?(index) }
+
+    private var isActive = false
+    private var isDirty = false
+    private var theme = EditorTheme.current()
 
     func setActive(_ active: Bool) {
-        layer?.backgroundColor = (active ? NSColor.selectedContentBackgroundColor : .clear).cgColor
-        label.textColor = active ? .white : .labelColor
+        isActive = active
+        restyle()
+    }
+
+    /// 未保存状態を反映する（●表示＋×アイコンの塗り分け）。
+    func setDirty(_ dirty: Bool) {
+        isDirty = dirty
+        restyle()
+    }
+
+    /// テーマ変更時に色を差し替える（選択・未保存状態は保持）。
+    func applyTheme(_ theme: EditorColorTheme) {
+        self.theme = theme
+        restyle()
+    }
+
+    private func restyle() {
+        layer?.backgroundColor = (isActive ? theme.chromeActiveBackground : .clear).cgColor
+        // 名前は可読性優先で通常色のまま。未保存は●と×をアクセント色にして色分けする。
+        label.textColor = isActive ? theme.chromeActiveText : theme.chromeText
+        dirtyDot.isHidden = !isDirty
+        dirtyDot.layer?.backgroundColor = theme.dirtyIndicator.cgColor
+        closeButton.image = NSImage(
+            systemSymbolName: isDirty ? "xmark.circle.fill" : "xmark.circle",
+            accessibilityDescription: L("sidebar.close"))
+        closeButton.contentTintColor = isDirty ? theme.dirtyIndicator
+                                               : (isActive ? theme.chromeActiveText : theme.chromeSecondaryText)
     }
 }

--- a/Sources/MrEditor/UI/StatusBarView.swift
+++ b/Sources/MrEditor/UI/StatusBarView.swift
@@ -25,15 +25,13 @@ final class StatusBarView: NSView {
         // 同一ウィンドウ内の別のカスタム描画ビュー(LargeFileViewer/DocumentView)の
         // 画面合成が壊れる macOS の不具合を避けるため。
         wantsLayer = true
-        layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
-        separator.backgroundColor = NSColor.separatorColor.cgColor
         layer?.addSublayer(separator)
 
         label.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
-        label.textColor = .secondaryLabelColor
         label.lineBreakMode = .byTruncatingMiddle
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
+        applyTheme()
         NSLayoutConstraint.activate([
             label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
             label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -10),
@@ -53,10 +51,15 @@ final class StatusBarView: NSView {
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         // cgColor はアピアランス変化に追従しないため明示的に再設定する。
-        effectiveAppearance.performAsCurrentDrawingAppearance {
-            layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
-            separator.backgroundColor = NSColor.separatorColor.cgColor
-        }
+        effectiveAppearance.performAsCurrentDrawingAppearance { applyTheme() }
+    }
+
+    /// 配色（テーマ）を背景・区切り線・ラベルへ適用する。
+    func applyTheme() {
+        let theme = EditorTheme.current()
+        layer?.backgroundColor = theme.chromeBackground.cgColor
+        separator.backgroundColor = theme.separator.cgColor
+        label.textColor = theme.chromeSecondaryText
     }
 
     func setPlaceholder() {

--- a/Sources/MrEditor/Viewer/DocumentView.swift
+++ b/Sources/MrEditor/Viewer/DocumentView.swift
@@ -61,7 +61,7 @@ final class DocumentView: NSView {
     /// `extendsToLineEnd` は改行をまたいで行末まで選択が続くか（右端まで帯を伸ばす）。
     struct RowSelection { var range: NSRange; var extendsToLineEnd: Bool }
     var selectionByRow: [Int: RowSelection] = [:]
-    private let selectionColor = NSColor.selectedTextBackgroundColor
+    private var selectionColor = EditorTheme.current().selection
 
     /// 長い行の扱い。false＝折り返さず横スクロール、true＝内容幅で折り返す（B6・config 連動）。
     var wrapEnabled = false { didSet { if wrapEnabled != oldValue { layoutsDirty = true; needsDisplay = true } } }
@@ -76,7 +76,12 @@ final class DocumentView: NSView {
     var cursorShape: CursorShape = AppSettings.cursorShape
     /// ブロックカーソルの幅（configure で font から算出）。
     private var caretWidth: CGFloat = 8
-    private let currentLineColor = NSColor.textColor.withAlphaComponent(0.06)
+    private var currentLineColor = EditorTheme.current().currentLine
+    /// 本文背景色（configure で theme から更新。draw の背景 fill に使う）。
+    private var backgroundColor = EditorTheme.current().background
+    /// ガター背景・区切り線（configure で theme から更新）。
+    private var gutterBackground = EditorTheme.current().chromeBackground
+    private var gutterSeparator = EditorTheme.current().separator
 
     /// 各可視論理行のレイアウト（折り返し・描画・座標変換）。lines/wrap/幅/フォント変化で再構築。
     private var rowLayouts: [LineLayout] = []
@@ -111,14 +116,21 @@ final class DocumentView: NSView {
         caretWidth = EditorStyle.caretWidth(for: font)
         // 行番号が収まるよう、ガター幅をフォントサイズに追従させる。
         gutterWidth = max(64, ceil(font.pointSize * 4.5))
+        // 配色（config 連動）を読み直す。
+        let theme = EditorTheme.current()
+        selectionColor = theme.selection
+        currentLineColor = theme.currentLine
+        backgroundColor = theme.background
+        gutterBackground = theme.chromeBackground
+        gutterSeparator = theme.separator
         textAttributes = [
             .font: font,
-            .foregroundColor: NSColor.textColor,
+            .foregroundColor: theme.foreground,
             .paragraphStyle: EditorStyle.paragraphStyle(for: font),
         ]
         gutterAttributes = [
             .font: font,
-            .foregroundColor: NSColor.secondaryLabelColor,
+            .foregroundColor: theme.chromeSecondaryText,
         ]
         layoutsDirty = true
     }
@@ -135,14 +147,14 @@ final class DocumentView: NSView {
     }
 
     override func draw(_ dirtyRect: NSRect) {
-        NSColor.textBackgroundColor.setFill()
+        backgroundColor.setFill()
         dirtyRect.fill()
 
         // ガター背景
         let gutterRect = NSRect(x: 0, y: 0, width: gutterWidth, height: bounds.height)
-        NSColor.windowBackgroundColor.setFill()
+        gutterBackground.setFill()
         gutterRect.fill()
-        NSColor.separatorColor.setStroke()
+        gutterSeparator.setStroke()
         let divider = NSBezierPath()
         divider.move(to: NSPoint(x: gutterWidth - 0.5, y: 0))
         divider.line(to: NSPoint(x: gutterWidth - 0.5, y: bounds.height))

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -70,6 +70,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.autoresizingMask = [.width]
         textView.textContainer?.widthTracksTextView = true
         textView.delegate = self
+        applyColors()
 
         scrollView.documentView = textView
         addSubview(scrollView)
@@ -231,7 +232,19 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.cursorShape = AppSettings.cursorShape
         textView.highlightCurrentLine = AppSettings.highlightCurrentLine
         applyParagraphStyle()   // タブ幅・行間
+        applyColors()           // 配色（テーマ）
         textView.needsDisplay = true
+    }
+
+    /// 本文エリアの配色（前景・背景・選択）をテーマから適用する。現在行ハイライトは
+    /// `EditorTextView` が描画時に `EditorTheme` を直接読む。
+    private func applyColors() {
+        let theme = EditorTheme.current()
+        textView.textColor = theme.foreground
+        textView.backgroundColor = theme.background
+        textView.insertionPointColor = theme.foreground
+        scrollView.backgroundColor = theme.background
+        textView.selectedTextAttributes[.backgroundColor] = theme.selection
     }
 
     /// 段落スタイル（タブ幅・行間）を typingAttributes と本文全体へ適用する。

--- a/Sources/MrEditor/Viewer/EditorTextView.swift
+++ b/Sources/MrEditor/Viewer/EditorTextView.swift
@@ -29,7 +29,7 @@ final class EditorTextView: NSTextView {
         frag.size.width = bounds.width
         frag = frag.offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
         _ = tc
-        NSColor.textColor.withAlphaComponent(0.06).setFill()
+        EditorTheme.current().currentLine.setFill()
         frag.fill()
     }
 

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -102,7 +102,7 @@ final class PieceTableViewer: NSView, DocumentPane {
     private var searchRegex: NSRegularExpression?
     private var caseSensitive = false
     private var filterMode = false
-    private let matchHighlight = NSColor.systemYellow.withAlphaComponent(0.45)
+    private var matchHighlight = EditorTheme.current().searchMatch
     private var searchEngine: SearchEngine?
     private var searchResults = SearchEngine.Result()
     private var currentMatchIdx = -1
@@ -182,7 +182,8 @@ final class PieceTableViewer: NSView, DocumentPane {
     func applyDisplaySettings() {
         documentView.highlightCurrentLine = AppSettings.highlightCurrentLine
         documentView.cursorShape = AppSettings.cursorShape
-        // タブ幅・行間は configure(font:) が段落スタイル・行高へ織り込む。
+        matchHighlight = EditorTheme.current().searchMatch
+        // タブ幅・行間・配色は configure(font:) が段落スタイル・行高・色へ織り込む。
         documentView.configure(font: EditorFont.current())
         layoutSubviewsManually()
         refresh()

--- a/Tests/MrEditorTests/EditorThemeTests.swift
+++ b/Tests/MrEditorTests/EditorThemeTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import AppKit
+@testable import MrEditor
+
+/// `EditorTheme` のプリセット解決・カスタム色の永続化・変更通知を検証する。
+/// UserDefaults.standard を触るため、各テストで元の値へ復元する。
+final class EditorThemeTests: XCTestCase {
+
+    private var savedPreset: ThemePreset!
+    private var savedCustom: [EditorTheme.ColorKey: NSColor] = [:]
+
+    override func setUp() {
+        super.setUp()
+        savedPreset = EditorTheme.preset
+        for key in EditorTheme.ColorKey.allCases { savedCustom[key] = EditorTheme.customColor(key) }
+    }
+
+    override func tearDown() {
+        // custom 色を戻す（setCustomColor は preset を .custom にするので、preset 復元は最後）。
+        for key in EditorTheme.ColorKey.allCases {
+            if let c = savedCustom[key] { EditorTheme.setCustomColor(key, c) }
+        }
+        EditorTheme.preset = savedPreset
+        super.tearDown()
+    }
+
+    func testDefaultSystemUsesSemanticColors() {
+        EditorTheme.preset = .system
+        let t = EditorTheme.current()
+        // 既存ハードコード値（セマンティック色）と一致＝既定で現状と同じ見た目。
+        XCTAssertEqual(t.foreground, NSColor.textColor)
+        XCTAssertEqual(t.background, NSColor.textBackgroundColor)
+        XCTAssertEqual(t.selection, NSColor.selectedTextBackgroundColor)
+    }
+
+    func testPresetReturnsFixedColors() {
+        EditorTheme.preset = .solarizedDark
+        let bg = EditorTheme.current().background.usingColorSpace(.sRGB)!
+        // Solarized Dark 背景 #002B36。
+        XCTAssertEqual(bg.redComponent, 0x00 / 255.0, accuracy: 0.01)
+        XCTAssertEqual(bg.greenComponent, 0x2B / 255.0, accuracy: 0.01)
+        XCTAssertEqual(bg.blueComponent, 0x36 / 255.0, accuracy: 0.01)
+    }
+
+    func testSetCustomColorSwitchesToCustomAndRoundTrips() {
+        let picked = NSColor(srgbRed: 0.2, green: 0.4, blue: 0.6, alpha: 0.5)
+        EditorTheme.setCustomColor(.foreground, picked)
+        XCTAssertEqual(EditorTheme.preset, .custom)
+        let got = EditorTheme.current().foreground.usingColorSpace(.sRGB)!
+        XCTAssertEqual(got.redComponent, 0.2, accuracy: 0.001)
+        XCTAssertEqual(got.greenComponent, 0.4, accuracy: 0.001)
+        XCTAssertEqual(got.blueComponent, 0.6, accuracy: 0.001)
+        XCTAssertEqual(got.alphaComponent, 0.5, accuracy: 0.001)   // alpha も保たれる
+    }
+
+    func testChangePostsDisplayNotification() {
+        let presetExp = expectation(forNotification: .mrEditorDisplayChanged, object: nil)
+        EditorTheme.preset = .monokai
+        wait(for: [presetExp], timeout: 1)
+
+        let colorExp = expectation(forNotification: .mrEditorDisplayChanged, object: nil)
+        EditorTheme.setCustomColor(.background, .white)
+        wait(for: [colorExp], timeout: 1)
+    }
+}


### PR DESCRIPTION
本文エリアの配色を config 化し、周辺UI（サイドバー/ガター/ステータス/検索パネル/タイトルバー）まで exact にテーマ連動させる。あわせてサイドバーに閉じるボタンと保存済み/未保存の色分けを追加。

## 主な変更
- **EditorTheme** 新設: 本文5色＋周辺UI派生色＋未保存の目印色。プリセット(System / Solarized Dark / Light / Monokai)＋カスタム。System は従来のセマンティック色でライト/ダーク自動追従を維持。
- 環境設定に **「配色」タブ**（テーマ選択＋カスタム時のカラーウェル）。
- 周辺UIをテーマ色で塗り、窓 appearance をテーマ輝度に連動（framework コントロールの明暗も揃う）。サイドバーとメインに濃淡。
- サイドバー各行に **× 閉じるボタン**（既存の確認シート付きクローズを再利用）。
- **保存済み/未保存の色分け**（未保存は●＋塗り×、目印色は設定可能・既定オレンジ）。

## 位置づけ
v0.4（編集）には含めない **次バージョン向け**。実機で Solarized Dark / System 両方を確認、全77テスト green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)