### PR TITLE
構造化ビュー: CSV/TSV 等幅カラム整形＋NDJSON フィールド投影

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -87,6 +87,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func performZoomOut(_ sender: Any?) { windowController?.zoomOut() }
     @objc private func performZoomReset(_ sender: Any?) { windowController?.zoomReset() }
 
+    @objc private func setStructuredMode(_ sender: NSMenuItem) {
+        let modes = StructuredMode.allCases
+        let mode: StructuredMode? = (sender.tag >= 0 && sender.tag < modes.count) ? modes[sender.tag] : nil
+        windowController?.setActiveStructuredMode(mode)
+    }
+
     // MARK: - 最近使った項目
 
     @objc private func openRecent(_ sender: NSMenuItem) {
@@ -160,6 +166,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return c.canFollow
         case #selector(performGoToLine(_:)), #selector(performCloseDocument(_:)):
             return c.hasActiveDocument
+        case #selector(setStructuredMode(_:)):
+            let modes = StructuredMode.allCases
+            let current = c.activeStructuredMode
+            if item.tag < 0 { item.state = (current == nil) ? .on : .off }
+            else if item.tag < modes.count { item.state = (current == modes[item.tag]) ? .on : .off }
+            return c.canStructured
         default:
             return true
         }
@@ -326,6 +338,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         follow.target = self
         viewMenu.addItem(follow)
         self.followItem = follow
