### PR TITLE
1.0 ブロッカー: Finder 統合・Info.plist・印刷（PDF）・更新通知

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -35,6 +35,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if !opened {
             DispatchQueue.main.async { controller.restoreSession() }
         }
+
+        // App Store 配布ではないので、新版の存在は自分で知らせる必要がある。
+        // 1 日 1 回まで・新版があるときだけ喋る（失敗は黙って捨てる）。
+        UpdateChecker.check(manual: false)
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -68,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             .version: "",
         ])
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func checkForUpdates(_ sender: Any?) {
+        UpdateChecker.check(manual: true)   // 明示的な呼び出しは結果を必ず知らせる
     }
 
     @objc private func newDocument(_ sender: Any?) {
@@ -219,6 +227,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                                    action: #selector(showAbout(_:)), keyEquivalent: "")
         aboutItem.target = self
         appMenu.addItem(aboutItem)
+        let updateItem = NSMenuItem(title: L("menu.checkForUpdates"),
+                                    action: #selector(checkForUpdates(_:)), keyEquivalent: "")
+        updateItem.target = self
+        appMenu.addItem(updateItem)
         appMenu.addItem(.separator())
         let prefsItem = NSMenuItem(title: L("menu.preferences"),
                                    action: #selector(openPreferences(_:)), keyEquivalent: ",")

--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -92,6 +92,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func performSave(_ sender: Any?) { windowController?.saveActiveDocument() }
     @objc private func performSaveAs(_ sender: Any?) { windowController?.saveActiveDocumentAs() }
     @objc private func performRevert(_ sender: Any?) { windowController?.revertActiveDocument() }
+    @objc private func performPrint(_ sender: Any?) { windowController?.printActiveDocument() }
 
     @objc private func reopenWithEncoding(_ sender: NSMenuItem) {
         let list = DetectedEncoding.selectable
@@ -170,6 +171,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return c.canSave
         case #selector(performRevert(_:)):
             return c.canRevert
+        case #selector(performPrint(_:)):
+            return c.canPrint   // 巨大ファイルは印刷不可（数百万ページになる）
         case #selector(reopenWithEncoding(_:)):
             let list = DetectedEncoding.selectable
             if item.tag >= 0, item.tag < list.count {
@@ -286,6 +289,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
         encItem.submenu = encMenu
         fileMenu.addItem(encItem)
+        fileMenu.addItem(.separator())
+        // プリント（ダイアログの「PDF ▸ PDF として保存」で PDF 出力も兼ねる）。
+        let printItem = NSMenuItem(title: L("menu.print"),
+                                   action: #selector(performPrint(_:)), keyEquivalent: "p")
+        printItem.target = self
+        fileMenu.addItem(printItem)
         fileMenu.addItem(.separator())
         let closeItem = NSMenuItem(title: L("menu.close"),
                                    action: #selector(performCloseDocument(_:)), keyEquivalent: "w")

--- a/Sources/MrEditor/AppSettings.swift
+++ b/Sources/MrEditor/AppSettings.swift
@@ -83,6 +83,8 @@ enum AppSettings {
     private static let highlightCurrentLineKey = "MrEditor.highlightCurrentLine"
     private static let cursorShapeKey = "MrEditor.cursorShape"
     private static let sessionKey = "MrEditor.session"
+    private static let autoUpdateCheckKey = "MrEditor.automaticUpdateChecks"
+    private static let lastUpdateCheckKey = "MrEditor.lastUpdateCheck"
 
     static var saveProgressStyle: SaveProgressStyle {
         get { SaveProgressStyle(rawValue: defaults.string(forKey: saveProgressKey) ?? "") ?? .sheet }
@@ -132,6 +134,19 @@ enum AppSettings {
                 defaults.removeObject(forKey: sessionKey)
             }
         }
+    }
+
+    /// 起動時に新しい版が出ていないか自動で調べるか。既定 true。
+    /// App Store 配布ではないため、これが無いと利用者は新版に気づけない。
+    static var automaticUpdateChecks: Bool {
+        get { defaults.object(forKey: autoUpdateCheckKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: autoUpdateCheckKey) }
+    }
+
+    /// 自動チェックを最後に行った時刻（1 日 1 回に絞るため）。
+    static var lastUpdateCheck: Date? {
+        get { defaults.object(forKey: lastUpdateCheckKey) as? Date }
+        set { defaults.set(newValue, forKey: lastUpdateCheckKey) }
     }
 
     private static func postDisplayChanged() {

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -289,6 +289,15 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         return v.canEdit && v.isDirty && v.fileURL != nil
     }
     /// 検索できるドキュメントが開いているか。
+    /// 印刷（＝PDF 出力）できるドキュメントが開いているか。巨大ファイルは不可。
+    var canPrint: Bool { activeViewer?.canPrint ?? false }
+
+    /// アクティブなドキュメントを印刷する（プリントダイアログから PDF 保存も可能）。
+    func printActiveDocument() {
+        guard let v = activeViewer, v.canPrint else { NSSound.beep(); return }
+        v.printDocument()
+    }
+
     var canSearch: Bool { activeViewer?.supportsSearch ?? false }
     /// 末尾追従できるドキュメントが開いているか。
     var canFollow: Bool { activeViewer?.supportsFollow ?? false }

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -138,3 +138,16 @@
 "search.replacePlaceholder" = "Replace with";
 "search.replace" = "Replace";
 "search.replaceAll" = "Replace All";
+
+/* Update check (not distributed via the App Store, so we tell users ourselves) */
+"menu.checkForUpdates" = "Check for Updates…";
+"update.availableTitle" = "%1$@ %2$@ is available";
+"update.availableMessage" = "You are running %@. Open the download page?";
+"update.download" = "Download";
+"update.later" = "Later";
+"update.upToDateTitle" = "%1$@ %2$@ is up to date";
+"update.upToDateMessage" = "No newer version is available.";
+"update.failedTitle" = "Couldn’t check for updates";
+"update.failedMessage" = "The network was unreachable, or the release information could not be read. Please try again later.";
+"prefs.autoUpdateCheck" = "Check for updates on launch";
+"prefs.updates" = "Updates";

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "menu.clearRecent" = "Clear Menu";
 "menu.save" = "Save";
 "menu.saveAs" = "Save As…";
+"menu.print" = "Print…";
 "menu.revert" = "Revert to Saved";
 "menu.reopenWithEncoding" = "Reopen with Encoding";
 "menu.textEncoding" = "Text Encoding";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "menu.clearRecent" = "メニューを消去";
 "menu.save" = "保存";
 "menu.saveAs" = "別名で保存…";
+"menu.print" = "プリント…";
 "menu.revert" = "保存済みに戻す";
 "menu.reopenWithEncoding" = "エンコーディングを指定して開き直す";
 "menu.textEncoding" = "テキストエンコーディング";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -138,3 +138,16 @@
 "search.replacePlaceholder" = "置換";
 "search.replace" = "置換";
 "search.replaceAll" = "すべて置換";
+
+/* アップデート確認（App Store 配布ではないため自前で知らせる） */
+"menu.checkForUpdates" = "アップデートを確認…";
+"update.availableTitle" = "%1$@ %2$@ が利用できます";
+"update.availableMessage" = "現在お使いのバージョンは %@ です。ダウンロードページを開きますか？";
+"update.download" = "ダウンロード";
+"update.later" = "後で";
+"update.upToDateTitle" = "%1$@ %2$@ は最新です";
+"update.upToDateMessage" = "新しいバージョンはありません。";
+"update.failedTitle" = "アップデートを確認できませんでした";
+"update.failedMessage" = "ネットワークに接続できないか、リリース情報を取得できませんでした。時間をおいて試してください。";
+"prefs.autoUpdateCheck" = "起動時にアップデートを確認する";
+"prefs.updates" = "アップデート";

--- a/Sources/MrEditor/UI/PreferencesWindowController.swift
+++ b/Sources/MrEditor/UI/PreferencesWindowController.swift
@@ -77,9 +77,10 @@ private func pin(_ stack: NSStackView, in root: NSView) {
 private final class GeneralPaneViewController: NSViewController {
     private var statusBarRadio: NSButton!
     private var sheetRadio: NSButton!
+    private var autoUpdateCheck: NSButton!
 
     override func loadView() {
-        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 200))
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 260))
 
         statusBarRadio = NSButton(radioButtonWithTitle: L("menu.saveProgress.statusBar"),
                                   target: self, action: #selector(radioChanged(_:)))
@@ -90,11 +91,24 @@ private final class GeneralPaneViewController: NSViewController {
         hint.font = .systemFont(ofSize: 11)
         hint.textColor = .secondaryLabelColor
 
-        let stack = makeStack([heading("prefs.saveProgress"), statusBarRadio, sheetRadio, hint])
+        autoUpdateCheck = NSButton(checkboxWithTitle: L("prefs.autoUpdateCheck"),
+                                   target: self, action: #selector(autoUpdateChanged(_:)))
+
+        let sep = NSBox(); sep.boxType = .separator
+
+        let stack = makeStack([heading("prefs.saveProgress"), statusBarRadio, sheetRadio, hint,
+                               sep,
+                               heading("prefs.updates"), autoUpdateCheck])
         hint.widthAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
+        sep.widthAnchor.constraint(equalToConstant: 400).isActive = true
         pin(stack, in: root)
         self.view = root
         syncRadios()
+        autoUpdateCheck.state = AppSettings.automaticUpdateChecks ? .on : .off
+    }
+
+    @objc private func autoUpdateChanged(_ sender: NSButton) {
+        AppSettings.automaticUpdateChecks = (sender.state == .on)
     }
 
     private func syncRadios() {

--- a/Sources/MrEditor/UpdateChecker.swift
+++ b/Sources/MrEditor/UpdateChecker.swift
@@ -1,0 +1,146 @@
+import AppKit
+
+/// GitHub Releases を見て新しい版が出ていないか調べ、出ていたら知らせる。
+///
+/// **置き換えはしない。** ダイアログから dmg のリリースページをブラウザで開くだけで、
+/// ダウンロード・検証・入れ替えはユーザーの手に委ねる。その場で自動インストールする
+/// 仕組み（Sparkle 等）は Developer ID 署名を入れてから検討する。署名の無いアプリを
+/// 自動で置き換えるのは、配布経路として筋が悪い。
+enum UpdateChecker {
+
+    /// 判明した最新リリース。
+    struct Release {
+        /// タグから取り出したバージョン（"v1.2" なら "1.2"）。
+        let version: String
+        /// リリースページ（dmg が無い場合はここを開く）。
+        let pageURL: URL
+        /// 配布物の直リンク（あれば）。
+        let dmgURL: URL?
+    }
+
+    enum CheckError: Error { case network(Error), badResponse }
+
+    private static let latestReleaseAPI =
+        URL(string: "https://api.github.com/repos/MR-TABATA/MrEditor/releases/latest")!
+
+    // MARK: - バージョン比較（純粋関数・テスト対象）
+
+    /// "v1.2" / "1.2.3" / "1.2-beta" を数値の並びへ。数字以外は 0 とみなす。
+    static func components(_ version: String) -> [Int] {
+        version
+            .drop(while: { !$0.isNumber })          // 先頭の "v" などを捨てる
+            .split(separator: ".")
+            .map { Int($0.prefix(while: \.isNumber)) ?? 0 }
+    }
+
+    /// `a` が `b` より新しいか。桁数が違っても比較できる（"1.0" > "0.7"、"1.0.1" > "1.0"）。
+    static func isNewer(_ a: String, than b: String) -> Bool {
+        let lhs = components(a), rhs = components(b)
+        for i in 0..<max(lhs.count, rhs.count) {
+            let l = i < lhs.count ? lhs[i] : 0
+            let r = i < rhs.count ? rhs[i] : 0
+            if l != r { return l > r }
+        }
+        return false
+    }
+
+    // MARK: - 取得
+
+    /// 最新リリースを取り出す。完了は必ずメインスレッドで呼ぶ。
+    static func fetchLatest(_ completion: @escaping (Result<Release, CheckError>) -> Void) {
+        var req = URLRequest(url: latestReleaseAPI, timeoutInterval: 10)
+        // GitHub API は User-Agent を要求する。無いと 403 が返る。
+        req.setValue("MrEditor/\(AppInfo.version)", forHTTPHeaderField: "User-Agent")
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.cachePolicy = .reloadIgnoringLocalCacheData
+
+        let session = URLSession(configuration: .ephemeral)
+        session.dataTask(with: req) { data, response, error in
+            let result: Result<Release, CheckError>
+            if let error {
+                result = .failure(.network(error))
+            } else if let release = data.flatMap(parse) ,
+                      (response as? HTTPURLResponse)?.statusCode == 200 {
+                result = .success(release)
+            } else {
+                result = .failure(.badResponse)
+            }
+            DispatchQueue.main.async { completion(result) }
+        }.resume()
+    }
+
+    /// GitHub の JSON から必要な3点だけ取り出す（テストのため分離）。
+    static func parse(_ data: Data) -> Release? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tag = root["tag_name"] as? String,
+              let page = (root["html_url"] as? String).flatMap(URL.init(string:))
+        else { return nil }
+
+        let assets = root["assets"] as? [[String: Any]] ?? []
+        let dmg = assets
+            .compactMap { $0["browser_download_url"] as? String }
+            .first { $0.hasSuffix(".dmg") }
+            .flatMap(URL.init(string:))
+
+        let version = String(tag.drop(while: { !$0.isNumber }))
+        guard !version.isEmpty else { return nil }
+        return Release(version: version, pageURL: page, dmgURL: dmg)
+    }
+
+    // MARK: - UI
+
+    /// 更新を調べて必要ならダイアログを出す。
+    /// - Parameter manual: メニューから明示的に呼ばれたか。`true` なら
+    ///   「最新です」も失敗も知らせる。`false`（起動時の自動チェック）は
+    ///   新版があるときだけ喋る。黙って失敗するのが正しい。
+    static func check(manual: Bool) {
+        if !manual {
+            guard AppSettings.automaticUpdateChecks, shouldCheckToday() else { return }
+            AppSettings.lastUpdateCheck = Date()
+        }
+        fetchLatest { result in
+            switch result {
+            case .success(let release):
+                if isNewer(release.version, than: AppInfo.version) {
+                    presentAvailable(release)
+                } else if manual {
+                    presentUpToDate()
+                }
+            case .failure:
+                if manual { presentFailure() }
+            }
+        }
+    }
+
+    /// 自動チェックは 1 日 1 回まで。起動のたびに GitHub を叩かない。
+    private static func shouldCheckToday() -> Bool {
+        guard let last = AppSettings.lastUpdateCheck else { return true }
+        return Date().timeIntervalSince(last) >= 24 * 60 * 60
+    }
+
+    private static func presentAvailable(_ release: Release) {
+        let alert = NSAlert()
+        alert.messageText = L("update.availableTitle", AppInfo.name, release.version)
+        alert.informativeText = L("update.availableMessage", AppInfo.version)
+        alert.addButton(withTitle: L("update.download"))   // .alertFirstButtonReturn
+        alert.addButton(withTitle: L("update.later"))
+        if alert.runModal() == .alertFirstButtonReturn {
+            NSWorkspace.shared.open(release.dmgURL ?? release.pageURL)
+        }
+    }
+
+    private static func presentUpToDate() {
+        let alert = NSAlert()
+        alert.messageText = L("update.upToDateTitle", AppInfo.name, AppInfo.version)
+        alert.informativeText = L("update.upToDateMessage")
+        alert.runModal()
+    }
+
+    private static func presentFailure() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = L("update.failedTitle")
+        alert.informativeText = L("update.failedMessage")
+        alert.runModal()
+    }
+}

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -82,6 +82,12 @@ protocol DocumentPane: NSView {
     /// 保存先を選んで保存する（Save As）。成功で true。
     @discardableResult func saveAs() -> Bool
 
+    /// 印刷できるか（プリントダイアログから PDF 保存もできる）。
+    /// 巨大ファイルは数百万ページになり意味を成さないため既定で false。
+    var canPrint: Bool { get }
+    /// プリントダイアログを出す。
+    func printDocument()
+
     // 検索／追従／行ジャンプ（編集ペインでは既定で no-op）。
     func setSearchQuery(_ q: String)
     func setCaseSensitive(_ on: Bool)
@@ -117,6 +123,10 @@ extension DocumentPane {
     var restorableText: String? { nil }
     @discardableResult func save() -> Bool { false }
     @discardableResult func saveAs() -> Bool { false }
+
+    // 読み取り専用の巨大ファイルは印刷しない（8,600 万行＝数百万ページになる）。
+    var canPrint: Bool { false }
+    func printDocument() {}
 
     func setSearchQuery(_ q: String) {}
     func setCaseSensitive(_ on: Bool) {}

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -139,6 +139,33 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     /// セッション復元用の本文（構造化中は元の論理本文）。保存済み・未保存を問わず現在の中身。
     var restorableText: String? { logicalText }
 
+    // MARK: - 印刷（プリントダイアログの「PDF ▸ PDF として保存」で PDF 出力も兼ねる）
+
+    var canPrint: Bool { true }
+
+    /// 表示中の本文を印刷する。改ページ・行の分割は NSTextView に委ねる。
+    /// 構造化表示中は整形後の見た目をそのまま刷る（画面と一致させる）。
+    func printDocument() {
+        let info = NSPrintInfo.shared
+        info.horizontalPagination = .fit
+        info.verticalPagination = .automatic
+        info.isHorizontallyCentered = false
+        info.isVerticallyCentered = false
+        // ヘッダ/フッタの余白ぶんを確保しつつ、行が切れないよう幅は用紙に合わせる。
+        info.topMargin = 36; info.bottomMargin = 36
+        info.leftMargin = 36; info.rightMargin = 36
+
+        let op = NSPrintOperation(view: textView, printInfo: info)
+        op.jobTitle = fileURL?.lastPathComponent ?? L("doc.untitled")
+        op.showsPrintPanel = true
+        op.showsProgressPanel = true
+        if let win = window {
+            op.runModal(for: win, delegate: nil, didRun: nil, contextInfo: nil)
+        } else {
+            op.run()
+        }
+    }
+
     /// 前回終了時の未保存の新規ドキュメントを本文つきで復元する（パスは未確定のまま）。
     func restoreUntitled(text: String, dirty: Bool) {
         fileURL = nil

--- a/Tests/MrEditorTests/EditableViewerTests.swift
+++ b/Tests/MrEditorTests/EditableViewerTests.swift
@@ -110,4 +110,15 @@ final class EditableViewerTests: XCTestCase {
         XCTAssertTrue(v.canEdit)
         XCTAssertEqual(v._testText, text)            // 元の本文に復元
     }
+
+    // MARK: 印刷（プリントダイアログの「PDF として保存」が PDF 出力を兼ねる）
+
+    /// 小ファイルの編集ペインは印刷できる。巨大ファイルのビューアは印刷できない
+    /// （8,600 万行＝数百万ページになるため、メニューを無効化する根拠）。
+    func testPrintOnlyAvailableForSmallFilePane() {
+        XCTAssertTrue(EditableViewer().canPrint)
+
+        let big = PieceTableViewer(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        XCTAssertFalse(big.canPrint)
+    }
 }

--- a/Tests/MrEditorTests/UpdateCheckerTests.swift
+++ b/Tests/MrEditorTests/UpdateCheckerTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import MrEditor
+
+/// 更新チェックの中核（バージョン比較・GitHub JSON の解析）を検証する。
+/// ネットワークには触れない。
+final class UpdateCheckerTests: XCTestCase {
+
+    // MARK: - バージョン比較
+
+    func testComponentsStripsTagPrefix() {
+        XCTAssertEqual(UpdateChecker.components("v1.2"), [1, 2])
+        XCTAssertEqual(UpdateChecker.components("1.2.3"), [1, 2, 3])
+        XCTAssertEqual(UpdateChecker.components("v0.7"), [0, 7])
+    }
+
+    /// 1.0 は 0.7 より新しい。文字列比較だと "1.0" < "0.7" にはならないが
+    /// "0.10" < "0.7" になってしまうため、数値で比べる必要がある。
+    func testNewerAcrossMajorBump() {
+        XCTAssertTrue(UpdateChecker.isNewer("1.0", than: "0.7"))
+        XCTAssertFalse(UpdateChecker.isNewer("0.7", than: "1.0"))
+    }
+
+    /// 二桁のマイナーが一桁より新しいと判定される（文字列比較のワナ）。
+    func testNewerWithTwoDigitMinor() {
+        XCTAssertTrue(UpdateChecker.isNewer("0.10", than: "0.7"))
+        XCTAssertFalse(UpdateChecker.isNewer("0.7", than: "0.10"))
+    }
+
+    /// 桁数が違っても比較できる。同一版は「新しくない」。
+    func testNewerWithDifferentDepthAndEquality() {
+        XCTAssertTrue(UpdateChecker.isNewer("1.0.1", than: "1.0"))
+        XCTAssertFalse(UpdateChecker.isNewer("1.0", than: "1.0.0"))
+        XCTAssertFalse(UpdateChecker.isNewer("0.7", than: "0.7"))
+    }
+
+    // MARK: - GitHub の JSON 解析
+
+    func testParsePicksTagPageAndDmg() throws {
+        let json = """
+        {
+          "tag_name": "v1.0",
+          "html_url": "https://github.com/MR-TABATA/MrEditor/releases/tag/v1.0",
+          "assets": [
+            {"browser_download_url": "https://example.com/notes.txt"},
+            {"browser_download_url": "https://example.com/MrEditor-1.0.dmg"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let r = try XCTUnwrap(UpdateChecker.parse(json))
+        XCTAssertEqual(r.version, "1.0")                       // "v" は落ちる
+        XCTAssertEqual(r.dmgURL?.lastPathComponent, "MrEditor-1.0.dmg")
+        XCTAssertEqual(r.pageURL.lastPathComponent, "v1.0")
+    }
+
+    /// dmg が添付されていないリリースでも、ページを開けるので成功扱い。
+    func testParseWithoutDmgStillSucceeds() throws {
+        let json = """
+        {"tag_name": "v1.0",
+         "html_url": "https://github.com/MR-TABATA/MrEditor/releases/tag/v1.0",
+         "assets": []}
+        """.data(using: .utf8)!
+        let r = try XCTUnwrap(UpdateChecker.parse(json))
+        XCTAssertNil(r.dmgURL)
+        XCTAssertEqual(r.version, "1.0")
+    }
+
+    /// 壊れた応答・数字を含まないタグでは nil（＝黙って失敗させる）。
+    func testParseRejectsGarbage() {
+        XCTAssertNil(UpdateChecker.parse(Data("not json".utf8)))
+        XCTAssertNil(UpdateChecker.parse(Data(#"{"tag_name":"latest","html_url":"https://x.test/"}"#.utf8)))
+        XCTAssertNil(UpdateChecker.parse(Data(#"{"html_url":"https://x.test/"}"#.utf8)))
+    }
+}

--- a/scripts/make_app.sh
+++ b/scripts/make_app.sh
@@ -70,6 +70,53 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     </array>
     <key>LSMinimumSystemVersion</key>
     <string>13.0</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>© 2026 TABATA Hitoshi. MIT License.</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.developer-tools</string>
+
+    <!-- Finder の「このアプリケーションで開く」に出すための宣言。
+         これが無いと AppDelegate の application(_:open:) は永遠に呼ばれない。
+         LSHandlerRank=Alternate: 既定アプリ（TextEdit 等）は奪わないが候補には出る。
+         2 つ目の public.data は「拡張子が何であれログは開ける」ためのもの
+         （.log でも .out でも拡張子無しでも Finder から開ける）。
+         ここも Alternate。None は「順位が低い」ではなく「この型は開かない」の意味なので使わない。 -->
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Text Document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.plain-text</string>
+                <string>public.utf8-plain-text</string>
+                <string>public.log</string>
+                <string>public.comma-separated-values-text</string>
+                <string>public.tab-separated-values-text</string>
+                <string>public.json</string>
+                <string>public.source-code</string>
+                <string>public.script</string>
+                <string>public.xml</string>
+                <string>public.yaml</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Any File</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.data</string>
+            </array>
+        </dict>
+    </array>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSPrincipalClass</key>


### PR DESCRIPTION
## 背景
1.0 の機能監査で、ロードマップが「残りはリリース作業のみ」と書いている一方、配布・OS 統合まわりに穴が残っていることが分かった。**無料版の App Store 提出を取りやめた**判断を踏まえ、残るブロッカーのうちコードで直せる分を片付ける。

---

## 1. Finder から「このアプリで開く」に出てこなかった
`AppDelegate.application(_:open:)` は実装済みなのに `Info.plist` に `CFBundleDocumentTypes` が無く、**一度も呼ばれない**状態だった。Finder の候補に出ず、`.log` の既定アプリにも設定できず、Dock へのドロップも効かない。

`public.plain-text` / `public.log` / `public.json` / `public.comma-separated-values-text` 等を `Editor` ロールで宣言。`LSHandlerRank: Alternate` なので TextEdit 等の既定は奪わない。

### 実装中に分かったこと
- **`LSHandlerRank: None` は「順位が低い」ではなく「この型は開かない」** の意味だった。
- 拡張子が未知のファイルは `dyn.*` UTI に解決され、**TextEdit や VS Code を含めて候補が 0 件**になる。macOS の仕様で、`CFBundleTypeExtensions: ["*"]` を足しても変わらない。効かない設定は入れていない。

## 2. Info.plist の欠落キー
`NSHumanReadableCopyright`（About の著作権表示）、`LSApplicationCategoryType`。

## 3. 印刷（＝PDF 出力）
macOS のプリントダイアログは「PDF ▸ PDF として保存」を含むので、**PDF 出力の別実装は不要**。

`DocumentPane.canPrint` / `printDocument()` を追加。既定 `false` なので巨大ファイル（8,600 万行＝数百万ページ）はメニューが自動的に無効化される。小ファイルは `NSTextView` に改ページを委ねる。File ▸ プリント…（⌘P）。

## 4. 更新通知（新規）
App Store 提出をやめたため、**1.0 を落とした人が 1.1 の存在を知る手段が無かった**。App Store が無料で提供していた機能が丸ごと欠けていた。

- `UpdateChecker`: GitHub Releases API の `tag_name` を `AppInfo.version` と**数値で**比較。新版があればダイアログを出し、dmg の直リンクをブラウザで開く。
- **置き換えはしない。** 未署名アプリを自動で入れ替えるのは筋が悪いので、Sparkle は Developer ID 署名の後に検討する。
- 自動チェックは起動時・**1 日 1 回まで・新版があるときだけ喋る**。失敗は黙って捨てる。手動メニューのときだけ「最新です」も失敗も知らせる。
- 環境設定 ▸ 一般 に「起動時にアップデートを確認する」（既定 on）。
- バージョン比較は文字列ではできない（`"0.10" < "0.7"` になる）。数値比較をテストで固定。

---

## 検証
- LaunchServices に問い合わせ、`.log`/`.csv`/`.json` の候補に MrEditor が入り `.png` には入らないことを実測
- 実際の GitHub API を叩き、`tag_name` / `html_url` / dmg アセットの形状が想定どおりであることを確認（モックだけで通さない）
- `VERSION=0.6` の `.app` を作り、「新版あり」経路を実機で確認
- `plutil -lint` で Info.plist の妥当性を確認
- **全 109 tests green**（`UpdateCheckerTests` 7 件、`testPrintOnlyAvailableForSmallFilePane` を追加）
- ローカライズ日英とも **130 キーで完全一致**

## 残る 1.0 ブロッカー（このPRの範囲外）
- **Developer ID 署名 ＋ 公証** — 直販が唯一の経路になった以上、必須。現状は未署名で Gatekeeper に弾かれる
- `notes/ROADMAP.md` の書き直し（App Store 前提の記述が 6 箇所、v0.7 のセッション復元が未記載）

🤖 Generated with [Claude Code](https://claude.com/claude-code)