### PR TITLE
リリース 1.0.1: 未保存の新規ドキュメントが消えるデータ消失バグを修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -114,7 +114,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-配布用ディスクイメージ（`.build/MrEditor-1.0.dmg`）の作成:
+配布用ディスクイメージ（`.build/MrEditor-1.0.1.dmg`）の作成:
 
 ```sh
 sh scripts/make_dmg.sh
@@ -144,7 +144,8 @@ sh scripts/make_dmg.sh
 - **v0.7 — セッション復元（未保存の新規も本文ごと）・About パネル修正** ✅
 - **v0.8 — Finder 統合・印刷/PDF 出力・アップデート確認・新アイコン・universal ビルド。および配布物の重大な修正（下記）** ✅
 - **v0.9 — Apple Developer ID で署名し、公証（notarization）を通した。右クリック不要でダブルクリックで開ける** ✅
-- **1.0 — 巨大ファイルを開いて編集できる Mac エディタとして完成。署名・公証済みで、ダブルクリックで開く** ✅（このリリース）
+- **1.0 — 巨大ファイルを開いて編集できる Mac エディタとして完成。署名・公証済みで、ダブルクリックで開く** ✅
+- **1.0.1 — ファイルを開いて起動すると未保存の新規ドキュメントが消えるバグを修正（データ消失）** ✅（このリリース）
 - **以降** — シンタックス/ログのハイライト、その他の分析ツール
 
 > **⚠️ v0.7 以前の dmg は、ダウンロードした Mac で起動しません。**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-Build a distributable disk image (`.build/MrEditor-1.0.dmg`):
+Build a distributable disk image (`.build/MrEditor-1.0.1.dmg`):
 
 ```sh
 sh scripts/make_dmg.sh
@@ -145,7 +145,8 @@ resident app memory. The number that matters (`Physical footprint`) stays at 44 
 - **v0.7 — session restore (unsaved drafts included), About panel fix** ✅
 - **v0.8 — Finder integration, print/PDF export, update check, new icon, universal build, and a critical distribution fix (below)** ✅
 - **v0.9 — signed with an Apple Developer ID and notarized by Apple; opens with a plain double-click** ✅
-- **1.0 — the milestone: open and edit 10 GB files on a Mac, signed and notarized, opens with a double-click** ✅ (this release)
+- **1.0 — the milestone: open and edit 10 GB files on a Mac, signed and notarized, opens with a double-click** ✅
+- **1.0.1 — fixes data loss: an unsaved new document vanished when the app was launched by opening a file** ✅ (this release)
 - **later** — syntax/log highlighting, and more analysis tooling
 
 > **⚠️ Builds up to v0.7 do not launch on a Mac that downloaded them.**

--- a/Sources/MrEditor/AppInfo.swift
+++ b/Sources/MrEditor/AppInfo.swift
@@ -15,7 +15,7 @@ enum AppInfo {
     static var version: String {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? fallbackVersion
     }
-    private static let fallbackVersion = "1.0"
+    private static let fallbackVersion = "1.0.1"
 
     /// ヘルプメニューから開くプロジェクトページ。
     static let helpURL = URL(string: "https://github.com/MR-TABATA/MrEditor")!

--- a/scripts/make_app.sh
+++ b/scripts/make_app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-debug}"
 APP_NAME="${APP_NAME:-MrEditor}"
 BUNDLE_ID="${BUNDLE_ID:-com.aaedit.MrEditor}"
 # バージョン（Info.plist へ埋め込む）。make_dmg.sh と揃えるため VERSION で上書き可能。
-VERSION="${VERSION:-1.0}"
+VERSION="${VERSION:-1.0.1}"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # 成果物の置き場所。universal ビルド（--arch arm64 --arch x86_64）では

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -24,7 +24,7 @@ set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="${APP_NAME:-MrEditor}"
-VERSION="${VERSION:-1.0}"
+VERSION="${VERSION:-1.0.1}"
 APP="$ROOT/.build/$APP_NAME.app"
 DMG="$ROOT/.build/$APP_NAME-$VERSION.dmg"
 

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -132,11 +132,11 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v1.0 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0.1 · MIT</span>
       <h1>86,420,337 lines.<br><span class='teal'>Open in 0.2 seconds.</span></h1>
       <p class="lede">That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds 44&nbsp;MB — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes.</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0/MrEditor-1.0.dmg">↓ Download .dmg</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.1/MrEditor-1.0.1.dmg">↓ Download .dmg</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">View source</a>
       </div>
       <p class="note">Signed with an Apple Developer ID and notarized by Apple — just double-click it. Universal (Apple Silicon &amp; Intel).</p>

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -132,11 +132,11 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v1.0 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0.1 · MIT</span>
       <h1>86,420,337 行。<br><span class='teal'>開くのに 0.2 秒。</span></h1>
       <p class="lede">10&nbsp;GB のログです。開いたまま一日使っても、実メモリは 44&nbsp;MB。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0/MrEditor-1.0.dmg">↓ .dmg をダウンロード</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.1/MrEditor-1.0.1.dmg">↓ .dmg をダウンロード</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">ソースを見る</a>
       </div>
       <p class="note">Apple Developer ID で署名し、Apple の公証を通しています。ダブルクリックするだけで開きます。Apple Silicon / Intel 両対応。</p>

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -135,14 +135,14 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v1.0 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0.1 · MIT</span>
       <h1 data-en="86,420,337 lines.<br><span class='teal'>Open in 0.2 seconds.</span>"
           data-ja="86,420,337 行。<br><span class='teal'>開くのに 0.2 秒。</span>"></h1>
       <p class="lede"
          data-en="That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds 44&nbsp;MB — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes."
          data-ja="10&nbsp;GB のログです。開いたまま一日使っても、実メモリは 44&nbsp;MB。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。"></p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0/MrEditor-1.0.dmg"
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.1/MrEditor-1.0.1.dmg"
            data-en="↓ Download .dmg" data-ja="↓ .dmg をダウンロード"></a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener"
            data-en="View source" data-ja="ソースを見る"></a>


### PR DESCRIPTION
公開中の 1.0 は、ファイルを開いて起動すると（Finder の「このアプリで開く」・ドロップ・引数）**前回の未保存の新規ドキュメントを本文ごと失う**。保存先が無いドキュメントなので、消えたら二度と戻せない。告知より先に patch を出す。

修正そのものは #19。この PR は版数と文書だけ。

- `VERSION`（`make_app.sh` / `make_dmg.sh`）と `AppInfo.fallbackVersion` を 1.0.1 に
- README（日英）のリリース一覧に 1.0.1 を追加
- LP のバッジ v1.0→v1.0.1、DL リンクを v1.0.1 dmg へ。`site/` を再生成

dmg は Developer ID 署名＋公証済み（notarytool: Accepted / staple 済み / `spctl` accepted）。universal（arm64 + x86_64）。112 tests green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)