+
+        // 構造化表示（CSV/TSV/NDJSON の読み取り専用整形）
+        viewMenu.addItem(.separator())
+        let structMenu = NSMenu(title: L("menu.structured"))
+        let offItem = NSMenuItem(title: L("menu.structured.off"),
+                                 action: #selector(setStructuredMode(_:)), keyEquivalent: "")
+        offItem.tag = -1; offItem.target = self
+        structMenu.addItem(offItem)
+        structMenu.addItem(.separator())
+        for (i, m) in StructuredMode.allCases.enumerated() {
+            let it = NSMenuItem(title: L("menu.structured.\(m.rawValue)"),
+                                action: #selector(setStructuredMode(_:)), keyEquivalent: "")
+            it.tag = i; it.target = self
+            structMenu.addItem(it)
+        }
+        let structItem = NSMenuItem(title: L("menu.structured"), action: nil, keyEquivalent: "")
+        structItem.submenu = structMenu
+        viewMenu.addItem(structItem)
 
         // ウインドウメニュー（Minimize / Zoom ＋ 開いているウィンドウ一覧を AppKit が自動追記）
         let windowMenuItem = NSMenuItem()

--- a/Sources/MrEditor/Core/TabularFormatter.swift
+++ b/Sources/MrEditor/Core/TabularFormatter.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// 構造化表示のモード。CSV/TSV は区切り整形、NDJSON はキー投影。
+enum StructuredMode: String, CaseIterable {
+    case csv, tsv, ndjson
+}
+
+/// 生の1行文字列を、等幅カラムに桁揃えした表示文字列へ整形する純ロジック（UI 非依存）。
+///
+/// 列（ヘッダ名＋固定幅）はサンプル行から `build` で確定する。`format` は1行を
+/// セルに分解し、各セルを列幅へ表示幅ベースでパディング／省略して ` │ ` で連結する。
+/// バイトオフセットに依存しないため、大ファイル（`PieceTableViewer`）と小ファイル
+/// （`EditableViewer`）の両経路から同じ呼び出しで使える。
+struct TabularFormatter {
+    struct Column { let key: String; let width: Int }   // width は表示セル単位
+
+    let mode: StructuredMode
+    let columns: [Column]
+    /// セルの区切り。
+    static let separator = " │ "
+
+    var columnCount: Int { columns.count }
+
+    // MARK: - 構築
+
+    /// サンプル行（生文字列・先頭〜1000 行想定）から列（名前＋固定幅）を確定する。
+    static func build(mode: StructuredMode, sampleLines: [String], widthCap: Int = 40) -> TabularFormatter {
+        let rows = sampleLines.filter { !$0.isEmpty }
+        switch mode {
+        case .csv, .tsv:
+            let sep: Character = (mode == .csv) ? "," : "\t"
+            let parsed = rows.map { splitDelimited($0, sep: sep, csvQuotes: mode == .csv) }
+            let header = parsed.first ?? []
+            let colCount = parsed.map(\.count).max() ?? header.count
+            var cols: [Column] = []
+            for j in 0..<max(colCount, header.count) {
+                let name = j < header.count ? header[j] : ""
+                var w = displayWidth(name)
+                for cells in parsed where j < cells.count { w = max(w, displayWidth(cells[j])) }
+                cols.append(Column(key: name, width: clampWidth(w, cap: widthCap)))
+            }
+            return TabularFormatter(mode: mode, columns: cols)
+        case .ndjson:
+            var order: [String] = []
+            var seen = Set<String>()
+            var maxW: [String: Int] = [:]
+            for line in rows {
+                guard let obj = jsonObject(line) else { continue }
+                for key in orderedKeys(of: line) {
+                    if !seen.contains(key) { seen.insert(key); order.append(key); maxW[key] = displayWidth(key) }
+                    let v = valueString(obj[key] ?? NSNull())
+                    maxW[key] = max(maxW[key] ?? 0, displayWidth(v))
+                }
+            }
+            let cols = order.map { Column(key: $0, width: clampWidth(maxW[$0] ?? displayWidth($0), cap: widthCap)) }
+            return TabularFormatter(mode: mode, columns: cols)
+        }
+    }
+
+    // MARK: - 整形
+
+    /// 1 行 → 列に桁揃えした表示文字列。
+    func format(_ rawLine: String) -> String {
+        let cells = self.cells(of: rawLine)
+        var parts: [String] = []
+        parts.reserveCapacity(columns.count)
+        for (j, col) in columns.enumerated() {
+            let raw = j < cells.count ? cells[j] : ""
+            parts.append(Self.pad(raw, to: col.width))
+        }
+        return parts.joined(separator: Self.separator)
+    }
+
+    /// ヘッダ行（列名を桁揃え）。将来のピン留めヘッダ用。CSV/TSV では行0が実データのヘッダ。
+    func headerLine() -> String {
+        columns.map { Self.pad($0.key, to: $0.width) }.joined(separator: Self.separator)
+    }
+
+    /// 1 行 → セル配列。
+    func cells(of rawLine: String) -> [String] {
+        switch mode {
+        case .csv:    return Self.splitDelimited(rawLine, sep: ",", csvQuotes: true)
+        case .tsv:    return Self.splitDelimited(rawLine, sep: "\t", csvQuotes: false)
+        case .ndjson:
+            guard let obj = Self.jsonObject(rawLine) else { return [rawLine] }
+            return columns.map { Self.valueString(obj[$0.key] ?? NSNull()) }
+        }
+    }
+
+    // MARK: - 分割（1行内）
+
+    /// 区切り分割。`csvQuotes` の場合のみ RFC4180 風のクォート（フィールド先頭の "…"、"" エスケープ）を扱う。
+    /// クォート内改行は対象外（行指向のため各物理行＝1レコード）。
+    static func splitDelimited(_ line: String, sep: Character, csvQuotes: Bool) -> [String] {
+        if !csvQuotes { return line.components(separatedBy: String(sep)) }
+        var out: [String] = []
+        var field = ""
+        var inQuotes = false
+        let chars = Array(line)
+        var i = 0
+        while i < chars.count {
+            let c = chars[i]
+            if inQuotes {
+                if c == "\"" {
+                    if i + 1 < chars.count && chars[i + 1] == "\"" { field.append("\""); i += 2; continue }
+                    inQuotes = false; i += 1; continue
+                }
+                field.append(c); i += 1
+            } else {
+                if c == "\"" && field.isEmpty { inQuotes = true; i += 1 }
+                else if c == sep { out.append(field); field = ""; i += 1 }
+                else { field.append(c); i += 1 }
+            }
+        }
+        out.append(field)
+        return out
+    }
+
+    // MARK: - JSON
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return obj
+    }
+
+    /// JSON オブジェクトのキーを**出現順**で返す（`JSONSerialization` は順序を保たないため元文字列を軽く走査）。
+    private static func orderedKeys(of line: String) -> [String] {
+        guard let obj = jsonObject(line) else { return [] }
+        var keys: [String] = []
+        var seen = Set<String>()
+        let chars = Array(line)
+        var i = 0
+        var depth = 0
+        while i < chars.count {
+            let c = chars[i]
+            if c == "{" || c == "[" { depth += 1; i += 1; continue }
+            if c == "}" || c == "]" { depth -= 1; i += 1; continue }
+            // トップレベル（depth==1）の "key": だけ拾う。
+            if c == "\"" && depth == 1 {
+                var k = ""; i += 1
+                while i < chars.count, chars[i] != "\"" {
+                    if chars[i] == "\\" && i + 1 < chars.count { i += 1 }
+                    k.append(chars[i]); i += 1
+                }
+                i += 1 // 閉じ "
+                // 直後（空白を飛ばして）が : ならキー。
+                var j = i
+                while j < chars.count, chars[j] == " " { j += 1 }
+                if j < chars.count, chars[j] == ":", obj[k] != nil, !seen.contains(k) {
+                    seen.insert(k); keys.append(k)
+                }
+                continue
+            }
+            i += 1
+        }
+        // 走査で拾えなかったキーは末尾に足す（順不同でも欠落させない）。
+        for k in obj.keys where !seen.contains(k) { keys.append(k) }
+        return keys
+    }
+
+    /// JSON 値を表示文字列へ。文字列はそのまま、その他は compact JSON、null は空。
+    private static func valueString(_ value: Any) -> String {
+        if value is NSNull { return "" }
+        if let s = value as? String { return s }
+        if let data = try? JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed]),
+           let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+        return "\(value)"
+    }
+
+    // MARK: - パディング／表示幅
+
+    /// 表示幅ベースで `width` セルへ左寄せパディング。超過は `width-1` セルで切って `…`。
+    static func pad(_ s: String, to width: Int) -> String {
+        let w = displayWidth(s)
+        if w == width { return s }
+        if w < width { return s + String(repeating: " ", count: width - w) }
+        // 切り詰め（… の 1 セルを残す）。
+        var out = ""
+        var used = 0
+        for ch in s {
+            let cw = charWidth(ch)
+            if used + cw > width - 1 { break }
+            out.append(ch); used += cw
+        }
+        out.append("…")            // … は幅1
+        let pad = width - (used + 1)
+        return pad > 0 ? out + String(repeating: " ", count: pad) : out
+    }
+
+    /// 文字列の表示幅（等幅フォント基準・CJK/全角=2）。
+    static func displayWidth(_ s: String) -> Int {
+        var w = 0
+        for ch in s { w += charWidth(ch) }
+        return w
+    }
+
+    private static func charWidth(_ ch: Character) -> Int {
+        for u in ch.unicodeScalars where isWide(u.value) { return 2 }
+        return 1
+    }
+
+    private static func clampWidth(_ w: Int, cap: Int) -> Int { max(1, min(cap, w)) }
+
+    /// East Asian Wide/Fullwidth のおおよその範囲判定（等幅で2セル幅になる文字）。
+    private static func isWide(_ v: UInt32) -> Bool {
+        switch v {
+        case 0x1100...0x115F,      // Hangul Jamo
+             0x2E80...0x303E,      // CJK radicals, Kangxi, CJK symbols/punct
+             0x3041...0x33FF,      // Hiragana, Katakana, CJK symbols
+             0x3400...0x4DBF,      // CJK Ext A
+             0x4E00...0x9FFF,      // CJK Unified
+             0xA000...0xA4CF,      // Yi
+             0xAC00...0xD7A3,      // Hangul syllables
+             0xF900...0xFAFF,      // CJK compat ideographs
+             0xFE30...0xFE4F,      // CJK compat forms
+             0xFF00...0xFF60,      // Fullwidth forms
+             0xFFE0...0xFFE6,      // Fullwidth signs
+             0x1F300...0x1FAFF,    // emoji / symbols
+             0x20000...0x3FFFD:    // CJK Ext B+
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -20,6 +20,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     private let statusBar = StatusBarView()
     private let searchBar = SearchBarView()
     private let readOnlyBanner = ReadOnlyBanner()
+    private let structuredBanner = StructuredBanner()
 
     private let sidebar = SidebarView()
     private let viewerContainer = DropView()
@@ -155,6 +156,18 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             readOnlyBanner.heightAnchor.constraint(equalToConstant: ReadOnlyBanner.height),
         ])
 
