### PR TITLE
リリース v0.9: Apple Developer ID で署名し、公証を通した

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ macOS でテキストを表示する定番は `NSTextView` ですが、内部の
 
 設計の詳細は [docs/ARCHITECTURE_v0.1.md](docs/ARCHITECTURE_v0.1.md) を参照してください。
 
-## 機能（v0.8）
+## 機能（v0.9）
 
 **表示**
 - 任意サイズの巨大テキストを開ける（10GB で検証済み）。表示開始はほぼ一瞬。
@@ -85,11 +85,8 @@ UI は **日本語と英語にローカライズ**（システム言語に追従
 
 **Apple Silicon / Intel の両方で動きます**（universal ビルド）。
 
-このアプリは **Apple Developer ID による署名・公証をしていません**（証明書が未取得のため）。
-そのため初回起動時に Gatekeeper が開発元を検証できず、警告します。開くには次のいずれか:
-
-- MrEditor を右クリック →「**開く**」→ ダイアログで「**開く**」、または
-- `xattr -dr com.apple.quarantine /Applications/MrEditor.app`
+**v0.9 から Apple Developer ID で署名し、Apple の公証（notarization）を通しています。**
+右クリックも `xattr` も不要です。ダブルクリックするだけで開きます。
 
 あるいは下記のソースからのビルドでも動きます。
 
@@ -110,7 +107,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-配布用ディスクイメージ（`.build/MrEditor-0.8.dmg`）の作成:
+配布用ディスクイメージ（`.build/MrEditor-0.9.dmg`）の作成:
 
 ```sh
 sh scripts/make_dmg.sh
@@ -138,7 +135,8 @@ sh scripts/make_dmg.sh
 - **v0.5 — カスタマイズ: フォント選択・表示設定・配色テーマ（本文＋UI）・サイドバー閉じる/未保存の色分け** ✅
 - **v0.6 — 構造化表示: CSV/TSV カラム整形・NDJSON フィールド投影（読み取り専用・サイズ不問）** ✅
 - **v0.7 — セッション復元（未保存の新規も本文ごと）・About パネル修正** ✅
-- **v0.8 — Finder 統合・印刷/PDF 出力・アップデート確認・新アイコン・universal ビルド。および配布物の重大な修正（下記）** ✅（このリリース）
+- **v0.8 — Finder 統合・印刷/PDF 出力・アップデート確認・新アイコン・universal ビルド。および配布物の重大な修正（下記）** ✅
+- **v0.9 — Apple Developer ID で署名し、公証（notarization）を通した。右クリック不要でダブルクリックで開ける** ✅（このリリース）
 - **以降** — シンタックス/ログのハイライト、その他の分析ツール
 
 > **⚠️ v0.7 以前の dmg は、ダウンロードした Mac で起動しません。**
@@ -146,6 +144,9 @@ sh scripts/make_dmg.sh
 > quarantine の付いたアプリを検証してプロセスを終了させていました
 > （「予期しない理由で終了しました」）。**v0.8 で修正済みです。**
 > あわせて **Apple Silicon / Intel の universal ビルド**になりました（従来は arm64 専用）。
+>
+> **v0.8 は起動しますが、初回だけ右クリック →「開く」が必要です**（ad-hoc 署名のため）。
+> **v0.9 以降は署名・公証済みで、その操作も不要です。**
 
 ## まだ「作らない」もの
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ approach (klogg / glogg / lnav):
 
 See [docs/ARCHITECTURE_v0.1.md](docs/ARCHITECTURE_v0.1.md) for the full design.
 
-## Features (v0.8)
+## Features (v0.9)
 
 **Viewing**
 - Opens arbitrarily large text files (validated at 10 GB) with near-instant first paint.
@@ -87,11 +87,8 @@ Download `MrEditor-<version>.dmg` from [Releases](../../releases), open it, and 
 
 **Runs on both Apple Silicon and Intel** (universal build).
 
-The app is **not signed or notarized with an Apple Developer ID** (no certificate yet), so
-Gatekeeper cannot verify the developer and warns on first launch. To open it anyway, either:
-
-- Right-click MrEditor → **Open** → **Open** in the dialog, or
-- `xattr -dr com.apple.quarantine /Applications/MrEditor.app`
+**As of v0.9 the app is signed with an Apple Developer ID and notarized by Apple.**
+No right-click, no `xattr` — just double-click it.
 
 Or just build from source (below).
 
@@ -112,7 +109,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-Build a distributable disk image (`.build/MrEditor-0.8.dmg`):
+Build a distributable disk image (`.build/MrEditor-0.9.dmg`):
 
 ```sh
 sh scripts/make_dmg.sh
