### PR TITLE
リリース 1.0.3: 日本語入力の行ジャンプ修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,7 +117,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-配布用ディスクイメージ（`.build/MrEditor-1.0.2.dmg`）の作成:
+配布用ディスクイメージ（`.build/MrEditor-1.0.3.dmg`）の作成:
 
 ```sh
 sh scripts/make_dmg.sh
@@ -164,7 +164,8 @@ vmmap $(pgrep -x MrEditor) | grep test_10gb.log     # → 10.0G  4.2G  0K  (vsiz
 - **v0.9 — Apple Developer ID で署名し、公証（notarization）を通した。右クリック不要でダブルクリックで開ける** ✅
 - **1.0 — 巨大ファイルを開いて編集できる Mac エディタとして完成。署名・公証済みで、ダブルクリックで開く** ✅
 - **1.0.1 — ファイルを開いて起動すると未保存の新規ドキュメントが消えるバグを修正（データ消失）** ✅
-- **1.0.2 — 未保存の本文を draft ファイルとして守る（打鍵のたびに保存。クラッシュ・強制終了でも失わない）** ✅（このリリース）
+- **1.0.2 — 未保存の本文を draft ファイルとして守る（打鍵のたびに保存。クラッシュ・強制終了でも失わない）** ✅
+- **1.0.3 — 日本語入力ONのとき、行ジャンプ（⌘L）が黙って失敗するバグを修正** ✅（このリリース）
 - **以降** — シンタックス/ログのハイライト、その他の分析ツール
 
 > **⚠️ v0.7 以前の dmg は、ダウンロードした Mac で起動しません。**

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ python3 scripts/gen_testdata.py --encoding-set --out-dir testdata/   # UTF-8 / S
 python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 ```
 
