### PR TITLE
未保存の本文をセッションから追い出し、draft ファイルとして守る

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -45,6 +45,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return true
     }
 
+    /// 他のアプリへ切り替えた時点で未保存の本文をディスクへ書き出す。
+    /// 打鍵のデバウンス待ちのまま落ちても（クラッシュ・強制終了）失わないため。
+    func applicationDidResignActive(_ notification: Notification) {
+        windowController?.flushDrafts()
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard let c = windowController else { return .terminateNow }
         return c.confirmTerminate() ? .terminateNow : .terminateCancel

--- a/Sources/MrEditor/AppSettings.swift
+++ b/Sources/MrEditor/AppSettings.swift
@@ -32,35 +32,54 @@ enum CursorShape: String, CaseIterable {
 
 /// 復元対象の 1 ドキュメント。
 /// - 保存済みファイル: `path` を持ち、次回はそのファイルを開き直す。
-/// - 未保存の新規ドキュメント: `text`（本文）を持ち、空タブとして本文つきで復元する。
+/// - 未保存の新規ドキュメント: `draftID` を持つ。**本文はここには入れない**（[[DraftStore]] のファイル）。
 struct SessionEntry: Codable {
     /// 保存済みファイルのパス（未保存の新規では nil）。
     var path: String?
-    /// 未保存の新規ドキュメントの本文（保存済みファイルでは nil）。
-    var text: String?
+    /// 未保存の新規ドキュメントの本文が入った draft ファイルの id（保存済みファイルでは nil）。
+    var draftID: String?
     /// 復元時に未保存（編集済み）として印を付けるか。
     var dirty: Bool
+
+    /// 旧版（〜1.0.1）が本文をセッションに直接入れていた名残。読み込み専用（更新時の移行に使う）。
+    /// `DraftStore.migratingLegacyText(in:)` が draft ファイルへ移して nil にする。
+    var text: String?
+}
+
+/// 起動時に開くもの 1 件。
+enum RestoreItem: Equatable {
+    case file(path: String)
+    case draft(id: String, dirty: Bool)
+}
+
+/// 起動時に何をどの順で開くかの計画。
+struct RestorePlan: Equatable {
+    var items: [RestoreItem]
+    /// `items` 内のアクティブ位置（-1＝なし）。
+    var activeIndex: Int
 }
 
 /// 前回終了時に開いていたドキュメント一覧と、アクティブだった位置。
+/// **本文は持たない**（未保存の本文は DraftStore が持ち、ここは id を指すだけ）。
 struct SessionState: Codable {
     var entries: [SessionEntry]
     /// `entries` 内のアクティブ位置（-1＝なし）。
     var activeIndex: Int
 
     /// 開いているドキュメント情報からセッションを組み立てる（副作用なし・テスト可能）。
-    /// - 保存済み（`url` あり）はパスのみ。未保存の新規（`url` なし）は本文つきで残すが、
-    ///   **空の本文はスキップ**（復元しない）。
+    /// - 保存済み（`url` あり）はパスのみ。未保存の新規（`url` なし）は draft の id を指す。
+    ///   **本文が空の新規はスキップ**（復元しない）。
     /// - `activeIndex`（`docs` 内の位置）は、スキップでずれるため `entries` 内の位置へ付け替える。
-    static func make(docs: [(url: URL?, text: String?, dirty: Bool)], activeIndex: Int) -> SessionState {
+    static func make(docs: [(url: URL?, text: String?, draftID: String?, dirty: Bool)],
+                     activeIndex: Int) -> SessionState {
         var entries: [SessionEntry] = []
         var active = -1
         for (i, d) in docs.enumerated() {
             let entry: SessionEntry?
             if let url = d.url {
-                entry = SessionEntry(path: url.path, text: nil, dirty: false)
-            } else if let text = d.text, !text.isEmpty {
-                entry = SessionEntry(path: nil, text: text, dirty: d.dirty)
+                entry = SessionEntry(path: url.path, draftID: nil, dirty: false, text: nil)
+            } else if let id = d.draftID, let text = d.text, !text.isEmpty {
+                entry = SessionEntry(path: nil, draftID: id, dirty: d.dirty, text: nil)
             } else {
                 entry = nil
             }
@@ -72,13 +91,46 @@ struct SessionState: Codable {
         return SessionState(entries: entries, activeIndex: active)
     }
 
-    /// 起動時に復元するエントリを選ぶ（副作用なし・テスト可能）。
-    /// - `hasOpenDocuments`＝引数や Finder からファイルを開いて起動したとき。
-    ///   そのファイルを優先し、前回の**保存済み**ファイルは開き直さない（従来どおり）。
-    ///   ただし未保存の新規は捨てたら二度と戻せないので、この場合でも必ず復元する。
-    func entriesToRestore(hasOpenDocuments: Bool) -> [SessionEntry] {
-        guard hasOpenDocuments else { return entries }
-        return entries.filter { $0.path == nil && $0.text != nil }
+    /// 起動時に何を開くかを決める（副作用なし・テスト可能）。**この関数がデータ保護の要になる。**
+    ///
+    /// 守る不変条件：**実在する draft（`draftIDs`）は、セッションが何であっても必ず計画に入る。**
+    /// セッションが nil でも・壊れていても・別の内容で上書きされていても、未保存の本文は戻る。
+    /// 索引（セッション）ではなく、ディスク上の実体（draft ファイル）が真実だという構え。
+    ///
+    /// - `hasOpenDocuments`＝引数や Finder からファイルを開いて起動したとき。そのファイルを
+    ///   優先し、前回の**保存済み**ファイルは開き直さない（従来どおりの意図的な挙動）。
+    ///   未保存の draft は、この場合でも必ず復元する。
+    static func restorePlan(session: SessionState?,
+                            draftIDs: [String],
+                            hasOpenDocuments: Bool) -> RestorePlan {
+        var items: [RestoreItem] = []
+        var active = -1
+        var placed = Set<String>()
+
+        if let session {
+            for (i, e) in session.entries.enumerated() {
+                let item: RestoreItem?
+                if let path = e.path {
+                    item = hasOpenDocuments ? nil : .file(path: path)
+                } else if let id = e.draftID, draftIDs.contains(id) {
+                    placed.insert(id)
+                    item = .draft(id: id, dirty: e.dirty)
+                } else {
+                    item = nil   // 本文の無い draft 参照（＝既に保存/破棄済み）は捨てる
+                }
+                if let item {
+                    if i == session.activeIndex { active = items.count }
+                    items.append(item)
+                }
+            }
+        }
+
+        // セッションが指していない draft（＝孤児）も必ず開く。ここが最後の砦。
+        // 本文が残っている以上、ユーザーはまだ保存も破棄もしていない。
+        for id in draftIDs where !placed.contains(id) {
+            items.append(.draft(id: id, dirty: true))
+        }
+        return RestorePlan(items: items, activeIndex: active)
     }
 }
 

--- a/Sources/MrEditor/Core/DraftStore.swift
+++ b/Sources/MrEditor/Core/DraftStore.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// 未保存の新規ドキュメントの本文を、**1 ドキュメント＝1 ファイル**でディスクに持つ。
+///
+/// ## なぜセッションと器を分けるのか
+/// 未保存の本文は、ユーザーがまだどこにも保存していない**唯一の写し**で、失えば戻せない。
+/// 一方セッション（開いていた一覧・並び・アクティブ位置）は、壊れても作り直せる索引にすぎない。
+/// この二つを同じ器（1 個の UserDefaults キー）に入れ、毎回まるごと書き直していたことが、
+/// 1.0 のデータ消失バグ（起動時のオープンがセッションを上書きして未保存の本文ごと消す）と、
+/// クラッシュで全消しになる穴の共通の根だった。
+///
+/// そこで本文はここに追い出す。守る規則は 3 つ：
+/// 1. 本文は `Drafts/<id>.txt` へ **atomic 書き込み**。セッションは `id` を参照するだけ。
+/// 2. **起動時はセッションではなくこのディレクトリを真実として読む**（索引に載っていない
+///    孤児 draft も必ず拾う）。索引が壊れても・全消しされても本文は戻る。
+/// 3. **消えるのは `discard(_:)` を通ったときだけ。** 呼ぶのは「実ファイルへの保存に成功した」
+///    「ユーザーがドキュメントを閉じた（破棄を選んだ）」の 2 経路に限る。
+///    セッションの書き出しからは決して消さない。
+struct DraftStore {
+    /// draft ファイルを置くディレクトリ（テストでは一時ディレクトリを渡す）。
+    let root: URL
+
+    static let shared = DraftStore(root: DraftStore.defaultRoot)
+
+    /// `~/Library/Application Support/MrEditor/Drafts`
+    static var defaultRoot: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support")
+        return base.appendingPathComponent("MrEditor/Drafts", isDirectory: true)
+    }
+
+    /// 新しい draft の識別子。ファイル名にそのまま使う。
+    static func newID() -> String { UUID().uuidString }
+
+    private func url(for id: String) -> URL {
+        root.appendingPathComponent(id).appendingPathExtension("txt")
+    }
+
+    /// 本文を書き出す（atomic）。**空の本文はファイルを持たない**（新規タブを開いただけの
+    /// 状態を復元しても意味が無い）。空になったら消すが、`id` は生き続けるので打ち直せば復活する。
+    func write(id: String, text: String) {
+        guard !text.isEmpty else { discard(id); return }
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try Data(text.utf8).write(to: url(for: id), options: .atomic)
+        } catch {
+            // 書けなくてもアプリは止めない（次の打鍵でまた試す）。
+            NSLog("MrEditor: draft の書き出しに失敗した (%@): %@", id, error.localizedDescription)
+        }
+    }
+
+    /// 本文を読む（無ければ nil）。
+    func read(id: String) -> String? {
+        guard let data = try? Data(contentsOf: url(for: id)) else { return nil }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// 実在する draft の id を**古い順**に返す（復元したとき前回に近い並びになる）。
+    func allIDs() -> [String] {
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(at: root,
+                                                      includingPropertiesForKeys: [.contentModificationDateKey],
+                                                      options: [.skipsHiddenFiles]) else { return [] }
+        return names
+            .filter { $0.pathExtension == "txt" }
+            .sorted { a, b in
+                let da = (try? a.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+                let db = (try? b.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+                return da < db
+            }
+            .map { $0.deletingPathExtension().lastPathComponent }
+    }
+
+    /// **本文を消す唯一の入口。** 保存に成功したか、ユーザーがドキュメントを閉じたときだけ呼ぶ。
+    func discard(_ id: String) {
+        try? FileManager.default.removeItem(at: url(for: id))
+    }
+
+    /// 旧版（〜1.0.1）のセッションは本文をセッション自身に入れていた。
+    /// その本文を draft ファイルへ移し、`draftID` を振ったセッションを返す（更新に伴う取りこぼし防止）。
+    func migratingLegacyText(in state: SessionState) -> SessionState {
+        var s = state
+        for i in s.entries.indices {
+            guard s.entries[i].path == nil, s.entries[i].draftID == nil,
+                  let text = s.entries[i].text, !text.isEmpty else { continue }
+            let id = DraftStore.newID()
+            write(id: id, text: text)
+            s.entries[i].draftID = id
+            s.entries[i].text = nil
+        }
+        return s
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -32,6 +32,9 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     private var viewers: [DocumentPane] = []
     private var activeIndex = -1
 
+    /// 未保存の本文（draft）の置き場。**セッションとは別の器**で、消えたら戻せない本文だけを持つ。
+    var draftStore: DraftStore = .shared
+
     /// 前回終了時のセッション。**生成時に読み込む**（起動時に開いたファイルが
     /// `persistSession` 経由で上書きする前に確保しておく必要がある）。
     private var pendingSession: SessionState? = AppSettings.session
@@ -204,6 +207,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
         let v = EditableViewer()
+        v.draftStore = draftStore
         install(v)
         v.newDocument()
         viewers.append(v)
@@ -249,15 +253,23 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// 無条件に書くと、これから読むはずのセッション（未保存の新規の本文を含む）を潰してしまう。
     private func persistSession() {
         guard didRestoreSession else { return }
-        let docs = viewers.map { (url: $0.fileURL, text: $0.restorableText, dirty: $0.isDirty) }
+        let docs = viewers.map {
+            (url: $0.fileURL, text: $0.restorableText, draftID: $0.draftID, dirty: $0.isDirty)
+        }
         AppSettings.session = SessionState.make(docs: docs, activeIndex: activeIndex)
     }
 
+    /// 開いている未保存の本文を今すぐ draft ファイルへ書き出す（終了直前・非アクティブ化時）。
+    func flushDrafts() {
+        viewers.forEach { $0.flushDraft() }
+    }
+
     /// 前回終了時のドキュメント一覧を復元する（順序保持）。起動時に一度だけ呼ぶ。
-    /// 保存済みは存在するものだけ開き直し、未保存の新規は本文つきで再現する。
     ///
-    /// 引数や Finder からファイルを開いて起動したときは、そのファイルを優先して前回の
-    /// 保存済みファイルは開き直さないが、**未保存の新規だけは必ず取り戻す**（失えば戻せない）。
+    /// **セッションではなく draft ファイル（ディスク上の実体）を真実として読む。**
+    /// セッションが無くても・壊れていても・起動時のオープンに上書きされていても、実在する
+    /// 未保存の本文は必ず開き直す（`SessionState.restorePlan` が不変条件を持つ）。
+    /// 保存済みファイルの一覧はセッションが持つが、これは失っても作り直せる情報。
     func restoreSession() {
         guard !didRestoreSession else { return }
         defer {
@@ -265,37 +277,44 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             didRestoreSession = true
             persistSession()
         }
-        guard let state = pendingSession, !state.entries.isEmpty else { return }
+
+        // 旧版（〜1.0.1）はセッションに本文を直接入れていた。更新で取りこぼさないよう draft へ移す。
+        let session = pendingSession.map { draftStore.migratingLegacyText(in: $0) }
 
         // 起動時に開いたファイル（引数 / Finder）。復元分はこの後ろに積む。
         let launchOpened = viewers.count
-        let entries = state.entriesToRestore(hasOpenDocuments: launchOpened > 0)
-        guard !entries.isEmpty else { return }
+        let plan = SessionState.restorePlan(session: session,
+                                            draftIDs: draftStore.allIDs(),
+                                            hasOpenDocuments: launchOpened > 0)
+        guard !plan.items.isEmpty else { return }
 
         let fm = FileManager.default
-        for entry in entries {
-            if let path = entry.path {
+        for item in plan.items {
+            switch item {
+            case .file(let path):
                 if fm.fileExists(atPath: path) { open(url: URL(fileURLWithPath: path)) }
-            } else if let text = entry.text {
-                restoreUntitled(text: text, dirty: entry.dirty)
+            case .draft(let id, let dirty):
+                guard let text = draftStore.read(id: id) else { continue }
+                restoreDraft(id: id, text: text, dirty: dirty)
             }
         }
         if launchOpened > 0 {
             activate(launchOpened - 1)   // 起動時に開いたファイルをアクティブのままにする
-        } else if state.activeIndex >= 0, !viewers.isEmpty {
+        } else if plan.activeIndex >= 0, !viewers.isEmpty {
             // 欠損ファイルのスキップで位置がずれうるため範囲内にクランプ。
-            activate(min(state.activeIndex, viewers.count - 1))
+            activate(min(plan.activeIndex, viewers.count - 1))
         }
         // 復元直後のアクティブペインを確実に初回描画させる。
         activeViewer?.needsDisplay = true
         window?.displayIfNeeded()
     }
 
-    /// 未保存の新規ドキュメントを本文つきで復元してサイドバーに追加する。
-    private func restoreUntitled(text: String, dirty: Bool) {
+    /// 未保存の新規ドキュメントを draft の本文つきで復元してサイドバーに追加する。
+    private func restoreDraft(id: String, text: String, dirty: Bool) {
         let v = EditableViewer()
+        v.draftStore = draftStore
         install(v)
-        v.restoreUntitled(text: text, dirty: dirty)
+        v.restoreDraft(id: id, text: text, dirty: dirty)
         viewers.append(v)
         reloadSidebar()
         activate(viewers.count - 1)   // activate 内で persistSession
@@ -450,6 +469,9 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     private func removePane(_ pane: DocumentPane) {
         guard let idx = viewers.firstIndex(where: { $0 === pane }) else { return }
         if !searchBar.isHidden { hideSearch() }
+        // ドキュメントを閉じるのはユーザーの明示的な操作。ここが draft を消してよい 2 経路の
+        // もう 1 つ（保存に成功したときはペイン側で消える）。閉じずに終了した draft は残る。
+        pane.discardDraft()
         let v = viewers.remove(at: idx)
         v.removeFromSuperview()
         if viewers.isEmpty {
@@ -649,7 +671,8 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// 未保存編集だけを確認する。閉じる直前に最新の本文をセッションへ書き出す。
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         if forceClose { return true }
-        persistSession()   // 未保存の新規タブの最新本文を取りこぼさない
+        flushDrafts()      // 未保存の本文をディスクへ（デバウンス待ちの分を取りこぼさない）
+        persistSession()
         let dirty = viewers.filter { $0.isDirty && $0.fileURL != nil }
         if dirty.isEmpty { return true }
         let alert = NSAlert()
@@ -674,7 +697,8 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// アプリ終了前の未保存確認（同期）。終了してよければ true。
     /// 未保存の新規はセッション復元で残るため確認しない。終了直前に最新の本文を書き出す。
     func confirmTerminate() -> Bool {
-        persistSession()   // 未保存の新規タブの最新本文を取りこぼさない
+        flushDrafts()      // 未保存の本文をディスクへ（デバウンス待ちの分を取りこぼさない）
+        persistSession()
         let dirty = viewers.filter { $0.isDirty && $0.fileURL != nil }
         if dirty.isEmpty { return true }
         let alert = NSAlert()

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -75,6 +75,15 @@ protocol DocumentPane: NSView {
     /// セッション復元用の本文（未保存の新規ドキュメントを保存/再現するため）。
     /// 大ファイル等・復元非対応のペインは nil（既定）。
     var restorableText: String? { get }
+
+    // MARK: - 未保存の本文の保護（DraftStore）
+
+    /// 未保存の新規ドキュメントの本文を持つ draft の id（保存済み・復元非対応のペインは nil）。
+    var draftID: String? { get }
+    /// 溜めている本文を今すぐ draft へ書き出す（終了直前・非アクティブ化時に呼ぶ）。
+    func flushDraft()
+    /// draft を捨てる。**ユーザーがそのドキュメントを閉じた（破棄した）ときだけ呼ぶ。**
+    func discardDraft()
     /// 未保存状態が変化したときの通知（タイトルバーの編集済みドット用）。
     var onDirtyChange: ((Bool) -> Void)? { get set }
     /// 既存パスへ保存する。成功で true。
@@ -121,6 +130,11 @@ extension DocumentPane {
     var canEdit: Bool { false }
     var isDirty: Bool { false }
     var restorableText: String? { nil }
+
+    // 未保存の本文を持たないペイン（読み取り専用・巨大ファイル）は draft と無縁。
+    var draftID: String? { nil }
+    func flushDraft() {}
+    func discardDraft() {}
     @discardableResult func save() -> Bool { false }
     @discardableResult func saveAs() -> Bool { false }
 

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -23,6 +23,20 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     /// 変更状態が変わったときの通知（タイトルバーの edited 表示用）。
     var onDirtyChange: ((Bool) -> Void)?
 
+    // MARK: - 未保存の本文の保護（DraftStore）
+    //
+    // 未保存の新規ドキュメントの本文は、ユーザーがまだどこにも保存していない唯一の写し。
+    // 終了時にまとめて書くのでは、クラッシュ・強制終了・電源断で消える。打鍵のたびに
+    // （デバウンスして）draft ファイルへ書き、落ちても直前まで残るようにする。
+
+    /// この draft を保存するストア（テストでは一時ディレクトリのものを差し込む）。
+    var draftStore: DraftStore = .shared
+    /// 未保存の新規ドキュメントの本文が入る draft の id。保存済みファイルでは nil。
+    private(set) var draftID: String?
+    /// 打鍵のたびに書かず、この間隔だけ落ち着いてから書く。
+    private var draftSaveTimer: Timer?
+    private static let draftDebounce: TimeInterval = 1.0
+
     var onStateChange: ((ViewerState) -> Void)?
     var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)?   // 編集ペインでは未使用
     var onDropFiles: (([URL]) -> Void)?
@@ -123,6 +137,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             text = String(decoding: data, as: UTF8.self)
         }
         self.fileURL = url
+        self.draftID = nil          // 実ファイルを開いたペインは draft を持たない
         self.encoding = detected
         self.lineEnding = LineEnding.detect(Data(prefix), encoding: detected)
         self.byteSize = data.count
@@ -166,6 +181,41 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         }
     }
 
+    // MARK: - draft（未保存の本文）の読み書き
+
+    /// 打鍵から少し待って draft を書く（連続入力のたびにディスクを叩かない）。
+    private func scheduleDraftSave() {
+        guard fileURL == nil, draftID != nil else { return }   // 保存済みファイルは draft を持たない
+        draftSaveTimer?.invalidate()
+        draftSaveTimer = Timer.scheduledTimer(withTimeInterval: Self.draftDebounce, repeats: false) { [weak self] _ in
+            self?.flushDraft()
+        }
+    }
+
+    /// 溜めている本文を今すぐ draft へ書き出す（終了直前・非アクティブ化時にも呼ばれる）。
+    func flushDraft() {
+        draftSaveTimer?.invalidate()
+        draftSaveTimer = nil
+        guard fileURL == nil, let id = draftID else { return }
+        draftStore.write(id: id, text: logicalText)
+    }
+
+    /// draft を捨てる。**ユーザーがドキュメントを閉じた（破棄した）ときだけ呼ぶ。**
+    /// 保存済みファイルのペインでは何も起きない（draftID が無い）。
+    func discardDraft() {
+        draftSaveTimer?.invalidate()
+        draftSaveTimer = nil
+        guard let id = draftID else { return }
+        draftStore.discard(id)
+        draftID = nil
+    }
+
+    /// draft から未保存の新規ドキュメントを復元する（本文はディスクの draft ファイルが持つ）。
+    func restoreDraft(id: String, text: String, dirty: Bool) {
+        draftID = id
+        restoreUntitled(text: text, dirty: dirty)
+    }
+
     /// 前回終了時の未保存の新規ドキュメントを本文つきで復元する（パスは未確定のまま）。
     func restoreUntitled(text: String, dirty: Bool) {
         fileURL = nil
@@ -182,7 +232,9 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     }
 
     /// 空の新規ドキュメントとして初期化する（パス未確定。保存時に確定する）。
+    /// この時点で draft の id を振る（本文が空のうちはファイルを作らない）。
     func newDocument() {
+        draftID = DraftStore.newID()
         fileURL = nil
         encoding = .utf8
         lineEnding = .lf
@@ -262,6 +314,8 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         fileURL = url
         byteSize = data.count
         setDirty(false)
+        // 本文が実ファイルになった。draft はもう要らない（消してよい 2 経路のうちの 1 つ）。
+        discardDraft()
         emitState()
         return true
     }
@@ -270,7 +324,8 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
 
     func textDidChange(_ notification: Notification) {
         setDirty(true)
-        emitState()   // 行数・状態を更新
+        scheduleDraftSave()   // 落ちても直前まで残るよう、未保存の本文をディスクへ
+        emitState()           // 行数・状態を更新
     }
 
     // MARK: - DocumentPane

--- a/Tests/MrEditorTests/DraftStoreTests.swift
+++ b/Tests/MrEditorTests/DraftStoreTests.swift
@@ -1,0 +1,251 @@
+import XCTest
+@testable import MrEditor
+
+/// 未保存の本文の保護（[[DraftStore]] と復元プラン）を検証する。
+///
+/// ここで守っている不変条件は 1 つ：
+/// **実在する draft は、セッションが何であっても（nil・壊れている・上書きされている）必ず復元される。**
+/// 1.0 のデータ消失バグは、本文がセッションと同じ器に入っていたために起きた。
+/// セッションは索引にすぎず、真実はディスク上の draft ファイルである、という構えをテストで固定する。
+final class DraftStoreTests: XCTestCase {
+
+    private var root: URL!
+    private var store: DraftStore!
+
+    override func setUp() {
+        super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mreditor-drafts-\(UUID().uuidString)")
+        store = DraftStore(root: root)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: root)
+        super.tearDown()
+    }
+
+    // MARK: - DraftStore（本文の器）
+
+    /// 書いて読める。ディレクトリが無くても作る。
+    func testWriteThenRead() {
+        let id = DraftStore.newID()
+        store.write(id: id, text: "未保存の下書き\n2行目")
+        XCTAssertEqual(store.read(id: id), "未保存の下書き\n2行目")
+        XCTAssertEqual(store.allIDs(), [id])
+    }
+
+    /// 上書きできる（打鍵のたびに最新へ）。
+    func testWriteOverwrites() {
+        let id = DraftStore.newID()
+        store.write(id: id, text: "old")
+        store.write(id: id, text: "new")
+        XCTAssertEqual(store.read(id: id), "new")
+        XCTAssertEqual(store.allIDs().count, 1)
+    }
+
+    /// 空の本文はファイルを持たない（新規タブを開いただけの状態は復元しない）。
+    func testEmptyTextRemovesFile() {
+        let id = DraftStore.newID()
+        store.write(id: id, text: "something")
+        store.write(id: id, text: "")
+        XCTAssertNil(store.read(id: id))
+        XCTAssertTrue(store.allIDs().isEmpty)
+    }
+
+    /// discard が本文を消す唯一の入口。
+    func testDiscardRemoves() {
+        let id = DraftStore.newID()
+        store.write(id: id, text: "捨てる")
+        store.discard(id)
+        XCTAssertNil(store.read(id: id))
+        XCTAssertTrue(store.allIDs().isEmpty)
+    }
+
+    /// 存在しない draft を読んでも discard しても壊れない。
+    func testMissingDraftIsHarmless() {
+        XCTAssertNil(store.read(id: "no-such-id"))
+        store.discard("no-such-id")   // 例外を投げない
+        XCTAssertTrue(store.allIDs().isEmpty)
+    }
+
+    /// 旧版（〜1.0.1）のセッション（本文を直に持つ）は draft ファイルへ移す。更新で失わない。
+    func testMigratingLegacyTextMovesBodyIntoDraftFile() throws {
+        let legacy = SessionState(entries: [
+            SessionEntry(path: "/tmp/a.txt", draftID: nil, dirty: false, text: nil),
+            SessionEntry(path: nil, draftID: nil, dirty: true, text: "旧版の未保存の本文"),
+        ], activeIndex: 1)
+
+        let migrated = store.migratingLegacyText(in: legacy)
+
+        let id = try XCTUnwrap(migrated.entries[1].draftID)
+        XCTAssertNil(migrated.entries[1].text)                      // セッションからは本文が消える
+        XCTAssertEqual(store.read(id: id), "旧版の未保存の本文")      // ファイルへ移っている
+        XCTAssertEqual(migrated.entries[0].path, "/tmp/a.txt")      // 保存済みはそのまま
+    }
+
+    // MARK: - restorePlan（起動時に何を開くか）— データ保護の要
+
+    /// 通常の起動：セッションの順どおりに開き、アクティブ位置も引き継ぐ。
+    func testPlanFollowsSessionOrder() {
+        let session = SessionState(entries: [
+            SessionEntry(path: "/tmp/a.txt", draftID: nil, dirty: false, text: nil),
+            SessionEntry(path: nil, draftID: "D1", dirty: true, text: nil),
+        ], activeIndex: 1)
+
+        let plan = SessionState.restorePlan(session: session, draftIDs: ["D1"], hasOpenDocuments: false)
+
+        XCTAssertEqual(plan.items, [.file(path: "/tmp/a.txt"), .draft(id: "D1", dirty: true)])
+        XCTAssertEqual(plan.activeIndex, 1)
+    }
+
+    /// **セッションが無くても、実在する draft は必ず開く。**（初回・設定消去・読み込み失敗）
+    func testPlanWithoutSessionStillRestoresDrafts() {
+        let plan = SessionState.restorePlan(session: nil, draftIDs: ["D1", "D2"], hasOpenDocuments: false)
+        XCTAssertEqual(plan.items, [.draft(id: "D1", dirty: true), .draft(id: "D2", dirty: true)])
+    }
+
+    /// **セッションが別の内容に上書きされていても、draft は必ず開く。**
+    /// これが 1.0 のデータ消失（起動時のオープンがセッションを潰した）の再発防止そのもの。
+    func testPlanRestoresOrphanDraftsWhenSessionWasOverwritten() {
+        // セッションは「small.txt だけ」に潰されている。draft への参照は残っていない。
+        let clobbered = SessionState(entries: [
+            SessionEntry(path: "/tmp/small.txt", draftID: nil, dirty: false, text: nil),
+        ], activeIndex: 0)
+
+        let plan = SessionState.restorePlan(session: clobbered, draftIDs: ["D1"], hasOpenDocuments: false)
+
+        XCTAssertTrue(plan.items.contains(.draft(id: "D1", dirty: true)), "孤児 draft を拾えていない")
+    }
+
+    /// ファイルを開いて起動したとき（Finder / 引数）：前回の保存済みは開き直さないが、
+    /// **未保存の draft は必ず戻す**。
+    func testPlanWithOpenDocumentsKeepsDraftsAndDropsFiles() {
+        let session = SessionState(entries: [
+            SessionEntry(path: "/tmp/a.txt", draftID: nil, dirty: false, text: nil),
+            SessionEntry(path: nil, draftID: "D1", dirty: true, text: nil),
+        ], activeIndex: 0)
+
+        let plan = SessionState.restorePlan(session: session, draftIDs: ["D1"], hasOpenDocuments: true)
+
+        XCTAssertEqual(plan.items, [.draft(id: "D1", dirty: true)])
+    }
+
+    /// 保存済み／破棄済みの draft をセッションが指していても、本文が無いなら開かない（幽霊タブを出さない）。
+    func testPlanDropsSessionEntryWhoseDraftIsGone() {
+        let session = SessionState(entries: [
+            SessionEntry(path: nil, draftID: "GONE", dirty: true, text: nil),
+        ], activeIndex: 0)
+
+        let plan = SessionState.restorePlan(session: session, draftIDs: [], hasOpenDocuments: false)
+
+        XCTAssertTrue(plan.items.isEmpty)
+        XCTAssertEqual(plan.activeIndex, -1)
+    }
+
+    /// **不変条件（総括）：どんなセッションを与えても、実在する draft は 1 つ残らず計画に入る。**
+    func testInvariantEveryExistingDraftIsAlwaysRestored() {
+        let draftIDs = ["D1", "D2", "D3"]
+        let sessions: [SessionState?] = [
+            nil,                                                                     // 無い
+            SessionState(entries: [], activeIndex: -1),                              // 空
+            SessionState(entries: [                                                  // 一部しか知らない
+                SessionEntry(path: nil, draftID: "D2", dirty: false, text: nil),
+            ], activeIndex: 0),
+            SessionState(entries: [                                                  // 別物で上書きされた
+                SessionEntry(path: "/tmp/x.txt", draftID: nil, dirty: false, text: nil),
+            ], activeIndex: 0),
+            SessionState(entries: [                                                  // 存在しない draft を指す
+                SessionEntry(path: nil, draftID: "STALE", dirty: true, text: nil),
+            ], activeIndex: 0),
+        ]
+
+        for session in sessions {
+            for open in [false, true] {
+                let plan = SessionState.restorePlan(session: session, draftIDs: draftIDs, hasOpenDocuments: open)
+                for id in draftIDs {
+                    let restored = plan.items.contains { item in
+                        if case .draft(let i, _) = item { return i == id }
+                        return false
+                    }
+                    XCTAssertTrue(restored, "draft \(id) が復元計画から漏れた（hasOpenDocuments=\(open)）")
+                }
+            }
+        }
+    }
+
+    // MARK: - EditableViewer が draft を持つ
+
+    /// 新規ドキュメントには draft の id が振られる（本文が空のうちはファイルを作らない）。
+    func testNewDocumentGetsDraftIDButNoFileWhileEmpty() {
+        let v = EditableViewer()
+        v.draftStore = store
+        v.newDocument()
+
+        XCTAssertNotNil(v.draftID)
+        v.flushDraft()
+        XCTAssertTrue(store.allIDs().isEmpty, "空の新規でファイルを作ってはいけない")
+    }
+
+    /// 本文があれば flushDraft でディスクに残る（クラッシュしても戻せる状態）。
+    func testFlushDraftWritesBody() {
+        let v = EditableViewer()
+        v.draftStore = store
+        let id = DraftStore.newID()
+        v.restoreDraft(id: id, text: "落ちても残る本文", dirty: true)
+
+        v.flushDraft()
+
+        XCTAssertEqual(store.read(id: id), "落ちても残る本文")
+        XCTAssertEqual(v.draftID, id)
+        XCTAssertTrue(v.isDirty)
+    }
+
+    /// 閉じた（破棄した）ときだけ draft が消える。
+    func testDiscardDraftRemovesFileAndID() {
+        let v = EditableViewer()
+        v.draftStore = store
+        let id = DraftStore.newID()
+        v.restoreDraft(id: id, text: "捨てる本文", dirty: true)
+        v.flushDraft()
+        XCTAssertNotNil(store.read(id: id))
+
+        v.discardDraft()
+
+        XCTAssertNil(store.read(id: id))
+        XCTAssertNil(v.draftID)
+    }
+
+    /// 実ファイルへ保存できたら draft は要らない（消えてよい 2 経路のうちの 1 つ）。
+    func testSavingToFileDiscardsDraft() throws {
+        let v = EditableViewer()
+        v.draftStore = store
+        let id = DraftStore.newID()
+        v.restoreDraft(id: id, text: "保存する本文\n", dirty: true)
+        v.flushDraft()
+        XCTAssertNotNil(store.read(id: id))
+
+        let url = root.appendingPathComponent("saved-\(UUID().uuidString).txt")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        XCTAssertTrue(v._testWrite(to: url))
+
+        XCTAssertNil(store.read(id: id), "保存したのに draft が残っている")
+        XCTAssertNil(v.draftID)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "保存する本文\n")
+    }
+
+    /// 実ファイルを開いたペインは draft を持たない（保存済みの本文を二重に持たない）。
+    func testOpeningFileClearsDraftID() throws {
+        let url = root.appendingPathComponent("open-\(UUID().uuidString).txt")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try "ファイルの中身".data(using: .utf8)!.write(to: url)
+
+        let v = EditableViewer()
+        v.draftStore = store
+        v.newDocument()
+        XCTAssertNotNil(v.draftID)
+
+        XCTAssertTrue(v.open(url: url))
+
+        XCTAssertNil(v.draftID)
+    }
+}

--- a/Tests/MrEditorTests/SessionRestoreTests.swift
+++ b/Tests/MrEditorTests/SessionRestoreTests.swift
@@ -28,11 +28,11 @@ final class SessionRestoreTests: XCTestCase {
     func testMakeSkipsEmptyUntitledAndRemapsActive() {
         let fileA = URL(fileURLWithPath: "/tmp/a.txt")
         let fileB = URL(fileURLWithPath: "/tmp/b.txt")
-        let docs: [(url: URL?, text: String?, dirty: Bool)] = [
-            (fileA, nil, false),          // 0: 保存済み
-            (nil, "", false),             // 1: 空の新規 → スキップ
-            (nil, "メモ", true),           // 2: 未保存の新規（本文あり）← アクティブ
-            (fileB, nil, false),          // 3: 保存済み
+        let docs: [(url: URL?, text: String?, draftID: String?, dirty: Bool)] = [
+            (fileA, nil, nil, false),          // 0: 保存済み
+            (nil, "", "D0", false),            // 1: 空の新規 → スキップ
+            (nil, "メモ", "D1", true),          // 2: 未保存の新規（本文あり）← アクティブ
+            (fileB, nil, nil, false),          // 3: 保存済み
         ]
         let s = SessionState.make(docs: docs, activeIndex: 2)
 
@@ -41,7 +41,8 @@ final class SessionRestoreTests: XCTestCase {
         XCTAssertEqual(s.entries[0].path, fileA.path)
         XCTAssertNil(s.entries[0].text)
         XCTAssertNil(s.entries[1].path)
-        XCTAssertEqual(s.entries[1].text, "メモ")
+        XCTAssertEqual(s.entries[1].draftID, "D1")   // 本文はセッションに入れない（draft ファイルが持つ）
+        XCTAssertNil(s.entries[1].text)
         XCTAssertTrue(s.entries[1].dirty)
         XCTAssertEqual(s.entries[2].path, fileB.path)
 
@@ -51,9 +52,9 @@ final class SessionRestoreTests: XCTestCase {
 
     /// アクティブが空の新規（スキップされる）を指していたら activeIndex は -1。
     func testMakeActiveOnSkippedUntitledBecomesNone() {
-        let docs: [(url: URL?, text: String?, dirty: Bool)] = [
-            (URL(fileURLWithPath: "/tmp/a.txt"), nil, false),
-            (nil, "", false),   // アクティブだがスキップされる
+        let docs: [(url: URL?, text: String?, draftID: String?, dirty: Bool)] = [
+            (URL(fileURLWithPath: "/tmp/a.txt"), nil, nil, false),
+            (nil, "", "D0", false),   // アクティブだがスキップされる
         ]
         let s = SessionState.make(docs: docs, activeIndex: 1)
         XCTAssertEqual(s.entries.count, 1)
@@ -67,48 +68,13 @@ final class SessionRestoreTests: XCTestCase {
         XCTAssertEqual(s.activeIndex, -1)
     }
 
-    // MARK: - entriesToRestore（起動時に何を復元するか）
-
-    /// 通常起動（ファイルを開かずに起動）なら全部復元する。
-    func testEntriesToRestoreWithoutOpenDocumentsRestoresAll() {
-        let s = SessionState(entries: [
-            SessionEntry(path: "/tmp/a.txt", text: nil, dirty: false),
-            SessionEntry(path: nil, text: "メモ", dirty: true),
-        ], activeIndex: 0)
-        XCTAssertEqual(s.entriesToRestore(hasOpenDocuments: false).count, 2)
-    }
-
-    /// 引数や Finder からファイルを開いて起動したときは、保存済みは開き直さないが
-    /// **未保存の新規は必ず復元する**（開いたファイルに前回のセッションを潰させない）。
-    func testEntriesToRestoreWithOpenDocumentsKeepsOnlyUntitled() {
-        let s = SessionState(entries: [
-            SessionEntry(path: "/tmp/a.txt", text: nil, dirty: false),
-            SessionEntry(path: nil, text: "未保存の下書き", dirty: true),
-            SessionEntry(path: "/tmp/b.txt", text: nil, dirty: false),
-        ], activeIndex: 0)
-
-        let restored = s.entriesToRestore(hasOpenDocuments: true)
-        XCTAssertEqual(restored.count, 1)
-        XCTAssertNil(restored[0].path)
-        XCTAssertEqual(restored[0].text, "未保存の下書き")
-        XCTAssertTrue(restored[0].dirty)
-    }
-
-    /// 未保存の新規が無ければ、ファイルを開いての起動では何も復元しない。
-    func testEntriesToRestoreWithOpenDocumentsAndNoUntitledIsEmpty() {
-        let s = SessionState(entries: [
-            SessionEntry(path: "/tmp/a.txt", text: nil, dirty: false),
-        ], activeIndex: 0)
-        XCTAssertTrue(s.entriesToRestore(hasOpenDocuments: true).isEmpty)
-    }
-
     // MARK: - AppSettings.session（UserDefaults 永続化往復）
 
     /// 保存済み＋未保存の新規（本文つき）を UserDefaults へ書いて読み戻せる。
     func testAppSettingsSessionPersistRoundTrip() {
         let state = SessionState(entries: [
-            SessionEntry(path: "/tmp/x.log", text: nil, dirty: false),
-            SessionEntry(path: nil, text: "未保存の本文\n2行目", dirty: true),
+            SessionEntry(path: "/tmp/x.log", draftID: nil, dirty: false, text: nil),
+            SessionEntry(path: nil, draftID: "D9", dirty: true, text: nil),
         ], activeIndex: 1)
 
         AppSettings.session = state
@@ -116,14 +82,14 @@ final class SessionRestoreTests: XCTestCase {
         XCTAssertNotNil(read)
         XCTAssertEqual(read?.entries.count, 2)
         XCTAssertEqual(read?.entries[0].path, "/tmp/x.log")
-        XCTAssertEqual(read?.entries[1].text, "未保存の本文\n2行目")
+        XCTAssertEqual(read?.entries[1].draftID, "D9")
         XCTAssertEqual(read?.entries[1].dirty, true)
         XCTAssertEqual(read?.activeIndex, 1)
     }
 
     /// nil を代入すると保存が消える（＝次回は復元しない）。
     func testAppSettingsSessionClear() {
-        AppSettings.session = SessionState(entries: [SessionEntry(path: "/tmp/x", text: nil, dirty: false)], activeIndex: 0)
+        AppSettings.session = SessionState(entries: [SessionEntry(path: "/tmp/x", draftID: nil, dirty: false, text: nil)], activeIndex: 0)
         XCTAssertNotNil(AppSettings.session)
         AppSettings.session = nil
         XCTAssertNil(AppSettings.session)


### PR DESCRIPTION
1.0 のデータ消失（#19 / v1.0.1 で修正）は**器の設計を変えずに順序だけ直した**もので、同じ根から生えた穴が残っていた：**未保存の本文は終了時にしか書かれないため、`kill -9` で全部消える**（実測で確認）。

## 根はひとつ

二度と戻せない**本文**の唯一の写しを、壊れても作り直せる**索引**（開いていた一覧）と同じ 1 個の UserDefaults キーに入れ、毎回まるごと書き直していた。そこから 3 つの脆さが出ていた — **上書き**（#19 のバグ）・**終了時のみ**（クラッシュで消える）・**同居**。

## 本文を器から出す

- **`DraftStore`** — `~/Library/Application Support/MrEditor/Drafts/<id>.txt` に **1 未保存ドキュメント = 1 ファイル**で atomic 書き込み。セッションは **id を指すだけ**で本文を持たない
- **起動時はセッションではなく Drafts ディレクトリを真実として読む。** 索引に載っていない孤児 draft も必ず開く（`SessionState.restorePlan`）。セッションが nil でも・壊れていても・別の内容で上書きされていても、未保存の本文は戻る
- 打鍵のたびにデバウンス（1 秒）して書き、**非アクティブ化・ウィンドウを閉じる・終了**の直前にも書き出す。クラッシュしても直前まで残る
- **draft が消える経路は 2 つだけ**：実ファイルへの保存に成功した／ユーザーがドキュメントを閉じた。**セッションの書き出しからは決して消さない**
- 旧版（〜1.0.1）のセッションが持つ本文は、起動時に draft ファイルへ**移行**する（更新で取りこぼさない）

## 不変条件をテストの壁にした

> **どんなセッション（nil・空・一部欠落・別物で上書き・存在しない draft を参照）を与えても、実在する draft は 1 つ残らず復元計画に入る。**

`testInvariantEveryExistingDraftIsAlwaysRestored` がこれを固定する。#19 のバグは、この不変条件の下では起こしようがない。

## 実機（`.app`）での確認

| やったこと | 結果 |
|---|---|
| 入力 → `kill -9` → 再起動 | **セッションは空（`entries: []`）のまま、本文が未保存印つきで復活** |
| Finder の「このアプリで開く」（draft あり） | draft が戻り、開いたファイルがアクティブ |
| 1.0.1 の旧形式セッション（本文が中にある）で起動 | draft ファイルへ移行され、セッションは id 参照だけになる |
| 閉じる →「保存しない」 | draft ファイルが消える（0 件） |
| 空の新規タブ | draft ファイルを作らない（ゴミを残さない） |

126 tests green（+14）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)