@@ -139,7 +136,8 @@ resident app memory. The number that matters (`Physical footprint`) stays at 44 
 - **v0.5 — customization: font selection, display settings, color themes (editor + UI), sidebar close & unsaved markers** ✅
 - **v0.6 — structured view: CSV/TSV column alignment & NDJSON field projection (read-only, any size)** ✅
 - **v0.7 — session restore (unsaved drafts included), About panel fix** ✅
-- **v0.8 — Finder integration, print/PDF export, update check, new icon, universal build, and a critical distribution fix (below)** ✅ (this release)
+- **v0.8 — Finder integration, print/PDF export, update check, new icon, universal build, and a critical distribution fix (below)** ✅
+- **v0.9 — signed with an Apple Developer ID and notarized by Apple; opens with a plain double-click** ✅ (this release)
 - **later** — syntax/log highlighting, and more analysis tooling
 
 > **⚠️ Builds up to v0.7 do not launch on a Mac that downloaded them.**
@@ -147,6 +145,9 @@ resident app memory. The number that matters (`Physical footprint`) stays at 44 
 > macOS killed the quarantined app on launch ("quit unexpectedly").
 > **Fixed in v0.8.** The build is now **universal (Apple Silicon & Intel)** as well —
 > previously it was arm64-only.
+>
+> **v0.8 launches, but needs a right-click → Open on the first run** (it is only ad-hoc signed).
+> **v0.9 and later are signed and notarized, so even that is unnecessary.**
 
 ## Not yet
 

--- a/Sources/MrEditor/AppInfo.swift
+++ b/Sources/MrEditor/AppInfo.swift
@@ -15,7 +15,7 @@ enum AppInfo {
     static var version: String {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? fallbackVersion
     }
-    private static let fallbackVersion = "0.8"
+    private static let fallbackVersion = "0.9"
 
     /// ヘルプメニューから開くプロジェクトページ。
     static let helpURL = URL(string: "https://github.com/MR-TABATA/MrEditor")!

--- a/scripts/make_app.sh
+++ b/scripts/make_app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-debug}"
 APP_NAME="${APP_NAME:-MrEditor}"
 BUNDLE_ID="${BUNDLE_ID:-com.aaedit.MrEditor}"
 # バージョン（Info.plist へ埋め込む）。make_dmg.sh と揃えるため VERSION で上書き可能。
-VERSION="${VERSION:-0.8}"
+VERSION="${VERSION:-0.9}"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # 成果物の置き場所。universal ビルド（--arch arm64 --arch x86_64）では

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -1,13 +1,25 @@
 #!/bin/sh
 # release ビルド（universal: arm64 + x86_64） → .app → 配布用 .dmg を作る。
 #
-# 署名: 既定は ad-hoc。バンドルは必ず署名される（make_app.sh 側）。
-#   ad-hoc でもクラッシュはしないが、Gatekeeper には「開発元を検証できない」と
-#   言われるため、利用者は初回だけ右クリック →「開く」が必要。
-#   正式配布には Developer ID 証明書＋公証が要る:
-#     SIGN_IDENTITY="Developer ID Application: NAME (TEAMID)" sh scripts/make_dmg.sh
-#     xcrun notarytool submit .build/MrEditor-<ver>.dmg --keychain-profile <prof> --wait
-#     xcrun stapler staple .build/MrEditor-<ver>.dmg
+# ■ 既定（環境変数なし）: ad-hoc 署名
+#   クラッシュはしないが、Gatekeeper に「開発元を検証できない」と言われる。
+#   利用者は初回だけ右クリック →「開く」が必要。
+#
+# ■ 正式配布（Developer ID 署名＋公証）
+#   一度だけの準備:
+#     1. 証明書を作る（Xcode ▸ Settings ▸ Accounts ▸ Manage Certificates ▸ + ▸
+#        Developer ID Application）。`security find-identity -v -p codesigning` で確認。
+#     2. 公証の資格情報を Keychain に保存する:
+#        xcrun notarytool store-credentials mreditor \
+#          --apple-id <AppleID> --team-id <TEAMID> --password <App用パスワード>
+#        （App 用パスワードは appleid.apple.com で発行する。Apple ID の本パスワードではない）
+#   ビルド:
+#     SIGN_IDENTITY="Developer ID Application: NAME (TEAMID)" \
+#     NOTARY_PROFILE=mreditor \
+#     sh scripts/make_dmg.sh
+#
+#   公証は Apple のサーバへ送って審査を待つ（数分）。成功したら staple で
+#   チケットを dmg に焼き付ける。これでオフラインでも Gatekeeper を通る。
 set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -25,6 +37,21 @@ swift build -c release --arch arm64 --arch x86_64
 echo ">> .app バンドル作成（署名込み）"
 BINDIR="$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)"
 APP_NAME="$APP_NAME" BINDIR="$BINDIR" sh "$ROOT/scripts/make_app.sh" release >/dev/null