+        // 構造化表示バナー（本文領域の左上・構造化中だけ表示。「元に戻す」で通常表示へ）
+        structuredBanner.translatesAutoresizingMaskIntoConstraints = false
+        structuredBanner.isHidden = true
+        structuredBanner.onRevert = { [weak self] in self?.setActiveStructuredMode(nil) }
+        content.addSubview(structuredBanner)
+        NSLayoutConstraint.activate([
+            // 右上に浮かべる（左のヘッダ列を隠さない。検索バーは構造化中に閉じるため競合しない）。
+            structuredBanner.topAnchor.constraint(equalTo: viewerContainer.topAnchor, constant: 10),
+            structuredBanner.trailingAnchor.constraint(equalTo: viewerContainer.trailingAnchor, constant: -28),
+            structuredBanner.heightAnchor.constraint(equalToConstant: StructuredBanner.height),
+        ])
+
         applyChrome()   // 永続化されたテーマを起動時に反映する。
     }
 
@@ -243,6 +256,28 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     var hasActiveDocument: Bool { activeIndex >= 0 }
     /// アクティブなドキュメントが末尾追従中か。
     var isFollowingActive: Bool { activeViewer?.isFollowing ?? false }
+    /// 構造化表示できるか（View メニューの有効化）。
+    var canStructured: Bool { activeViewer?.supportsStructured ?? false }
+    /// アクティブなドキュメントの構造化表示モード（メニューのチェック用）。
+    var activeStructuredMode: StructuredMode? { activeViewer?.structuredMode }
+    /// アクティブなドキュメントの構造化表示モードを設定する。
+    func setActiveStructuredMode(_ mode: StructuredMode?) {
+        guard let v = activeViewer, v.supportsStructured else { NSSound.beep(); return }
+        v.setStructuredMode(mode)
+        if mode != nil, !searchBar.isHidden { hideSearch() }   // 構造化中は検索を閉じる
+        updateStructuredBanner()
+        updateReadOnlyBanner()
+    }
+
+    /// 構造化表示バナーの表示可否を更新する（構造化中だけ出す）。
+    private func updateStructuredBanner() {
+        if let mode = activeStructuredMode {
+            structuredBanner.configure(mode: mode)
+            structuredBanner.isHidden = false
+        } else {
+            structuredBanner.isHidden = true
+        }
+    }
 
     /// 各ビューアにステータス/検索/ドロップのハンドラを繋ぐ（アクティブな時だけ反映）。
     private func wire(_ v: DocumentPane) {
@@ -282,13 +317,16 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         sidebar.setActive(index)
         window?.title = displayName(of: v) + " — " + AppInfo.name
         updateEditedState()
+        updateStructuredBanner()
         updateReadOnlyBanner()
         v.focusContent()
     }
 
     /// 読み取り専用バナーの表示可否を更新する（編集不可のペイン＝LargeFileViewer のときだけ出す）。
     private func updateReadOnlyBanner() {
+        // 構造化表示による読み取り専用は専用バナーで案内するため除外する。
         let isReadOnly = activeViewer != nil && !(activeViewer?.canEdit ?? false)
+            && activeViewer?.structuredMode == nil
         readOnlyBanner.isHidden = !(isReadOnly && !readOnlyBannerDismissed)
     }
 

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -55,6 +55,14 @@
 "menu.saveProgress.statusBar" = "Status bar (stay interactive)";
 "menu.saveProgress.sheet" = "Sheet (wait while saving)";
 "menu.gotoLine" = "Go to Line…";
