### PR TITLE
リリース 1.0: 巨大ファイルを開いて編集できる Mac エディタとして完成

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,6 +11,13 @@
 > はじめは高速な**読み取り専用**ビューアでした（全文検索・フィルタ表示 / live grep・`tail -f`）。
 > **v0.4 で名前どおりに** ―― その場で編集して保存できます。
 
+![10GB・86,420,337 行のログを開いた画面](docs/img/10gb-dark.png)
+
+<p align="center">
+  <img src="docs/img/structured-dark.png" width="49%" alt="CSV を等幅カラムに桁揃え（構造化表示）">
+  <img src="docs/img/search-10gb-dark.png" width="49%" alt="10GB のログを全文検索（459 万件ヒット）">
+</p>
+
 ## なぜ作るのか
 
 macOS でテキストを表示する定番は `NSTextView` ですが、内部の `NSTextStorage` に
@@ -24,7 +31,7 @@ macOS でテキストを表示する定番は `NSTextView` ですが、内部の
 
 設計の詳細は [docs/ARCHITECTURE_v0.1.md](docs/ARCHITECTURE_v0.1.md) を参照してください。
 
-## 機能（v0.9）
+## 機能（1.0）
 
 **表示**
 - 任意サイズの巨大テキストを開ける（10GB で検証済み）。表示開始はほぼ一瞬。
@@ -107,7 +114,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-配布用ディスクイメージ（`.build/MrEditor-0.9.dmg`）の作成:
+配布用ディスクイメージ（`.build/MrEditor-1.0.dmg`）の作成:
 
 ```sh
 sh scripts/make_dmg.sh
@@ -136,7 +143,8 @@ sh scripts/make_dmg.sh
 - **v0.6 — 構造化表示: CSV/TSV カラム整形・NDJSON フィールド投影（読み取り専用・サイズ不問）** ✅
 - **v0.7 — セッション復元（未保存の新規も本文ごと）・About パネル修正** ✅
 - **v0.8 — Finder 統合・印刷/PDF 出力・アップデート確認・新アイコン・universal ビルド。および配布物の重大な修正（下記）** ✅
-- **v0.9 — Apple Developer ID で署名し、公証（notarization）を通した。右クリック不要でダブルクリックで開ける** ✅（このリリース）
+- **v0.9 — Apple Developer ID で署名し、公証（notarization）を通した。右クリック不要でダブルクリックで開ける** ✅
+- **1.0 — 巨大ファイルを開いて編集できる Mac エディタとして完成。署名・公証済みで、ダブルクリックで開く** ✅（このリリース）
 - **以降** — シンタックス/ログのハイライト、その他の分析ツール
 
 > **⚠️ v0.7 以前の dmg は、ダウンロードした Mac で起動しません。**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ you can also **edit and save** — at any size, with atomic writes.
 > It started life as a fast **read-only** viewer (full-file search, filtered view / live grep,
 > `tail -f`). **v0.4 makes the name literal**: it edits and saves too.
 
+![A 10 GB, 86,420,337-line log open in MrEditor](docs/img/10gb-dark.png)
+
+<p align="center">
+  <img src="docs/img/structured-dark.png" width="49%" alt="CSV aligned into monospaced columns (structured view)">
+  <img src="docs/img/search-10gb-dark.png" width="49%" alt="Full-file search across a 10 GB log (4.59 M hits)">
+</p>
+
 ## Why
 
 The usual answer on macOS is `NSTextView`, but it keeps the whole document in
@@ -25,7 +32,7 @@ approach (klogg / glogg / lnav):
 
 See [docs/ARCHITECTURE_v0.1.md](docs/ARCHITECTURE_v0.1.md) for the full design.
 
-## Features (v0.9)
+## Features (1.0)
 
 **Viewing**
 - Opens arbitrarily large text files (validated at 10 GB) with near-instant first paint.
@@ -109,7 +116,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-Build a distributable disk image (`.build/MrEditor-0.9.dmg`):
+Build a distributable disk image (`.build/MrEditor-1.0.dmg`):
 
 ```sh
 sh scripts/make_dmg.sh
@@ -137,7 +144,8 @@ resident app memory. The number that matters (`Physical footprint`) stays at 44 
 - **v0.6 — structured view: CSV/TSV column alignment & NDJSON field projection (read-only, any size)** ✅
 - **v0.7 — session restore (unsaved drafts included), About panel fix** ✅
 - **v0.8 — Finder integration, print/PDF export, update check, new icon, universal build, and a critical distribution fix (below)** ✅
-- **v0.9 — signed with an Apple Developer ID and notarized by Apple; opens with a plain double-click** ✅ (this release)
+- **v0.9 — signed with an Apple Developer ID and notarized by Apple; opens with a plain double-click** ✅
+- **1.0 — the milestone: open and edit 10 GB files on a Mac, signed and notarized, opens with a double-click** ✅ (this release)
 - **later** — syntax/log highlighting, and more analysis tooling
 
 > **⚠️ Builds up to v0.7 do not launch on a Mac that downloaded them.**

