### PR TITLE
未保存の新規ドキュメントが起動時に消えるのを直す

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -15,26 +15,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
         buildMenu()
 
-        let controller = MainWindowController()
-        self.windowController = controller
+        // Finder からの起動では open(_:) がここより先に届きうる。作り直すと
+        // そのとき開いたドキュメントを取りこぼすため、既にあれば使い回す。
+        let controller = ensureController()
         controller.showWindow(nil)
         controller.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
         // コマンドライン引数で渡されたパスを全て開く。
         let args = CommandLine.arguments.dropFirst().filter { !$0.hasPrefix("-") }
-        var opened = false
         for path in args {
             let url = URL(fileURLWithPath: path)
-            if FileManager.default.fileExists(atPath: url.path) { controller.open(url: url); opened = true }
+            if FileManager.default.fileExists(atPath: url.path) { controller.open(url: url) }
         }
 
-        // 引数で何も開かなかったときは前回終了時のファイル一覧を復元する。
+        // 前回終了時のファイル一覧を復元する。**ファイルを開いて起動したときも必ず呼ぶ**：
+        // 復元を飛ばすと、起動時のオープンが前回のセッション（未保存の新規の本文を含む）を
+        // 書き潰してしまう。開いたファイルを優先する判断は restoreSession 側が持つ。
         // ウィンドウが表示され切ってから復元する（同期実行だと復元直後のペインが
         // 初回描画されず、操作するまで本文が空に見える問題を避ける）。
-        if !opened {
-            DispatchQueue.main.async { controller.restoreSession() }
-        }
+        DispatchQueue.main.async { controller.restoreSession() }
 
         // App Store 配布ではないので、新版の存在は自分で知らせる必要がある。
         // 1 日 1 回まで・新版があるときだけ喋る（失敗は黙って捨てる）。

--- a/Sources/MrEditor/AppSettings.swift
+++ b/Sources/MrEditor/AppSettings.swift
@@ -71,6 +71,15 @@ struct SessionState: Codable {
         }
         return SessionState(entries: entries, activeIndex: active)
     }
+
+    /// 起動時に復元するエントリを選ぶ（副作用なし・テスト可能）。
+    /// - `hasOpenDocuments`＝引数や Finder からファイルを開いて起動したとき。
+    ///   そのファイルを優先し、前回の**保存済み**ファイルは開き直さない（従来どおり）。
+    ///   ただし未保存の新規は捨てたら二度と戻せないので、この場合でも必ず復元する。
+    func entriesToRestore(hasOpenDocuments: Bool) -> [SessionEntry] {
+        guard hasOpenDocuments else { return entries }
+        return entries.filter { $0.path == nil && $0.text != nil }
+    }
 }
 
 /// アプリの永続設定（UserDefaults 集約）。

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -31,6 +31,13 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// 開いているファイル（1ファイル＝1ペイン。表示を切り替えるだけ）。
     private var viewers: [DocumentPane] = []
     private var activeIndex = -1
+
+    /// 前回終了時のセッション。**生成時に読み込む**（起動時に開いたファイルが
+    /// `persistSession` 経由で上書きする前に確保しておく必要がある）。
+    private var pendingSession: SessionState? = AppSettings.session
+    /// 復元を済ませたか。済むまでセッションを書き出さない（下の `persistSession` を参照）。
+    private var didRestoreSession = false
+
     private var activeViewer: DocumentPane? {
         (activeIndex >= 0 && activeIndex < viewers.count) ? viewers[activeIndex] : nil
     }
@@ -237,26 +244,46 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// 開いているドキュメント一覧を永続化する（次回起動時に復元）。
     /// 保存済みはパス、未保存の新規は本文つきで残す（空の新規タブは対象外）。
     /// 保存/オープン/クローズ/切替、および終了直前に呼ぶ。
+    ///
+    /// **復元前は書かない。** 起動時に引数や Finder から開いたファイルも `activate` を通るため、
+    /// 無条件に書くと、これから読むはずのセッション（未保存の新規の本文を含む）を潰してしまう。
     private func persistSession() {
+        guard didRestoreSession else { return }
         let docs = viewers.map { (url: $0.fileURL, text: $0.restorableText, dirty: $0.isDirty) }
         AppSettings.session = SessionState.make(docs: docs, activeIndex: activeIndex)
     }
 
-    /// 前回終了時のドキュメント一覧を復元する（順序保持）。
+    /// 前回終了時のドキュメント一覧を復元する（順序保持）。起動時に一度だけ呼ぶ。
     /// 保存済みは存在するものだけ開き直し、未保存の新規は本文つきで再現する。