-Build a distributable disk image (`.build/MrEditor-1.0.2.dmg`):
+Build a distributable disk image (`.build/MrEditor-1.0.3.dmg`):
 
 ```sh
 sh scripts/make_dmg.sh
@@ -166,7 +166,8 @@ vmmap $(pgrep -x MrEditor) | grep test_10gb.log     # → 10.0G  4.2G  0K  (vsiz
 - **v0.9 — signed with an Apple Developer ID and notarized by Apple; opens with a plain double-click** ✅
 - **1.0 — the milestone: open and edit 10 GB files on a Mac, signed and notarized, opens with a double-click** ✅
 - **1.0.1 — fixes data loss: an unsaved new document vanished when the app was launched by opening a file** ✅
-- **1.0.2 — unsaved text is kept as its own draft file, written as you type: it survives a crash or force quit** ✅ (this release)
+- **1.0.2 — unsaved text is kept as its own draft file, written as you type: it survives a crash or force quit** ✅
+- **1.0.3 — Go to line (⌘L) no longer fails silently when a Japanese IME is active** ✅ (this release)
 - **later** — syntax/log highlighting, and more analysis tooling
 
 > **⚠️ Builds up to v0.7 do not launch on a Mac that downloaded them.**

--- a/Sources/MrEditor/AppInfo.swift
+++ b/Sources/MrEditor/AppInfo.swift
@@ -15,7 +15,7 @@ enum AppInfo {
     static var version: String {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? fallbackVersion
     }
-    private static let fallbackVersion = "1.0.2"
+    private static let fallbackVersion = "1.0.3"
 
     /// ヘルプメニューから開くプロジェクトページ。
     static let helpURL = URL(string: "https://github.com/MR-TABATA/MrEditor")!

--- a/scripts/make_app.sh
+++ b/scripts/make_app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-debug}"
 APP_NAME="${APP_NAME:-MrEditor}"
 BUNDLE_ID="${BUNDLE_ID:-com.aaedit.MrEditor}"
 # バージョン（Info.plist へ埋め込む）。make_dmg.sh と揃えるため VERSION で上書き可能。
-VERSION="${VERSION:-1.0.2}"
+VERSION="${VERSION:-1.0.3}"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # 成果物の置き場所。universal ビルド（--arch arm64 --arch x86_64）では

--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -24,7 +24,7 @@ set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="${APP_NAME:-MrEditor}"
-VERSION="${VERSION:-1.0.2}"
+VERSION="${VERSION:-1.0.3}"
 APP="$ROOT/.build/$APP_NAME.app"
 DMG="$ROOT/.build/$APP_NAME-$VERSION.dmg"
 

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -125,11 +125,11 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v1.0.2 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0.3 · MIT</span>
       <h1>86,420,337 lines.<br><span class='teal'>Open in 80 milliseconds.</span></h1>
       <p class="lede">That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds none of it — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes.</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.2/MrEditor-1.0.2.dmg">↓ Download .dmg</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.3/MrEditor-1.0.3.dmg">↓ Download .dmg</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">View source</a>
       </div>
       <p class="note">Signed with an Apple Developer ID and notarized by Apple — just double-click it. Universal (Apple Silicon &amp; Intel).</p>

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -125,11 +125,11 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v1.0.2 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0.3 · MIT</span>
       <h1>86,420,337 行。<br><span class='teal'>開くのに 80 ミリ秒。</span></h1>
       <p class="lede">10&nbsp;GB のログです。開いたまま一日使っても、本文は 1 バイトも抱えません。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。</p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.2/MrEditor-1.0.2.dmg">↓ .dmg をダウンロード</a>
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.3/MrEditor-1.0.3.dmg">↓ .dmg をダウンロード</a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener">ソースを見る</a>
       </div>
       <p class="note">Apple Developer ID で署名し、Apple の公証を通しています。ダブルクリックするだけで開きます。Apple Silicon / Intel 両対応。</p>

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -128,14 +128,14 @@
 
   <header class="hero">
     <div>
-      <span class="badge">macOS 13+ · v1.0.2 · MIT</span>
+      <span class="badge">macOS 13+ · v1.0.3 · MIT</span>
       <h1 data-en="86,420,337 lines.<br><span class='teal'>Open in 80 milliseconds.</span>"
           data-ja="86,420,337 行。<br><span class='teal'>開くのに 80 ミリ秒。</span>"></h1>
       <p class="lede"
          data-en="That is a 10&nbsp;GB log. Keep it open all day and MrEditor holds none of it — it reads and draws only the lines you can see. Since v0.4 you can edit and save it in place, with atomic writes."
          data-ja="10&nbsp;GB のログです。開いたまま一日使っても、本文は 1 バイトも抱えません。見えている行しか読まず、描かないからです。v0.4 からは、その場で編集して atomic に保存できます。"></p>
       <div class="cta">
-        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.2/MrEditor-1.0.2.dmg"
+        <a class="btn btn-primary" href="https://github.com/MR-TABATA/MrEditor/releases/download/v1.0.3/MrEditor-1.0.3.dmg"
            data-en="↓ Download .dmg" data-ja="↓ .dmg をダウンロード"></a>
         <a class="btn btn-ghost" href="https://github.com/MR-TABATA/MrEditor" target="_blank" rel="noopener"
            data-en="View source" data-ja="ソースを見る"></a>


### PR DESCRIPTION
[#23](https://github.com/MR-TABATA/MrEditor/pull/23) で直した「日本語入力ONだと ⌘L の行ジャンプが黙って失敗する」バグを、配布物として出す。

- VERSION（`make_app.sh` / `make_dmg.sh`）と `AppInfo.fallbackVersion` を 1.0.3 へ
- README（日英）のリリース一覧・LP のバッジと DL リンクを 1.0.3 へ
- dmg は署名・公証・staple 済み（`spctl` = `source=Notarized Developer ID`）

**配布物で検証済み**: 公証済み dmg 内の .app を起動し、日本語入力を有効にしたまま
⌘L → 数字（IME を通って全角になる）→ Return → Return で、86,420,337 行目へ跳ぶことを確認。

133 tests green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)