+
+# .app 自体を先に公証して staple しておく。
+# dmg だけに staple すると、Applications へドラッグした後の .app にチケットが無く、
+# オフラインの Mac では Gatekeeper が Apple に問い合わせられず検証に失敗しうる。
+# 公証は zip で提出する（.app はディレクトリなのでそのままでは送れない）。
+if [ -n "$SIGN_IDENTITY" ] && [ "$SIGN_IDENTITY" != "-" ] && [ -n "$NOTARY_PROFILE" ]; then
+    ZIP="$ROOT/.build/$APP_NAME-notarize.zip"
+    rm -f "$ZIP"
+    echo ">> .app を公証へ提出"
+    ditto -c -k --keepParent "$APP" "$ZIP"
+    xcrun notarytool submit "$ZIP" --keychain-profile "$NOTARY_PROFILE" --wait
+    rm -f "$ZIP"
+    echo ">> 公証チケットを .app に焼き付ける"
+    xcrun stapler staple "$APP"
+fi
 
 rm -f "$DMG"
 
@@ -47,6 +74,32 @@ else
     hdiutil create -volname "$APP_NAME $VERSION" -srcfolder "$STAGE" \
         -ov -format UDZO "$DMG" >/dev/null
     rm -rf "$STAGE"
+fi
+
+# ---------------------------------------------------------------------------
+# Developer ID 署名がある場合のみ: dmg にも署名し、公証して staple する。
+# .app は make_app.sh が既に署名済み。dmg 自体にも署名しないと公証を通らない。
+if [ -n "$SIGN_IDENTITY" ] && [ "$SIGN_IDENTITY" != "-" ]; then
+    echo ">> dmg に署名"
+    codesign --force --sign "$SIGN_IDENTITY" --timestamp "$DMG"
+
+    if [ -n "$NOTARY_PROFILE" ]; then
+        echo ">> 公証へ提出（Apple のサーバで審査。数分かかる）"
+        xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+
+        echo ">> 公証チケットを dmg に焼き付ける（staple）"
+        xcrun stapler staple "$DMG"
+
+        echo ">> 検証: Gatekeeper が受け入れるか"
+        # 「Notarized Developer ID」と出れば、利用者は右クリックすら不要になる。
+        spctl -a -vvv -t install "$DMG"
+        xcrun stapler validate "$DMG"
+        # .app にもチケットが焼かれていること（オフラインでも通るため）。
+        xcrun stapler validate "$APP"
+    else
+        echo ">> NOTARY_PROFILE が未設定のため公証はスキップ（署名のみ）"
+        echo "   公証しないと Gatekeeper は依然として警告する。"
+    fi
 fi
 
 echo "$DMG"

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -24,7 +24,7 @@ set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="${APP_NAME:-MrEditor}"
-VERSION="${VERSION:-0.8}"
+VERSION="${VERSION:-0.9}"
 APP="$ROOT/.build/$APP_NAME.app"
 DMG="$ROOT/.build/$APP_NAME-$VERSION.dmg"
 

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -132,14 +132,14 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v0.8 · MIT</span>
+      <span class="badge">macOS 13+ · v0.9 · MIT</span>
       <h1>86,420,337 lines.<br><span class='teal'>Open in 0.2 seconds.</span></h1>
       <p class="lede">That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds 44&nbsp;MB — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes.</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.8/MrEditor-0.8.dmg">↓ Download .dmg</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.9/MrEditor-0.9.dmg">↓ Download .dmg</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">View source</a>
       </div>
-      <p class="note">Apple Developer ID not obtained yet, so macOS cannot verify the developer. On first launch: right-click → Open. Universal (Apple Silicon &amp; Intel).</p>
+      <p class="note">Signed with an Apple Developer ID and notarized by Apple — just double-click it. Universal (Apple Silicon &amp; Intel).</p>
     </div>
     <div class="hero-ico" id="heroIco"></div>
   </header>

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -132,14 +132,14 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v0.8 · MIT</span>
+      <span class="badge">macOS 13+ · v0.9 · MIT</span>
       <h1>86,420,337 行。<br><span class='teal'>開くのに 0.2 秒。</span></h1>
       <p class="lede">10&nbsp;GB のログです。開いたまま一日使っても、実メモリは 44&nbsp;MB。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.8/MrEditor-0.8.dmg">↓ .dmg をダウンロード</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.9/MrEditor-0.9.dmg">↓ .dmg をダウンロード</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">ソースを見る</a>
       </div>