-    /// コマンドライン引数でファイルが渡されたときは呼ばない（そちらを優先）。
+    ///
+    /// 引数や Finder からファイルを開いて起動したときは、そのファイルを優先して前回の
+    /// 保存済みファイルは開き直さないが、**未保存の新規だけは必ず取り戻す**（失えば戻せない）。
     func restoreSession() {
-        guard let state = AppSettings.session, !state.entries.isEmpty else { return }
+        guard !didRestoreSession else { return }
+        defer {
+            // ここから先は通常どおり永続化する。抑止していた起動時の状態もここで書き出す。
+            didRestoreSession = true
+            persistSession()
+        }
+        guard let state = pendingSession, !state.entries.isEmpty else { return }
+
+        // 起動時に開いたファイル（引数 / Finder）。復元分はこの後ろに積む。
+        let launchOpened = viewers.count
+        let entries = state.entriesToRestore(hasOpenDocuments: launchOpened > 0)
+        guard !entries.isEmpty else { return }
+
         let fm = FileManager.default
-        for entry in state.entries {
+        for entry in entries {
             if let path = entry.path {
                 if fm.fileExists(atPath: path) { open(url: URL(fileURLWithPath: path)) }
             } else if let text = entry.text {
                 restoreUntitled(text: text, dirty: entry.dirty)
             }
         }
-        // 欠損ファイルのスキップで位置がずれうるため範囲内にクランプ。
-        if state.activeIndex >= 0, !viewers.isEmpty {
+        if launchOpened > 0 {
+            activate(launchOpened - 1)   // 起動時に開いたファイルをアクティブのままにする
+        } else if state.activeIndex >= 0, !viewers.isEmpty {
+            // 欠損ファイルのスキップで位置がずれうるため範囲内にクランプ。
             activate(min(state.activeIndex, viewers.count - 1))
         }
         // 復元直後のアクティブペインを確実に初回描画させる。

--- a/Tests/MrEditorTests/SessionRestoreTests.swift
+++ b/Tests/MrEditorTests/SessionRestoreTests.swift
@@ -67,6 +67,41 @@ final class SessionRestoreTests: XCTestCase {
         XCTAssertEqual(s.activeIndex, -1)
     }
 
+    // MARK: - entriesToRestore（起動時に何を復元するか）
+
+    /// 通常起動（ファイルを開かずに起動）なら全部復元する。
+    func testEntriesToRestoreWithoutOpenDocumentsRestoresAll() {
+        let s = SessionState(entries: [
+            SessionEntry(path: "/tmp/a.txt", text: nil, dirty: false),
+            SessionEntry(path: nil, text: "メモ", dirty: true),
+        ], activeIndex: 0)
+        XCTAssertEqual(s.entriesToRestore(hasOpenDocuments: false).count, 2)
+    }
+
+    /// 引数や Finder からファイルを開いて起動したときは、保存済みは開き直さないが
+    /// **未保存の新規は必ず復元する**（開いたファイルに前回のセッションを潰させない）。
+    func testEntriesToRestoreWithOpenDocumentsKeepsOnlyUntitled() {
+        let s = SessionState(entries: [
+            SessionEntry(path: "/tmp/a.txt", text: nil, dirty: false),
+            SessionEntry(path: nil, text: "未保存の下書き", dirty: true),
+            SessionEntry(path: "/tmp/b.txt", text: nil, dirty: false),
+        ], activeIndex: 0)
+
+        let restored = s.entriesToRestore(hasOpenDocuments: true)
+        XCTAssertEqual(restored.count, 1)
+        XCTAssertNil(restored[0].path)
+        XCTAssertEqual(restored[0].text, "未保存の下書き")
+        XCTAssertTrue(restored[0].dirty)
+    }
+
+    /// 未保存の新規が無ければ、ファイルを開いての起動では何も復元しない。
+    func testEntriesToRestoreWithOpenDocumentsAndNoUntitledIsEmpty() {
+        let s = SessionState(entries: [
+            SessionEntry(path: "/tmp/a.txt", text: nil, dirty: false),
+        ], activeIndex: 0)
+        XCTAssertTrue(s.entriesToRestore(hasOpenDocuments: true).isEmpty)
+    }
+
     // MARK: - AppSettings.session（UserDefaults 永続化往復）
 
     /// 保存済み＋未保存の新規（本文つき）を UserDefaults へ書いて読み戻せる。


### PR DESCRIPTION
## 何が起きていたか

ファイルを開いて起動すると（Finder の「このアプリで開く」・アイコンへのドロップ・コマンドライン引数）、**前回のセッションが本文ごと消えていた**。未保存の新規ドキュメントは保存先を持たないので、消えたら二度と戻せない。ユーザー報告：「未保存のセッションが消えるな..、表示されなくなった」。

## 原因

書き出しと読み出しの順序。起動時に開いたファイルも `open` → `activate` → `persistSession` を通るため、**`restoreSession` がまだ読んでいないセッションをその場で上書き**していた。さらに引数つき起動では復元自体を呼んでいなかったので、上書きされた側は誰にも読まれないまま消えた。

1.0 で `CFBundleDocumentTypes` を入れて Finder からの起動が初めて到達可能になったため、日常操作で踏むようになった（v0.7 の復元実装時には無かった経路）。

## 直し方

- セッションは `MainWindowController` の生成時に読み込んで保持する（起動時のオープンに上書きされる前に確保する）
- 復元を済ませるまで `persistSession` は書かない
- 復元は起動時のオープンの有無にかかわらず必ず通す。開いたファイルを優先する判断は `restoreSession` が持ち、前回の保存済みファイルは開き直さない（従来どおり）が、**未保存の新規だけは必ず取り戻す**（`entriesToRestore`）

## 確認

実機（`.app`）で 3 経路とも再現→修正を確認：

| 起動のしかた | 修正前 | 修正後 |
|---|---|---|
| 引数つき（`--args file`） | 未保存の本文が消える | 復元される・開いたファイルがアクティブ |
| Finder の「このアプリで開く」（odoc） | 未保存の本文が消える | 復元される・開いたファイルがアクティブ |
| 素の起動 | 正常 | 正常（変わらず） |

サイドバーに未保存印つきで並び、クリックで本文が出ることまで目視で確認した。112 tests green（新規 3 本）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)