--- a/Sources/MrEditor/AppInfo.swift
+++ b/Sources/MrEditor/AppInfo.swift
@@ -15,7 +15,7 @@ enum AppInfo {
     static var version: String {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? fallbackVersion
     }
-    private static let fallbackVersion = "0.9"
+    private static let fallbackVersion = "1.0"
 
     /// ヘルプメニューから開くプロジェクトページ。
     static let helpURL = URL(string: "https://github.com/MR-TABATA/MrEditor")!

--- a/scripts/make_app.sh
+++ b/scripts/make_app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-debug}"
 APP_NAME="${APP_NAME:-MrEditor}"
 BUNDLE_ID="${BUNDLE_ID:-com.aaedit.MrEditor}"
 # バージョン（Info.plist へ埋め込む）。make_dmg.sh と揃えるため VERSION で上書き可能。
-VERSION="${VERSION:-0.9}"
+VERSION="${VERSION:-1.0}"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # 成果物の置き場所。universal ビルド（--arch arm64 --arch x86_64）では

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -24,7 +24,7 @@ set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="${APP_NAME:-MrEditor}"
-VERSION="${VERSION:-0.9}"
+VERSION="${VERSION:-1.0}"
 APP="$ROOT/.build/$APP_NAME.app"
 DMG="$ROOT/.build/$APP_NAME-$VERSION.dmg"
 

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -132,11 +132,11 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v0.9 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0 · MIT</span>
       <h1>86,420,337 lines.<br><span class='teal'>Open in 0.2 seconds.</span></h1>
       <p class="lede">That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds 44&nbsp;MB — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes.</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.9/MrEditor-0.9.dmg">↓ Download .dmg</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0/MrEditor-1.0.dmg">↓ Download .dmg</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">View source</a>
       </div>
       <p class="note">Signed with an Apple Developer ID and notarized by Apple — just double-click it. Universal (Apple Silicon &amp; Intel).</p>

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -132,11 +132,11 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v0.9 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0 · MIT</span>
       <h1>86,420,337 行。<br><span class='teal'>開くのに 0.2 秒。</span></h1>
       <p class="lede">10&nbsp;GB のログです。開いたまま一日使っても、実メモリは 44&nbsp;MB。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.9/MrEditor-0.9.dmg">↓ .dmg をダウンロード</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0/MrEditor-1.0.dmg">↓ .dmg をダウンロード</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">ソースを見る</a>
       </div>
       <p class="note">Apple Developer ID で署名し、Apple の公証を通しています。ダブルクリックするだけで開きます。Apple Silicon / Intel 両対応。</p>

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -135,14 +135,14 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v0.9 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0 · MIT</span>
       <h1 data-en="86,420,337 lines.<br><span class='teal'>Open in 0.2 seconds.</span>"
           data-ja="86,420,337 行。<br><span class='teal'>開くのに 0.2 秒。</span>"></h1>
       <p class="lede"
          data-en="That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds 44&nbsp;MB — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes."
          data-ja="10&nbsp;GB のログです。開いたまま一日使っても、実メモリは 44&nbsp;MB。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。"></p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v0.9/MrEditor-0.9.dmg"
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0/MrEditor-1.0.dmg"
            data-en="↓ Download .dmg" data-ja="↓ .dmg をダウンロード"></a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener"
            data-en="View source" data-ja="ソースを見る"></a>


### PR DESCRIPTION
## 1.0 マイルストーン
編集・検索・構造化表示が揃い、Developer ID 署名＋公証済みでダブルクリックで開く。コードは v0.9（署名・公証を実証済み）から変えていない。**番号と文書だけを 1.0 へ上げる。**

## 変更
- VERSION と `AppInfo.fallbackVersion` を 1.0 に
- **README（日英）にスクリーンショットを追加** — 10GB・86,420,337 行を開いた画面、構造化表示（CSV 桁揃え）、10GB 全文検索（459 万件ヒット）。README に画像が 1 枚も無かった（awesome-mac 申請の要件でもある）
- 見出しを「機能（1.0）」に、ロードマップに 1.0 を追加
- LP バッジ v0.9→v1.0、DL リンクを v1.0 dmg へ

Pro 版の土台（`MrEditorCore` 切り出し・PR #17）は 1.0 には含めない。利用者から見た製品は不変で、旗艦リリースに構造リファクタを混ぜないため。

## 検証（quarantine 付き・ダウンロードした人と同じ条件）
| 項目 | 結果 |
|---|---|
| dmg / .app の Gatekeeper | accepted / **Notarized Developer ID** |
| 公証チケット | dmg・.app 両方に staple 済み |
| アーキテクチャ | `x86_64 arm64` |
| バージョン | 1.0 |
| 全 tests | 109 green |
| バージョン表記の一貫性 | scripts / AppInfo / LP / README 日英ですべて 1.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)