+"menu.structured" = "Structured View";
+"menu.structured.off" = "Off";
+"menu.structured.csv" = "CSV";
+"menu.structured.tsv" = "TSV";
+"menu.structured.ndjson" = "NDJSON";
+"structured.banner" = "Structured view (read-only)";
+"structured.revert" = "Back to raw text";
+"structured.hint" = "Display-only formatting. Your file is never modified (saving keeps the original CSV/JSON).";
 
 /* Preferences */
 "menu.preferences" = "Preferences…";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -55,6 +55,14 @@
 "menu.saveProgress.statusBar" = "ステータスバー（操作を止めない）";
 "menu.saveProgress.sheet" = "シート（保存中は待つ）";
 "menu.gotoLine" = "行へ移動…";
+"menu.structured" = "構造化表示";
+"menu.structured.off" = "オフ";
+"menu.structured.csv" = "CSV";
+"menu.structured.tsv" = "TSV";
+"menu.structured.ndjson" = "NDJSON";
+"structured.banner" = "構造化表示（読み取り専用）";
+"structured.revert" = "元のテキストに戻す";
+"structured.hint" = "表示だけの整形です。ファイルは変更されません（保存しても元の CSV/JSON のまま）。";
 
 /* 環境設定 */
 "menu.preferences" = "環境設定…";

