### PR TITLE
core を再利用ライブラリ MrEditorCore として切り出す（Pro 版の土台）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//private/var/folders/_j/_j2_j2_j2_j2_j2_j2_j2_j2_0000gn/T/**)"
+    ]
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,29 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
+// MrEditor = 無料版アプリ（MIT・公開）。
+// MrEditorCore = UI 非依存の再利用エンジン（piece table / mmap 索引 / 検索 /
+//   エンコード判定・変換 / 構造化整形）。ここを library として切り出しておくことで、
+//   Pro 版（別リポ・クローズド）が **core を一方向依存で参照** できる。
+//   依存の向きは常に Pro → core / app → core。core は app / Pro を知らない。
 let package = Package(
     name: "MrEditor",
     defaultLocalization: "en",
     platforms: [
         .macOS(.v13)
     ],
+    products: [
+        // Pro 版リポジトリはこの package を依存に追加し、この product を import する。
+        .library(name: "MrEditorCore", targets: ["MrEditorCore"]),
+    ],
     targets: [
+        .target(
+            name: "MrEditorCore",
+            path: "Sources/MrEditorCore"
+        ),
         .executableTarget(
             name: "MrEditor",
+            dependencies: ["MrEditorCore"],
             path: "Sources/MrEditor",
             resources: [
                 .process("Resources")
@@ -17,7 +31,7 @@ let package = Package(
         ),
         .testTarget(
             name: "MrEditorTests",
-            dependencies: ["MrEditor"],
+            dependencies: ["MrEditor", "MrEditorCore"],
             path: "Tests/MrEditorTests"
         )
     ]

--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MrEditorCore
 
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var windowController: MainWindowController?

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MrEditorCore
 
 /// ファイルをドロップで受けるコンテナ（ドキュメント未選択時の空き領域用）。
 final class DropView: NSView {

--- a/Sources/MrEditor/UI/StructuredBanner.swift
+++ b/Sources/MrEditor/UI/StructuredBanner.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MrEditorCore
 
 /// 構造化表示（CSV/TSV/NDJSON の桁揃え）が有効な間だけ本文左上に浮かべる帯。
 ///

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MrEditorCore
 
 /// 表示状態をステータスバーへ伝えるための情報。
 struct ViewerState {

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MrEditorCore
 
 /// 小ファイル用の編集ペイン。ファイル全体をメモリに読み込み、`NSTextView` で
 /// 編集する（アンドゥ・IME・選択・標準コピーは AppKit 標準機能に委ねる）。

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MrEditorCore
 
 /// 巨大ファイルの表示・編集・保存・検索・追従をすべて担う自前ビューア（1.0 の大ファイル既定）。
 ///

--- a/Sources/MrEditorCore/EncodingDetector.swift
+++ b/Sources/MrEditorCore/EncodingDetector.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// 判定された文字コード。
-enum DetectedEncoding {
+public enum DetectedEncoding {
     case utf8
     case utf16LE
     case utf16BE
     case shiftJIS
     case eucJP
 
-    var stringEncoding: String.Encoding {
+    public var stringEncoding: String.Encoding {
         switch self {
         case .utf8: return .utf8
         case .utf16LE: return .utf16LittleEndian
@@ -18,7 +18,7 @@ enum DetectedEncoding {
         }
     }
 
-    var displayName: String {
+    public var displayName: String {
         switch self {
         case .utf8: return "UTF-8"
         case .utf16LE: return "UTF-16 LE"
@@ -29,16 +29,16 @@ enum DetectedEncoding {
     }
 
     /// エンコード指定メニューに並べる候補（日本語圏で使う順）。
-    static let selectable: [DetectedEncoding] = [.utf8, .shiftJIS, .eucJP, .utf16LE, .utf16BE]
+    public static let selectable: [DetectedEncoding] = [.utf8, .shiftJIS, .eucJP, .utf16LE, .utf16BE]
 }
 
 /// ファイルの改行コード。挿入・貼り付けする改行はこれに揃える（読み込み時に検出）。
-enum LineEnding {
+public enum LineEnding {
     case lf      // \n（Unix / macOS）
     case crlf    // \r\n（Windows）
     case cr      // \r（旧 Mac）
 
-    var bytes: [UInt8] {
+    public var bytes: [UInt8] {
         switch self {
         case .lf: return [0x0A]
         case .crlf: return [0x0D, 0x0A]
@@ -46,7 +46,7 @@ enum LineEnding {
         }
     }
 
-    var string: String {
+    public var string: String {
         switch self {
         case .lf: return "\n"
         case .crlf: return "\r\n"
@@ -55,7 +55,7 @@ enum LineEnding {
     }
 
     /// 挿入テキスト内の改行（\r\n / \r / \n の混在）を、この EOL に揃える。改行が無ければそのまま。
-    func normalize(_ text: String) -> String {
+    public func normalize(_ text: String) -> String {
         guard text.contains("\r") || text.contains("\n") else { return text }
         let lf = text.replacingOccurrences(of: "\r\n", with: "\n")
                      .replacingOccurrences(of: "\r", with: "\n")
@@ -63,7 +63,7 @@ enum LineEnding {
     }
 
     /// 先頭バイト列から最初の改行を見つけて判定する（改行が無ければ LF 既定）。
-    static func detect(_ data: Data, encoding: DetectedEncoding) -> LineEnding {
+    public static func detect(_ data: Data, encoding: DetectedEncoding) -> LineEnding {
         // UTF-16 は CR/LF が 2 バイト単位で並ぶため、デコードして文字単位で判定する。
         if encoding == .utf16LE || encoding == .utf16BE,
            let s = String(data: data, encoding: encoding.stringEncoding) {
@@ -94,11 +94,11 @@ enum LineEnding {
 /// エンコード変換保存の心臓部。`source` のバイト列を**行境界**（最後の 0x0A まで）で切りながら
 /// `target` へ変換する。0x0A は UTF-8 / Shift-JIS / EUC-JP のマルチバイト内には現れないため、
 /// そこで区切れば文字を割らない安全な境界になる（原本を任意サイズのスライスで流し込める）。
-enum EncodingTranscoder {
+public enum EncodingTranscoder {
     /// `feed` に渡した消費関数へ原本スライスを順に流し、変換済みバイトを `emit` に渡す。
     /// 目的エンコードで表現できない文字を代替に置換したら（lossy）true を返す。
     @discardableResult
-    static func stream(from source: DetectedEncoding, to target: DetectedEncoding,
+    public static func stream(from source: DetectedEncoding, to target: DetectedEncoding,
                        feed: ((ArraySlice<UInt8>) throws -> Void) throws -> Void,
                        emit: @escaping (Data) throws -> Void) throws -> Bool {
         var carry = [UInt8]()
@@ -130,8 +130,8 @@ enum EncodingTranscoder {
 ///
 /// 判定順: BOM → UTF-8 厳密 → Shift-JIS / EUC-JP スコアリング。
 /// 不能なら UTF-8 にフォールバック（化けても落ちない方針）。
-enum EncodingDetector {
-    static func detect(_ data: Data) -> DetectedEncoding {
+public enum EncodingDetector {
+    public static func detect(_ data: Data) -> DetectedEncoding {
         let bytes = [UInt8](data)
         let n = bytes.count
 

--- a/Sources/MrEditorCore/FileBuffer.swift
+++ b/Sources/MrEditorCore/FileBuffer.swift
@@ -7,17 +7,17 @@ import Foundation
 ///
 /// tail -f 用に、ファイルが伸びたら再マップする（`remapIfGrownTry`）。
 /// 読み取り（withBytes/data）と再マップ（munmap+mmap）を rwlock で排他する。
-final class FileBuffer {
+public final class FileBuffer {
     let url: URL
     /// ファイルの総バイト数（再マップで増えうる）。
-    private(set) var count: Int
+    public private(set) var count: Int
 
     private let fd: Int32
     private var base: UnsafeRawPointer
     private var mapped: Bool
     private var lock = pthread_rwlock_t()
 
-    init?(url: URL) {
+    public init?(url: URL) {
         self.url = url
         let fd = open(url.path, O_RDONLY)
         guard fd >= 0 else { return nil }
@@ -58,7 +58,7 @@ final class FileBuffer {
 
     /// 指定範囲を生バッファとして渡す（コピーなし）。範囲はファイル内にクランプされる。
     @inline(__always)
-    func withBytes<R>(in range: Range<Int>, _ body: (UnsafeRawBufferPointer) -> R) -> R {
+    public func withBytes<R>(in range: Range<Int>, _ body: (UnsafeRawBufferPointer) -> R) -> R {
         pthread_rwlock_rdlock(&lock)
         defer { pthread_rwlock_unlock(&lock) }
         let lo = max(0, range.lowerBound)
@@ -69,7 +69,7 @@ final class FileBuffer {
     }
 
     /// 指定範囲を Data としてコピーする（小さなスライス向け）。
-    func data(in range: Range<Int>) -> Data {
+    public func data(in range: Range<Int>) -> Data {
         pthread_rwlock_rdlock(&lock)
         defer { pthread_rwlock_unlock(&lock) }
         let lo = max(0, range.lowerBound)
@@ -83,7 +83,7 @@ final class FileBuffer {
     /// 読み取り中（rdlock 保持）のときは再マップを諦めて nil を返す（次回に回す）。
     /// これで読み取りスレッドのポインタを munmap してしまう事故を防ぐ。
     /// 縮小・ローテーション（inode 入替）は対象外（成長のみ）。
-    func remapIfGrownTry() -> Int? {
+    public func remapIfGrownTry() -> Int? {
         var st = stat()
         guard fstat(fd, &st) == 0 else { return nil }
         let newSize = Int(st.st_size)

--- a/Sources/MrEditorCore/LineIndex.swift
+++ b/Sources/MrEditorCore/LineIndex.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// 行分割はバイト 0x0A (`\n`) のみで行う。UTF-8 / Shift-JIS / EUC-JP の
 /// いずれもマルチバイト文字の途中に 0x0A は現れないため安全。
-final class LineIndex: OriginalLineLocator {
+public final class LineIndex: OriginalLineLocator {
     let stride: Int
 
     /// 疎索引サンプル。`sampleLines[j]` 行目の先頭が `sampleOffsets[j]` バイト。
@@ -24,7 +24,7 @@ final class LineIndex: OriginalLineLocator {
     /// 先頭サンプルから求めた推定行数（索引完了前の表示用）。
     private(set) var estimatedLineCount: Int = 1
     /// 全索引が完了したか。
-    private(set) var isComplete: Bool = false
+    public private(set) var isComplete: Bool = false
 
     /// 走査済みのバイト数（増分拡張＝tail -f の起点）。
     private var scannedBytes = 0
@@ -35,23 +35,23 @@ final class LineIndex: OriginalLineLocator {
     /// 並列走査の 1 チャンクのバイト幅。テストでは小さくして多チャンク・境界跨ぎを踏ませる。
     private let chunkSize: Int
 
-    init(buffer: FileBuffer, stride: Int = 2000, chunkSize: Int = 16 << 20) {
+    public init(buffer: FileBuffer, stride: Int = 2000, chunkSize: Int = 16 << 20) {
         self.buffer = buffer
         self.stride = stride
         self.chunkSize = max(1, chunkSize)
     }
 
     /// 表示に使う現在の最良行数（確定 > 推定）。
-    var displayLineCount: Int {
+    public var displayLineCount: Int {
         isComplete ? exactLineCount : estimatedLineCount
     }
 
     /// 原本に含まれる改行（0x0A）の数（全索引完了後に確定）。
     /// PieceTable 初期化時の原本全スキャンを省くために渡す（`isComplete` 後のみ有効）。
-    var originalNewlines: Int { nlCount }
+    public var originalNewlines: Int { nlCount }
 
     /// 先頭サンプルから行数を推定する（即時表示用、同期・高速）。
-    func estimatePrefix() {
+    public func estimatePrefix() {
         let sample = min(buffer.count, 1 << 20) // 先頭 1MB
         guard sample > 0 else {
             estimatedLineCount = 0
@@ -84,7 +84,7 @@ final class LineIndex: OriginalLineLocator {
 
     /// 全体を複数コアで並列走査して疎索引を構築する（バックグラウンド）。
     /// progress / completion はメインスレッドで呼ばれる。
-    func buildInBackground(progress: @escaping (Double) -> Void,
+    public func buildInBackground(progress: @escaping (Double) -> Void,
                            completion: @escaping () -> Void) {
         let total = buffer.count
         let stride = self.stride
@@ -174,7 +174,7 @@ final class LineIndex: OriginalLineLocator {
 
     /// ファイルが伸びたぶんを索引に継ぎ足す（tail -f）。メインスレッドで呼ぶ。
     /// `newCount` は新しいファイルサイズ。`buffer` は既に再マップ済みであること。
-    func extend(toByte newCount: Int) {
+    public func extend(toByte newCount: Int) {
         guard isComplete, newCount > scannedBytes else { return }
         let from = scannedBytes
         let stride = self.stride
@@ -227,7 +227,7 @@ final class LineIndex: OriginalLineLocator {
 
     /// 原本 `[0, x)` に含まれる改行（0x0A）の数＝バイト `x` の直前までの行数。
     /// 最寄りの疎索引点から `x` までを memchr で数えるため O(stride)。`isComplete` 後のみ有効。
-    func newlineCount(upTo x: Int) -> Int {
+    public func newlineCount(upTo x: Int) -> Int {
         let target = min(max(0, x), buffer.count)
         guard target > 0 else { return 0 }
         let j = sampleIndex(forByte: target)
@@ -249,7 +249,7 @@ final class LineIndex: OriginalLineLocator {
     }
 
     /// 行 `line`（0始まり）の先頭バイトオフセット。最寄りの疎索引点から前方スキャンで求める（O(stride)）。
-    func byteOffset(ofLineStart line: Int) -> Int {
+    public func byteOffset(ofLineStart line: Int) -> Int {
         guard line > 0 else { return 0 }
         let total = buffer.count
         let j = sampleIndex(forLine: line)
@@ -271,7 +271,7 @@ final class LineIndex: OriginalLineLocator {
     }
 
     /// 原本で `m` 番目（0始まり）の 0x0A のバイトオフセット。行 `m+1` はその直後から始まる。
-    func newlineOffset(ordinal m: Int) -> Int {
+    public func newlineOffset(ordinal m: Int) -> Int {
         byteOffset(ofLineStart: m + 1) - 1
     }
 
@@ -279,7 +279,7 @@ final class LineIndex: OriginalLineLocator {
 
     /// 行 [start, start+count) のバイト範囲を 1 回の前方スキャンで求める。
     /// 索引未構築の領域（最寄り索引点から遠すぎる）は空配列で返す。
-    func lineRanges(from start: Int, count: Int) -> [Range<Int>] {
+    public func lineRanges(from start: Int, count: Int) -> [Range<Int>] {
         guard count > 0, start >= 0 else { return [] }
         let j = sampleIndex(forLine: start)
         let startLine = sampleLines[j]

--- a/Sources/MrEditorCore/PieceTable.swift
+++ b/Sources/MrEditorCore/PieceTable.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// piece table のバイト供給源（原本ファイル or テスト用インメモリ）。
 /// 全文をメモリに載せないため、必要な範囲だけ `read` で取り出す。
-protocol PieceSource {
+public protocol PieceSource {
     var count: Int { get }
     /// 範囲 `r`（ファイル内にクランプ）を生バイトで返す。
     func read(_ r: Range<Int>) -> [UInt8]
@@ -11,7 +11,7 @@ protocol PieceSource {
 /// 原本（不変・巨大）の行↔バイト変換を O(stride) で解くための近道。
 /// `LineIndex` の疎索引が実体。無い場合 `PieceTable` は原本を線形スキャンする
 /// （テスト用の小さな `InMemorySource` はこれで十分）。
-protocol OriginalLineLocator: AnyObject {
+public protocol OriginalLineLocator: AnyObject {
     /// 原本 `[0, x)` に含まれる 0x0A の数。
     func newlineCount(upTo x: Int) -> Int
     /// 原本で `m` 番目（0始まり）の 0x0A のバイトオフセット。
@@ -19,11 +19,11 @@ protocol OriginalLineLocator: AnyObject {
 }
 
 /// インメモリのバイト供給源（テスト・小バッファ用）。
-struct InMemorySource: PieceSource {
+public struct InMemorySource: PieceSource {
     private let bytes: [UInt8]
-    init(_ bytes: [UInt8]) { self.bytes = bytes }
-    var count: Int { bytes.count }
-    func read(_ r: Range<Int>) -> [UInt8] {
+    public init(_ bytes: [UInt8]) { self.bytes = bytes }
+    public var count: Int { bytes.count }
+    public func read(_ r: Range<Int>) -> [UInt8] {
         let lo = max(0, r.lowerBound), hi = min(bytes.count, r.upperBound)
         guard lo < hi else { return [] }
         return Array(bytes[lo..<hi])
@@ -32,11 +32,11 @@ struct InMemorySource: PieceSource {
 
 /// 既存の mmap 済み `FileBuffer` を piece table のバイト供給源にするラッパ（B1で使用）。
 /// 全文をメモリへ載せず、要求された範囲だけ `FileBuffer` 経由で読む。
-struct FileBufferSource: PieceSource {
+public struct FileBufferSource: PieceSource {
     private let buffer: FileBuffer
-    init(_ buffer: FileBuffer) { self.buffer = buffer }
-    var count: Int { buffer.count }
-    func read(_ r: Range<Int>) -> [UInt8] {
+    public init(_ buffer: FileBuffer) { self.buffer = buffer }
+    public var count: Int { buffer.count }
+    public func read(_ r: Range<Int>) -> [UInt8] {
         let lo = max(0, r.lowerBound), hi = min(buffer.count, r.upperBound)
         guard lo < hi else { return [] }
         return [UInt8](buffer.data(in: lo..<hi))
@@ -67,7 +67,7 @@ private struct SplitMix64: RandomNumberGenerator {
 /// 行分割はバイト 0x0A のみ（UTF-8 / Shift-JIS / EUC-JP のいずれも 0x0A は
 /// マルチバイト文字の途中に現れない）。行数の数え方は `LineIndex.displayLineCount`
 /// と整合（空文書=0、末尾に改行が無ければその行も1行と数える）。
-final class PieceTable {
+public final class PieceTable {
     private enum Source { case original, add }
 
     private struct Piece {
@@ -104,7 +104,7 @@ final class PieceTable {
 
     /// 原本から初期化する。`originalNewlines` を渡せば初回スキャンを省略できる（B1で利用）。
     /// `locator`（＝`LineIndex`）を渡すと原本の行↔バイト変換が O(stride) になる（巨大原本で必須）。
-    init(original: PieceSource, originalNewlines: Int? = nil, locator: OriginalLineLocator? = nil) {
+    public init(original: PieceSource, originalNewlines: Int? = nil, locator: OriginalLineLocator? = nil) {
         self.original = original
         self.originalLocator = locator
         if original.count > 0 {
@@ -115,16 +115,16 @@ final class PieceTable {
     }
 
     /// テスト用：バイト列から直接作る。
-    convenience init(bytes: [UInt8]) {
+    public convenience init(bytes: [UInt8]) {
         self.init(original: InMemorySource(bytes))
     }
 
     // MARK: - 集計
 
-    var byteCount: Int { root?.subtreeBytes ?? 0 }
+    public var byteCount: Int { root?.subtreeBytes ?? 0 }
 
     /// 論理行数（空=0、末尾に改行が無ければ最終行も数える）。
-    var lineCount: Int {
+    public var lineCount: Int {
         let n = byteCount
         guard n > 0 else { return 0 }
         let nl = root?.subtreeNewlines ?? 0
@@ -143,7 +143,7 @@ final class PieceTable {
     // MARK: - 編集
 
     /// `offset` バイト目に `bytes` を挿入する。
-    func insert(_ bytes: [UInt8], at offset: Int) {
+    public func insert(_ bytes: [UInt8], at offset: Int) {
         guard !bytes.isEmpty else { return }
         let clamped = min(max(0, offset), byteCount)
         let addStart = add.count
@@ -156,7 +156,7 @@ final class PieceTable {
     }
 
     /// `range` のバイトを削除する。
-    func delete(_ range: Range<Int>) {
+    public func delete(_ range: Range<Int>) {
         let lo = max(0, range.lowerBound), hi = min(byteCount, range.upperBound)
         guard lo < hi else { return }
         let (l, rest) = split(root, at: lo)
@@ -167,7 +167,7 @@ final class PieceTable {
     // MARK: - 読み出し
 
     /// `range` のバイトを取り出す。
-    func bytes(in range: Range<Int>) -> [UInt8] {
+    public func bytes(in range: Range<Int>) -> [UInt8] {
         let lo = max(0, range.lowerBound), hi = min(byteCount, range.upperBound)
         guard lo < hi else { return [] }
         var out: [UInt8] = []
@@ -178,7 +178,7 @@ final class PieceTable {
 
     /// 文書全体を先頭から順に、`chunk` バイト単位で `sink` へ渡す（保存のストリーム書き出し用）。
     /// 全文をメモリに載せず、各ピースを供給源から分割読みする。木の高さは O(log n) で深くない。
-    func writeAll(chunk: Int = 1 << 20, _ sink: (ArraySlice<UInt8>) throws -> Void) rethrows {
+    public func writeAll(chunk: Int = 1 << 20, _ sink: (ArraySlice<UInt8>) throws -> Void) rethrows {
         try writeNode(root, chunk: chunk, sink)
     }
 
@@ -219,7 +219,7 @@ final class PieceTable {
 
     /// 行 `line`（0始まり）の内容バイト範囲（終端の 0x0A は含めない）。
     /// CRLF の CR 除去は呼び出し側（描画）で行う。
-    func byteRange(ofLine line: Int) -> Range<Int> {
+    public func byteRange(ofLine line: Int) -> Range<Int> {
         let total = lineCount
         guard total > 0, line >= 0, line < total else { return 0..<0 }
         let nl = root?.subtreeNewlines ?? 0
@@ -229,7 +229,7 @@ final class PieceTable {
     }
 
     /// 行 `line`（0始まり）の先頭バイトオフセット。
-    func byteOffset(ofLineStart line: Int) -> Int {
+    public func byteOffset(ofLineStart line: Int) -> Int {
         let total = lineCount
         let clamped = min(max(0, line), total)
         if clamped == 0 { return 0 }
@@ -239,7 +239,7 @@ final class PieceTable {
     }
 
     /// バイトオフセット `off` を含む行（0始まり）＝ `[0, off)` の改行数。
-    func line(ofByteOffset off: Int) -> Int {
+    public func line(ofByteOffset off: Int) -> Int {
         let target = min(max(0, off), byteCount)
         var node = root
         var count = 0

--- a/Sources/MrEditorCore/SearchEngine.swift
+++ b/Sources/MrEditorCore/SearchEngine.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// 検索モード。
-enum SearchMode {
+public enum SearchMode {
     case terms([String])               // リテラル AND（全語を含む行・語ごとに大小無視）
     case regex(NSRegularExpression)    // 正規表現（行ごとに照合）
 }
@@ -11,12 +11,16 @@ enum SearchMode {
 /// 行単位（0x0A 区切り）に走査する。UTF-8 はクエリのバイト列をそのまま探索（高速）、
 /// 非 UTF-8（Shift-JIS/EUC）は行をデコードして文字列照合（正確）。
 /// 全文をメモリに乗せない（mmap をそのまま舐める）。一致行は上限まで保持する。
-final class SearchEngine {
-    struct Result {
-        var lines: [Int] = []      // 一致した行番号（昇順・上限まで）
-        var lineCount = 0          // 一致行の総数（上限超過も計上）
-        var isComplete = false
-        var capped = false
+public final class SearchEngine {
+    public struct Result {
+        public var lines: [Int] = []      // 一致した行番号（昇順・上限まで）
+        public var lineCount = 0          // 一致行の総数（上限超過も計上）
+        public var isComplete = false
+        public var capped = false
+        public init(lines: [Int] = [], lineCount: Int = 0, isComplete: Bool = false, capped: Bool = false) {
+            self.lines = lines; self.lineCount = lineCount
+            self.isComplete = isComplete; self.capped = capped
+        }
     }
 
     private let buffer: FileBuffer
@@ -28,17 +32,17 @@ final class SearchEngine {
     /// （aligned Int の読みは arm64 で原子的。遅延キャンセルの良性レース。）
     private var generation = 0
 
-    init(buffer: FileBuffer, encoding: DetectedEncoding) {
+    public init(buffer: FileBuffer, encoding: DetectedEncoding) {
         self.buffer = buffer
         self.encoding = encoding
     }
 
     /// 進行中の検索を打ち切る。
-    func cancel() { generation += 1 }
+    public func cancel() { generation += 1 }
 
     /// 指定モードで全体を走査する。progress / completion はメインスレッドで呼ぶ。
     /// `caseSensitive` は terms モードに効く（regex は compile 時に決まる）。
-    func search(_ mode: SearchMode, caseSensitive: Bool = false,
+    public func search(_ mode: SearchMode, caseSensitive: Bool = false,
                 progress: @escaping (Result, Double) -> Void,
                 completion: @escaping (Result) -> Void) {
         generation += 1

--- a/Sources/MrEditorCore/TabularFormatter.swift
+++ b/Sources/MrEditorCore/TabularFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// 構造化表示のモード。CSV/TSV は区切り整形、NDJSON はキー投影。
-enum StructuredMode: String, CaseIterable {
+public enum StructuredMode: String, CaseIterable {
     case csv, tsv, ndjson
 }
 
@@ -11,10 +11,10 @@ enum StructuredMode: String, CaseIterable {
 /// セルに分解し、各セルを列幅へ表示幅ベースでパディング／省略して ` │ ` で連結する。
 /// バイトオフセットに依存しないため、大ファイル（`PieceTableViewer`）と小ファイル
 /// （`EditableViewer`）の両経路から同じ呼び出しで使える。
-struct TabularFormatter {
-    struct Column { let key: String; let width: Int }   // width は表示セル単位
+public struct TabularFormatter {
+    public struct Column { public let key: String; public let width: Int; public init(key: String, width: Int) { self.key = key; self.width = width } }   // width は表示セル単位
 
-    let mode: StructuredMode
+    public let mode: StructuredMode
     let columns: [Column]
     /// セルの区切り。
     static let separator = " │ "
@@ -24,7 +24,7 @@ struct TabularFormatter {
     // MARK: - 構築
 
     /// サンプル行（生文字列・先頭〜1000 行想定）から列（名前＋固定幅）を確定する。
-    static func build(mode: StructuredMode, sampleLines: [String], widthCap: Int = 40) -> TabularFormatter {
+    public static func build(mode: StructuredMode, sampleLines: [String], widthCap: Int = 40) -> TabularFormatter {
         let rows = sampleLines.filter { !$0.isEmpty }
         switch mode {
         case .csv, .tsv:
@@ -60,7 +60,7 @@ struct TabularFormatter {
     // MARK: - 整形
 
     /// 1 行 → 列に桁揃えした表示文字列。
-    func format(_ rawLine: String) -> String {
+    public func format(_ rawLine: String) -> String {
         let cells = self.cells(of: rawLine)
         var parts: [String] = []
         parts.reserveCapacity(columns.count)

--- a/Tests/MrEditorTests/BigFileSaveTests.swift
+++ b/Tests/MrEditorTests/BigFileSaveTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// 10GB 実ファイルでのストリーム保存を検証する（生命線）。
 /// 普段は skip。`MREDITOR_BIG_SAVE_TEST=1` を立てたときだけ走る（別ボリューム・時間がかかるため）。

--- a/Tests/MrEditorTests/DisplaySettingsTests.swift
+++ b/Tests/MrEditorTests/DisplaySettingsTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// 表示設定（タブ幅・行間・現在行ハイライト・カーソル形状）の永続化・通知と、
 /// それらを反映する `EditorStyle` の導出を検証する。

--- a/Tests/MrEditorTests/EditableViewerTests.swift
+++ b/Tests/MrEditorTests/EditableViewerTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// 小ファイル編集ペイン（NSTextView バック）の文字コード指定・EOL 追従を検証する。
 final class EditableViewerTests: XCTestCase {

--- a/Tests/MrEditorTests/EditorFontTests.swift
+++ b/Tests/MrEditorTests/EditorFontTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// `EditorFont` の種別・サイズの永続化と、変更通知・等幅列挙を検証する。
 /// UserDefaults.standard を触るため、各テストで元の値へ復元する。

--- a/Tests/MrEditorTests/EditorThemeTests.swift
+++ b/Tests/MrEditorTests/EditorThemeTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// `EditorTheme` のプリセット解決・カスタム色の永続化・変更通知を検証する。
 /// UserDefaults.standard を触るため、各テストで元の値へ復元する。

--- a/Tests/MrEditorTests/EncodingTranscoderTests.swift
+++ b/Tests/MrEditorTests/EncodingTranscoderTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// エンコード変換保存の心臓部（行境界ストリーム変換）を検証する。
 /// 原本を極端なスライス（1 バイトずつ＝マルチバイト分断）で流しても文字を割らないことが要点。

--- a/Tests/MrEditorTests/LineIndexTests.swift
+++ b/Tests/MrEditorTests/LineIndexTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// `LineIndex` の並列構築が、素朴な参照計算と完全一致することを検証する。
 /// チャンク幅を極小にして、多チャンク＆チャンク境界が行の途中に落ちる経路を必ず踏ませる。

--- a/Tests/MrEditorTests/PieceTableTests.swift
+++ b/Tests/MrEditorTests/PieceTableTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// テスト用の原本ロケータ（`LineIndex` の疎索引の代わりに、原本バイトを線形走査する単純実装）。
 /// `PieceTable` のロケータ経路を fuzz で検証するために使う。

--- a/Tests/MrEditorTests/PieceTableViewerEditTests.swift
+++ b/Tests/MrEditorTests/PieceTableViewerEditTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// B2b（テキスト変異＋Undo/Redo＋Cut/Paste）を document 単位でヘッドレス検証する。
 /// GUI を立てず、`PieceTableViewer` のテスト用シーム経由で編集パイプラインを駆動する。

--- a/Tests/MrEditorTests/SessionRestoreTests.swift
+++ b/Tests/MrEditorTests/SessionRestoreTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import AppKit
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// セッション復元（前回開いていた一覧＝サイドバーの復元）の中核ロジックを検証する。
 /// - `SessionState.make`: viewers → 保存データへの組み立て（空の新規スキップ・アクティブ位置付け替え）。

--- a/Tests/MrEditorTests/TabularFormatterTests.swift
+++ b/Tests/MrEditorTests/TabularFormatterTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// `TabularFormatter` の分割・キー投影・表示幅パディング・省略・列幅確定を検証する。
 final class TabularFormatterTests: XCTestCase {

--- a/Tests/MrEditorTests/UpdateCheckerTests.swift
+++ b/Tests/MrEditorTests/UpdateCheckerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import MrEditor
+@testable import MrEditorCore
 
 /// 更新チェックの中核（バージョン比較・GitHub JSON の解析）を検証する。
 /// ネットワークには触れない。


### PR DESCRIPTION
## 目的
Pro 版（MrkEditor・別リポ・クローズド）が **core を一方向依存で参照** できるよう、UI 非依存のエンジンを独立ターゲットにした。依存の向きは常に **app → core / Pro → core**。core は app / Pro を知らない。オープンコア方針の土台。

## 構成
```
Sources/MrEditorCore/   ← 新: 再利用エンジン（Foundation のみ・UI 非依存）
  PieceTable / LineIndex / SearchEngine / FileBuffer /
  EncodingDetector / TabularFormatter
  (+ DetectedEncoding / LineEnding / StructuredMode / SearchMode / EncodingTranscoder)
Sources/MrEditor/       ← 無料版アプリ（AppKit）。MrEditorCore に依存
```
`Package.swift` に `.library(name: "MrEditorCore")` を product として公開。Pro リポジトリはこの package を依存に追加して `import MrEditorCore` する。

## public 化はコンパイラ駆動
モジュールを分けると app が使う型・メンバーに `public` が要る。手で予測せず、**ビルドエラーが挙げた分だけ**を public にした（private ヘルパーは private のまま）。`SearchEngine.Result` は明示 init を足すと暗黙メンバーワイズ init が消えるため、全フィールドを既定値つきで受ける public init を用意。

## テスト
core の内部ヘルパー（`splitDelimited` / `displayWidth` / `pad` / `exactLineCount` 等）を叩くテストがあるため、テストは `@testable import MrEditorCore` にして内部へアクセスする（public 面を汚さない）。

## 検証
- core は **Foundation だけ**を import し、app を参照しない（`grep` で確認）
- **core ライブラリ単体でビルド可能**（`swift build --target MrEditorCore`）
- 振る舞いは不変。**全 109 tests green**（純粋な構造の切り出し）

## この後
Pro 版の準備の次の一手は、ユーザーと相談: ブランド雛形（MrkEditor）/ ライセンス・課金 / SSH リモート閲覧の試作。まず無料版 1.0 の告知が先、という順序も含めて。

🤖 Generated with [Claude Code](https://claude.com/claude-code)