-      <p class="note">Apple Developer ID 未取得のため、macOS は開発元を検証できません。初回は右クリック →「開く」。Apple Silicon / Intel 両対応。</p>
+      <p class="note">Apple Developer ID で署名し、Apple の公証を通しています。ダブルクリックするだけで開きます。Apple Silicon / Intel 両対応。</p>
     </div>
     <div class="hero-ico" id="heroIco"></div>
   </header>

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -135,21 +135,21 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v0.8 · MIT</span>
+      <span class="badge">macOS 13+ · v0.9 · MIT</span>
       <h1 data-en="86,420,337 lines.<br><span class='teal'>Open in 0.2 seconds.</span>"
           data-ja="86,420,337 行。<br><span class='teal'>開くのに 0.2 秒。</span>"></h1>
       <p class="lede"
          data-en="That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds 44&nbsp;MB — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes."
          data-ja="10&nbsp;GB のログです。開いたまま一日使っても、実メモリは 44&nbsp;MB。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。"></p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.8/MrEditor-0.8.dmg"
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.9/MrEditor-0.9.dmg"
            data-en="↓ Download .dmg" data-ja="↓ .dmg をダウンロード"></a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener"
            data-en="View source" data-ja="ソースを見る"></a>
       </div>
       <p class="note"
-         data-en="Apple Developer ID not obtained yet, so macOS cannot verify the developer. On first launch: right-click → Open. Universal (Apple Silicon &amp; Intel)."
-         data-ja="Apple Developer ID 未取得のため、macOS は開発元を検証できません。初回は右クリック →「開く」。Apple Silicon / Intel 両対応。"></p>
+         data-en="Signed with an Apple Developer ID and notarized by Apple — just double-click it. Universal (Apple Silicon &amp; Intel)."
+         data-ja="Apple Developer ID で署名し、Apple の公証を通しています。ダブルクリックするだけで開きます。Apple Silicon / Intel 両対応。"></p>
     </div>
     <div class="hero-ico" id="heroIco"></div>
   </header>


### PR DESCRIPTION
## 1.0 の唯一のブロッカーが外れた
Apple Developer Program に登録し、Developer ID Application 証明書を取得。`.app` と dmg の両方を署名・公証・staple した。**右クリックも `xattr` も不要で、ダブルクリックするだけで開く。**

```
spctl -a -t install MrEditor-0.9.dmg
→ accepted / source=Notarized Developer ID
```

## なぜ v0.8 を差し替えず v0.9 にするのか
v0.8 は「ad-hoc 署名・初回だけ右クリックが必要」として公開済み。それを黙って別物に差し替えるのは **v0.7 と同じ轍**。番号を上げる。

## `.app` を先に公証して staple する
dmg だけを公証・staple すると、Applications へドラッグした後の `.app` にチケットが無く、**オフラインの Mac では Gatekeeper が Apple に問い合わせられず検証に失敗しうる**。よって `.app` を zip で提出して公証 → staple → それを包んだ dmg をもう一度公証 → staple、という二段構えにした。

## 踏んだ落とし穴
- **同名の証明書が System.keychain と login.keychain の両方にあり**、名前で指定すると `codesign` が `ambiguous` で拒否する。SHA-1 ハッシュで一意に指定する。
- 有効期限が **5 年のものと約 7 ヶ月のもの**があった。5 年の方を使う。
- `notarytool store-credentials` は**公証の資格情報**を保存するコマンドで、**署名の証明書とは別物**。

## ドキュメント
README / LP から「初回は右クリック →『開く』」「`xattr -dr com.apple.quarantine`」の手順を削除（日英）。v0.8 が「起動はするが初回だけ右クリックが必要」であることは、既に配った版の事実として注記に残した。

## 検証（quarantine 付きで、ダウンロードした人と同じ条件）
| 項目 | 結果 |
|---|---|
| dmg の Gatekeeper 判定 | accepted / **Notarized Developer ID** |
| 取り出した `.app` の公証チケット | staple 済み |
| `.app` の Gatekeeper 判定 | accepted / **Notarized Developer ID** |
| `codesign --verify --deep --strict` | 通過 |
| hardened runtime | `flags=0x10000(runtime)` |
| アーキテクチャ | `x86_64 arm64` |
| バージョン | 0.9 |

全 109 tests green。バージョン表記は scripts / AppInfo / LP バッジ / DL リンク / README 日英ですべて 0.9 に一致。ローカライズ日英とも 130 キー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)