--- a/Sources/MrEditor/UI/StructuredBanner.swift
+++ b/Sources/MrEditor/UI/StructuredBanner.swift
@@ -1,0 +1,64 @@
+import AppKit
+
+/// 構造化表示（CSV/TSV/NDJSON の桁揃え）が有効な間だけ本文左上に浮かべる帯。
+///
+/// 「これは表示だけの整形・読み取り専用・いつでも元に戻せる」ことを明示し、
+/// 「縦棒付きで保存されてしまうのでは」という誤解を防ぐための安心材料。
+final class StructuredBanner: NSView {
+    /// 「元に戻す」を押したとき。
+    var onRevert: (() -> Void)?
+
+    static let height: CGFloat = 26
+
+    private let label = NSTextField(labelWithString: "")
+
+    override init(frame frameRect: NSRect) { super.init(frame: frameRect); setup() }
+    required init?(coder: NSCoder) { super.init(coder: coder); setup() }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.systemTeal.withAlphaComponent(0.16).cgColor
+        layer?.cornerRadius = 7
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.systemTeal.withAlphaComponent(0.32).cgColor
+        toolTip = L("structured.hint")
+
+        let icon = NSImageView()
+        icon.image = NSImage(systemSymbolName: "tablecells", accessibilityDescription: nil)
+        icon.contentTintColor = .secondaryLabelColor
+        icon.translatesAutoresizingMaskIntoConstraints = false
+
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .secondaryLabelColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let revert = NSButton(title: L("structured.revert"), target: self, action: #selector(revertTapped))
+        revert.bezelStyle = .rounded
+        revert.controlSize = .small
+        revert.font = .systemFont(ofSize: 11)
+        revert.translatesAutoresizingMaskIntoConstraints = false
+        revert.setContentHuggingPriority(.required, for: .horizontal)
+
+        addSubview(icon); addSubview(label); addSubview(revert)
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 13),
+            icon.heightAnchor.constraint(equalToConstant: 13),
+
+            label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            revert.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 12),
+            revert.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            revert.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    /// モード名（CSV/TSV/NDJSON）を反映する。
+    func configure(mode: StructuredMode) {
+        label.stringValue = L("structured.banner") + " · " + mode.rawValue.uppercased()
+    }
+
+    @objc private func revertTapped() { onRevert?() }
+}

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -55,6 +55,15 @@ protocol DocumentPane: NSView {
     /// 末尾追従（tail -f）に対応するか。
     var supportsFollow: Bool { get }
 
+    // MARK: - 構造化表示（CSV/TSV/NDJSON の読み取り専用整形。両ビューアが対応）
+
+    /// 構造化表示に対応するか（View メニューの有効化）。
+    var supportsStructured: Bool { get }
+    /// 現在の構造化表示モード（nil＝オフ）。
+    var structuredMode: StructuredMode? { get }
+    /// 構造化表示モードを設定する（nil でオフ＝通常表示へ復帰）。
+    func setStructuredMode(_ mode: StructuredMode?)
+
     // MARK: - 編集・保存（編集ペインのみ。読み取り専用は既定実装で no-op）
 
     /// 編集・保存できるか（保存メニューの有効化・読み取り専用バナーの判定）。
@@ -87,6 +96,10 @@ protocol DocumentPane: NSView {
 extension DocumentPane {
     var supportsSearch: Bool { true }
     var supportsFollow: Bool { true }
+
+    var supportsStructured: Bool { false }
+    var structuredMode: StructuredMode? { nil }
+    func setStructuredMode(_ mode: StructuredMode?) {}
 
     var currentEncoding: DetectedEncoding { .utf8 }
     var currentSaveEncoding: DetectedEncoding { .utf8 }

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -30,7 +30,14 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     // 編集ペインは検索バー／末尾追従を出さない。
     var supportsSearch: Bool { false }
     var supportsFollow: Bool { false }
-    var canEdit: Bool { true }
+    var canEdit: Bool { structuredFormatter == nil }   // 構造化中は読み取り専用
+
+    // MARK: - 構造化表示（読み取り専用の整形ビュー）
+    private var structuredFormatter: TabularFormatter?
+    /// 構造化 ON 前の本文（OFF で復元）。
+    private var preStructuredText: String?
+    var supportsStructured: Bool { true }
+    var structuredMode: StructuredMode? { structuredFormatter?.mode }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -119,6 +126,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         self.encoding = detected
         self.lineEnding = LineEnding.detect(Data(prefix), encoding: detected)
         self.byteSize = data.count
+        resetStructuredPresentation()
         textView.string = text
         applyParagraphStyle()                       // タブ幅・行間を本文全体へ
         textView.undoManager?.removeAllActions()   // 読み込みはアンドゥ対象にしない
@@ -134,6 +142,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         encoding = .utf8
         lineEnding = .lf
         byteSize = 0
+        resetStructuredPresentation()
         textView.string = ""
         textView.undoManager?.removeAllActions()
         textView.setSelectedRange(NSRange(location: 0, length: 0))
@@ -178,11 +187,15 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         return write(to: url)
     }
 
+    /// 保存・行数計算に使う論理テキスト。構造化表示中は整形後の見た目ではなく元の本文を返す
+    /// （整形は表示だけの変換であり、CSV/JSON の中身を壊さないため）。
+    private var logicalText: String { preStructuredText ?? textView.string }
+
     /// 現在のテキストを検出エンコードで原子的に書き出す。
     /// 検出エンコードで表現できない文字が増えていれば UTF-8 にフォールバックする。
     private func write(to url: URL) -> Bool {
         // NSTextView は改行を LF で挿入するため、保存時に全文をファイルの EOL へ揃える。
-        let s = lineEnding.normalize(textView.string)
+        let s = lineEnding.normalize(logicalText)
         var enc = encoding
         var data = s.data(using: enc.stringEncoding)
         if data == nil {
@@ -236,6 +249,84 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.needsDisplay = true
     }
 
+    // MARK: - 構造化表示
+
+    func setStructuredMode(_ mode: StructuredMode?) {
+        guard let mode else {
+            // OFF: 本文復元・編集可・折り返し復帰。
+            guard let original = preStructuredText else { structuredFormatter = nil; return }
+            structuredFormatter = nil
+            preStructuredText = nil
+            textView.isEditable = true
+            setWrapMode(wrapped: true)
+            textView.delegate = nil
+            textView.string = original
+            textView.delegate = self
+            applyParagraphStyle(); applyColors()
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
+            emitState()
+            return
+        }
+        // ON: 現在の本文から整形（読み取り専用）。
+        let source = preStructuredText ?? textView.string
+        preStructuredText = source
+        var lines = source.components(separatedBy: "\n")
+        if lines.last == "" { lines.removeLast() }   // 末尾改行の余り
+        let fmt = TabularFormatter.build(mode: mode, sampleLines: Array(lines.prefix(1000)))
+        structuredFormatter = fmt
+        textView.isEditable = false
+        setWrapMode(wrapped: false)
+        let formatted = formattedText(lines: lines, formatter: fmt)
+        textView.delegate = nil
+        textView.textStorage?.setAttributedString(formatted)
+        textView.delegate = self
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+    }
+
+    /// 整形済みの読み取り専用テキスト（等幅・CSV/TSV は先頭行を太字）。
+    private func formattedText(lines: [String], formatter: TabularFormatter) -> NSAttributedString {
+        let font = EditorFont.current()
+        let theme = EditorTheme.current()
+        let style = EditorStyle.paragraphStyle(for: font)
+        let base: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: theme.foreground, .paragraphStyle: style]
+        let bold = NSFontManager.shared.convert(font, toHaveTrait: .boldFontMask)
+        let out = NSMutableAttributedString()
+        for (i, line) in lines.enumerated() {
+            var attrs = base
+            if formatter.mode != .ndjson, i == 0 { attrs[.font] = bold }
+            out.append(NSAttributedString(string: formatter.format(line), attributes: attrs))
+            out.append(NSAttributedString(string: "\n", attributes: base))
+        }
+        return out
+    }
+
+    /// 折り返し（true）／横スクロール（false・列を折り返さない）を切り替える。
+    private func setWrapMode(wrapped: Bool) {
+        guard let container = textView.textContainer else { return }
+        if wrapped {
+            container.widthTracksTextView = true
+            textView.isHorizontallyResizable = false
+            textView.autoresizingMask = [.width]
+            scrollView.hasHorizontalScroller = false
+        } else {
+            container.widthTracksTextView = false
+            let big = CGFloat.greatestFiniteMagnitude
+            container.size = NSSize(width: big, height: big)
+            textView.isHorizontallyResizable = true
+            textView.maxSize = NSSize(width: big, height: big)
+            scrollView.hasHorizontalScroller = true
+        }
+    }
+
+    /// 別ファイル読込・新規時に構造化表示を解除して素の編集状態へ戻す。
+    private func resetStructuredPresentation() {
+        guard structuredFormatter != nil else { return }
+        structuredFormatter = nil
+        preStructuredText = nil
+        textView.isEditable = true
+        setWrapMode(wrapped: true)
+    }
+
     /// 本文エリアの配色（前景・背景・選択）をテーマから適用する。現在行ハイライトは
     /// `EditorTextView` が描画時に `EditorTheme` を直接読む。
     private func applyColors() {
@@ -261,7 +352,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     private func emitState() {
         let state = ViewerState(
             encodingName: encoding.displayName,
-            lineCount: lineCount(of: textView.string),
+            lineCount: lineCount(of: logicalText),
             lineCountIsExact: true,
             fileSize: byteSize,
             indexProgress: 1.0

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -88,8 +88,15 @@ final class PieceTableViewer: NSView, DocumentPane {
     private var preserveSearchOnEdit = false
 
     // 検索・追従（B4）: 未保存の編集がある間は無効（mmap と文書が乖離するため）。
-    var supportsSearch: Bool { searchEngine != nil && !isDirty }
-    var supportsFollow: Bool { fileBuffer != nil && !isDirty }
+    // 構造化表示中も無効（読み取り専用の整形ビュー）。
+    var supportsSearch: Bool { searchEngine != nil && !isDirty && structuredFormatter == nil }
+    var supportsFollow: Bool { fileBuffer != nil && !isDirty && structuredFormatter == nil }
+
+    // MARK: - 構造化表示（CSV/TSV/NDJSON の読み取り専用整形）
+    /// nil＝オフ。設定中は編集入力・検索・折り返しを止め、可視行を整形して描く。
+    private var structuredFormatter: TabularFormatter?
+    var supportsStructured: Bool { fileBuffer != nil }
+    var structuredMode: StructuredMode? { structuredFormatter?.mode }
 
     /// クリーン（未編集）の間は表示・検索・追従を LineIndex+mmap で行う（原本＝piece table 内容）。
     /// 編集して dirty になると piece table を真として表示し、検索・追従は止める。
@@ -173,9 +180,35 @@ final class PieceTableViewer: NSView, DocumentPane {
 
     /// 折り返し設定を反映する（config 変更・ドキュメント切替時）。
     func applyLineWrap() {
+        guard structuredFormatter == nil else { return }   // 構造化中は横スクロール固定
         documentView.wrapEnabled = AppSettings.lineWrap
         if documentView.wrapEnabled { documentView.setHorizontalOffset(0) }
         refresh()
+    }
+
+    // MARK: - 構造化表示の切替
+
+    func setStructuredMode(_ mode: StructuredMode?) {
+        guard let mode else {
+            structuredFormatter = nil
+            documentView.inputHandler = self              // 編集入力を復帰
+            documentView.wrapEnabled = AppSettings.lineWrap
+            refresh()
+            return
+        }
+        if filterMode { filterMode = false }             // filter と排他
+        let sample = structuredSampleLines(1000)
+        structuredFormatter = TabularFormatter.build(mode: mode, sampleLines: sample)
+        documentView.inputHandler = nil                  // 読み取り専用
+        documentView.wrapEnabled = false                 // 横スクロール（列を折り返さない）
+        documentView.setHorizontalOffset(0)
+        setTopLine(0)
+        refresh()
+    }
+
+    /// 構造化の列幅算出用サンプル（先頭 n 行の生文字列）。
+    private func structuredSampleLines(_ n: Int) -> [String] {
+        lineRanges(from: 0, count: n).map { decodeLineString($0) }
     }
 
     /// 表示設定（タブ幅・行間・現在行ハイライト・カーソル形状）を反映する。
@@ -322,19 +355,33 @@ final class PieceTableViewer: NSView, DocumentPane {
             for r in ranges { attributed.append(decodeLine(r)) }
             documentView.lineNumbers = nil
             documentView.firstLineNumber = topLine
-            // 検索でジャンプした一致行を帯で強調。
-            let visMatch = currentMatchIdx >= 0 && currentMatchLine >= topLine
-                && currentMatchLine < topLine + attributed.count
-            documentView.activeRow = visMatch ? currentMatchLine - topLine : nil
 
-            // IME 変換中はキャレット行に marked 文字列を下線付きで差し込み、選択は隠す。
-            if hasMarked, let (row, col) = spliceMarkedText(into: &attributed) {
+            if let fmt = structuredFormatter {
+                // 構造化＝読み取り専用。CSV/TSV は先頭行（ヘッダ）を太字に。
+                if fmt.mode != .ndjson, topLine == 0, let first = attributed.first {
+                    let h = NSMutableAttributedString(attributedString: first)
+                    h.addAttribute(.font, value: boldTextFont, range: NSRange(location: 0, length: h.length))
+                    attributed[0] = h
+                }
+                documentView.activeRow = nil
                 documentView.lines = attributed
-                documentView.caret = (row, col)
+                documentView.caret = nil
                 documentView.selectionByRow = [:]
             } else {
-                documentView.lines = attributed
-                updateCaretAndSelectionViews()
+                // 検索でジャンプした一致行を帯で強調。
+                let visMatch = currentMatchIdx >= 0 && currentMatchLine >= topLine
+                    && currentMatchLine < topLine + attributed.count
+                documentView.activeRow = visMatch ? currentMatchLine - topLine : nil
+
+                // IME 変換中はキャレット行に marked 文字列を下線付きで差し込み、選択は隠す。
+                if hasMarked, let (row, col) = spliceMarkedText(into: &attributed) {
+                    documentView.lines = attributed
+                    documentView.caret = (row, col)
+                    documentView.selectionByRow = [:]
+                } else {
+                    documentView.lines = attributed
+                    updateCaretAndSelectionViews()
+                }
             }
         }
         documentView.needsDisplay = true
@@ -364,15 +411,29 @@ final class PieceTableViewer: NSView, DocumentPane {
         return lineIndex?.lineRanges(from: start, count: count) ?? []
     }
 
-    private func decodeLine(_ range: Range<Int>) -> NSAttributedString {
+    /// 行のバイト範囲 → 生の表示文字列（CR 除去・表示上限キャップ）。整形前の素の1行。
+    private func decodeLineString(_ range: Range<Int>) -> String {
         let capped = range.lowerBound..<min(range.upperBound, range.lowerBound + maxLineBytes)
         var bytes = rawBytes(in: capped)
         // PieceTable.byteRange は CRLF の CR を残すため、描画側で落とす（LineIndex 経路では既に無い）。
         if bytes.last == 0x0D { bytes.removeLast() }
-        let str = decodeString(bytes)
+        return decodeString(bytes)
+    }
+
+    private func decodeLine(_ range: Range<Int>) -> NSAttributedString {
+        let str = decodeLineString(range)
+        if let fmt = structuredFormatter {
+            // 構造化＝列に桁揃えして表示（検索ハイライトは無効）。
+            return NSAttributedString(string: fmt.format(str), attributes: documentView.textAttributes)
+        }
         let attr = NSMutableAttributedString(string: str, attributes: documentView.textAttributes)
         if !searchTerms.isEmpty || searchRegex != nil { highlightMatches(in: attr, text: str) }
         return attr
+    }
+
+    /// ヘッダ行用の太字フォント（本文フォントに bold トレイトを付与。無ければ同フォント）。
+    private var boldTextFont: NSFont {
+        NSFontManager.shared.convert(EditorFont.current(), toHaveTrait: .boldFontMask)
     }
 
     /// 行内の一致箇所に背景色を付ける（可視行のみ・グローバル索引不要）。

--- a/Tests/MrEditorTests/EditableViewerTests.swift
+++ b/Tests/MrEditorTests/EditableViewerTests.swift
@@ -72,4 +72,42 @@ final class EditableViewerTests: XCTestCase {
         let saved = try Data(contentsOf: url)
         XCTAssertEqual(saved, "x\r\ny\r\nz".data(using: .utf8)) // 全行 CRLF
     }
+
+    // MARK: 構造化表示は表示だけの変換（保存で中身を壊さない）
+
+    /// 構造化表示（CSV 桁揃え）中に保存しても、書き出すのは整形後の見た目ではなく元の CSV。
+    func testSaveWhileStructuredWritesOriginalCSV() throws {
+        let text = "name,age\nAlice,30\nBob,7\n"
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try text.data(using: .utf8)!.write(to: url)
+
+        let v = EditableViewer()
+        XCTAssertTrue(v.open(url: url))
+        v.setStructuredMode(.csv)                    // 列に桁揃えして表示
+        XCTAssertEqual(v.structuredMode, .csv)
+        XCTAssertFalse(v.canEdit)                    // 構造化中は読み取り専用
+
+        XCTAssertTrue(v._testWrite(to: url))         // close→保存 等で write() が呼ばれても…
+        let saved = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertEqual(saved, text)                  // …元の CSV のまま
+        XCTAssertFalse(saved.contains("│"))          // 区切り記号が混入しない
+    }
+
+    /// 構造化表示をオフにすると編集可へ戻り、本文も元に復元される。
+    func testExitStructuredRestoresText() throws {
+        let text = "name,age\nAlice,30\n"
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try text.data(using: .utf8)!.write(to: url)
+
+        let v = EditableViewer()
+        XCTAssertTrue(v.open(url: url))
+        v.setStructuredMode(.csv)
+        XCTAssertNotEqual(v._testText, text)         // 表示は整形後
+        v.setStructuredMode(nil)
+        XCTAssertNil(v.structuredMode)
+        XCTAssertTrue(v.canEdit)
+        XCTAssertEqual(v._testText, text)            // 元の本文に復元
+    }
 }

--- a/Tests/MrEditorTests/TabularFormatterTests.swift
+++ b/Tests/MrEditorTests/TabularFormatterTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import MrEditor
+
+/// `TabularFormatter` の分割・キー投影・表示幅パディング・省略・列幅確定を検証する。
+final class TabularFormatterTests: XCTestCase {
+
+    // MARK: - 分割
+
+    func testCSVQuotedFields() {
+        let cells = TabularFormatter.splitDelimited("a,\"b,c\",\"d\"\"e\",f", sep: ",", csvQuotes: true)
+        XCTAssertEqual(cells, ["a", "b,c", "d\"e", "f"])
+    }
+
+    func testCSVEmptyFields() {
+        XCTAssertEqual(TabularFormatter.splitDelimited("a,,c", sep: ",", csvQuotes: true), ["a", "", "c"])
+    }
+
+    func testTSVPlainSplit() {
+        XCTAssertEqual(TabularFormatter.splitDelimited("a\tb\tc", sep: "\t", csvQuotes: false), ["a", "b", "c"])
+    }
+
+    // MARK: - 表示幅・パディング・省略
+
+    func testDisplayWidthCJKIsDouble() {
+        XCTAssertEqual(TabularFormatter.displayWidth("abc"), 3)
+        XCTAssertEqual(TabularFormatter.displayWidth("あいう"), 6)      // 全角=2
+        XCTAssertEqual(TabularFormatter.displayWidth("aあb"), 4)
+    }
+
+    func testPadLeftAlignsToDisplayWidth() {
+        XCTAssertEqual(TabularFormatter.pad("ab", to: 5), "ab   ")     // 3 スペース
+        XCTAssertEqual(TabularFormatter.pad("あ", to: 5), "あ   ")     // 全角2 + 3 スペース
+        XCTAssertEqual(TabularFormatter.displayWidth(TabularFormatter.pad("あ", to: 5)), 5)
+    }
+
+    func testPadTruncatesWithEllipsis() {
+        let out = TabularFormatter.pad("abcdef", to: 4)               // 3 文字 + …
+        XCTAssertEqual(out, "abc…")
+        XCTAssertEqual(TabularFormatter.displayWidth(out), 4)
+    }
+
+    func testPadTruncationRespectsCJKWidth() {
+        // 幅5に「あいうえ」(=8)。全角は2なので「あい」(=4)+… で幅5。
+        let out = TabularFormatter.pad("あいうえ", to: 5)
+        XCTAssertEqual(TabularFormatter.displayWidth(out), 5)
+        XCTAssertTrue(out.hasSuffix("…"))
+    }
+
+    // MARK: - build（列幅確定）
+
+    func testBuildCSVColumnsFromSample() {
+        let f = TabularFormatter.build(mode: .csv,
+                                       sampleLines: ["name,age", "Alice,30", "Bob,7"])
+        XCTAssertEqual(f.columnCount, 2)
+        XCTAssertEqual(f.columns[0].key, "name")
+        XCTAssertEqual(f.columns[0].width, 5)   // "Alice"
+        XCTAssertEqual(f.columns[1].key, "age")
+        XCTAssertEqual(f.columns[1].width, 3)   // "age"
+    }
+
+    func testFormatAlignsColumns() {
+        let f = TabularFormatter.build(mode: .csv, sampleLines: ["name,age", "Alice,30", "Bob,7"])
+        let row = f.format("Bob,7")
+        XCTAssertEqual(row, "Bob   │ 7  ")       // name 幅5, age 幅3
+    }
+
+    func testBuildCapsColumnWidth() {
+        let long = String(repeating: "x", count: 100)
+        let f = TabularFormatter.build(mode: .csv, sampleLines: ["h", long], widthCap: 10)
+        XCTAssertEqual(f.columns[0].width, 10)
+    }
+
+    func testRaggedRowsPadMissingCells() {
+        let f = TabularFormatter.build(mode: .csv, sampleLines: ["a,b,c", "1,2,3"])
+        let row = f.format("x")                  // 1 セルだけ → 残りは空でパディング
+        XCTAssertTrue(row.hasPrefix("x"))
+        XCTAssertEqual(f.columnCount, 3)
+    }
+
+    // MARK: - NDJSON
+
+    func testNDJSONProjectsKeysInOrder() {
+        let f = TabularFormatter.build(mode: .ndjson,
+            sampleLines: ["{\"level\":\"INFO\",\"msg\":\"hi\"}",
+                          "{\"level\":\"ERROR\",\"msg\":\"boom\",\"code\":500}"])
+        XCTAssertEqual(f.columns.map(\.key), ["level", "msg", "code"])
+        let cells = f.cells(of: "{\"level\":\"INFO\",\"msg\":\"hi\"}")
+        XCTAssertEqual(cells, ["INFO", "hi", ""])          // 欠けたキーは空
+    }
+
+    func testNDJSONNestedValueBecomesCompactJSON() {
+        let f = TabularFormatter.build(mode: .ndjson, sampleLines: ["{\"a\":{\"x\":1},\"b\":[1,2]}"])
+        let cells = f.cells(of: "{\"a\":{\"x\":1},\"b\":[1,2]}")
+        XCTAssertEqual(cells[0], "{\"x\":1}")
+        XCTAssertEqual(cells[1], "[1,2]")
+    }
+
+    func testNDJSONNumberAndNull() {
+        let f = TabularFormatter.build(mode: .ndjson, sampleLines: ["{\"n\":42,\"z\":null}"])
+        let cells = f.cells(of: "{\"n\":42,\"z\":null}")
+        XCTAssertEqual(cells[0], "42")
+        XCTAssertEqual(cells[1], "")
+    }
+}


### PR DESCRIPTION
巨大ファイルを一瞬で開く強みを、**「数百万行の CSV/NDJSON を一瞬で列整形」**という第二の看板デモへ拡張。読み取り専用の「構造化表示」モードをドキュメント単位でトグル（M3「無料の客寄せ核」）。

## 主な変更
- **TabularFormatter**（新規・UI 非依存・14テスト）: CSV(RFC4180風クォート) / TSV / NDJSON(キー投影・ネストは compact JSON) を分割し、**東アジア文字幅対応**で等幅カラムに桁揃え。列幅は先頭〜1000行のサンプルから固定（上限＋… 省略）。
- 大小両経路に注入（可視ウィンドウだけ整形＝巨大でも激安）: `PieceTableViewer`（先頭行太字・検索/編集/追従を無効化）と `EditableViewer`（読み取り専用整形・オフで復元）。
- **View メニュー ▸ 構造化表示**（オフ/CSV/TSV/NDJSON）＋チェック状態、日英ローカライズ。

## 安全性・UX
- 保存は常に**元の CSV/JSON** を書く（整形後の見た目は保存しない）。回帰テスト2本。
- 構造化中だけ右上に **「構造化表示（読み取り専用）· <mode>」帯＋「元のテキストに戻す」** ボタン（`StructuredBanner`）で「縦棒付きで保存されるのでは」という誤解を防止。

## 検証
全93テスト green。小CSV（日本語全角揃え）・NDJSON・大CSV(200K行/14MB) を実機確認。

## v1 スコープ外
NDJSON のヘッダ行／クォート内改行 CSV／複数行 pretty-print／列選択UI／構造化中の編集。

🤖 Generated with [Claude Code](https://claude.com/claude-code)