### PR TITLE
ローカル diff（並べて比較・行内差分・入口3つ）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(swift test *)"
+    ]
+  }
+}

--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -126,6 +126,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @objc private func performZoomOut(_ sender: Any?) { windowController?.zoomOut() }
     @objc private func performZoomReset(_ sender: Any?) { windowController?.zoomReset() }
 
+    // 比較（diff）。3 つの入口とも windowController が同じ DiffViewer へ流す。
+    @objc private func compareFiles(_ sender: Any?)         { windowController?.compareFiles() }
+    @objc private func compareOpenDocuments(_ sender: Any?) { windowController?.compareOpenDocuments() }
+    @objc private func compareWithClipboard(_ sender: Any?) { windowController?.compareWithClipboard() }
+    @objc private func nextDifference(_ sender: Any?)       { windowController?.activeDiffViewer?.nextHunk() }
+    @objc private func previousDifference(_ sender: Any?)   { windowController?.activeDiffViewer?.previousHunk() }
+
     @objc private func setStructuredMode(_ sender: NSMenuItem) {
         let modes = StructuredMode.allCases
         let mode: StructuredMode? = (sender.tag >= 0 && sender.tag < modes.count) ? modes[sender.tag] : nil
@@ -410,6 +417,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let structItem = NSMenuItem(title: L("menu.structured"), action: nil, keyEquivalent: "")
         structItem.submenu = structMenu
         viewMenu.addItem(structItem)
+
+        // 比較（diff）。入口は 3 つあるが、行き先は同じ DiffViewer。
+        viewMenu.addItem(.separator())
+        let diffMenu = NSMenu(title: L("menu.compare"))
+        let cmpFiles = NSMenuItem(title: L("menu.compare.files"),
+                                  action: #selector(compareFiles(_:)), keyEquivalent: "d")
+        cmpFiles.keyEquivalentModifierMask = [.command, .shift]
+        cmpFiles.target = self
+        diffMenu.addItem(cmpFiles)
+        let cmpOpen = NSMenuItem(title: L("menu.compare.openDocs"),
+                                 action: #selector(compareOpenDocuments(_:)), keyEquivalent: "")
+        cmpOpen.target = self
+        diffMenu.addItem(cmpOpen)
+        let cmpClip = NSMenuItem(title: L("menu.compare.clipboard"),
+                                 action: #selector(compareWithClipboard(_:)), keyEquivalent: "")
+        cmpClip.target = self
+        diffMenu.addItem(cmpClip)
+        diffMenu.addItem(.separator())
+        let nextHunk = NSMenuItem(title: L("menu.compare.next"),
+                                  action: #selector(nextDifference(_:)), keyEquivalent: "]")
+        nextHunk.keyEquivalentModifierMask = [.command, .shift]
+        nextHunk.target = self
+        diffMenu.addItem(nextHunk)
+        let prevHunk = NSMenuItem(title: L("menu.compare.previous"),
+                                  action: #selector(previousDifference(_:)), keyEquivalent: "[")
+        prevHunk.keyEquivalentModifierMask = [.command, .shift]
+        prevHunk.target = self
+        diffMenu.addItem(prevHunk)
+        let diffItem = NSMenuItem(title: L("menu.compare"), action: nil, keyEquivalent: "")
+        diffItem.submenu = diffMenu
+        viewMenu.addItem(diffItem)
 
         // ウインドウメニュー（Minimize / Zoom ＋ 開いているウィンドウ一覧を AppKit が自動追記）
         let windowMenuItem = NSMenuItem()

--- a/Sources/MrEditor/Core/CharDiff.swift
+++ b/Sources/MrEditor/Core/CharDiff.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// 変更行の「行内のどこが変わったか」。
+///
+/// ログの 1 文字違い（status=200 → status=500、latency=42ms → 43ms）を見つけるのが本命なので、
+/// 行を赤く塗るだけでは足りない。**変更行に限って**文字単位で差分を取る。
+///
+/// 対象は画面に出ている変更行だけ（数十行）なので、素朴な DP で足りる。
+/// 長すぎる行は諦めて行全体を変更扱いにする（1 行 10 万文字の DP を回すほうが害）。
+enum CharDiff {
+
+    /// この長さを超える行は、行内差分を取らない（左右とも丸ごと変更として塗る）。
+    static let maxLineLength = 2_000
+
+    /// 左右の行を比べ、**左で消えた範囲**と**右で足された範囲**を返す。
+    /// 範囲は Character 単位（絵文字や結合文字を割らない）。
+    static func ranges(left: String, right: String) -> (left: [Range<Int>], right: [Range<Int>]) {
+        let a = Array(left), b = Array(right)
+        if a.count > maxLineLength || b.count > maxLineLength {
+            return (a.isEmpty ? [] : [0..<a.count], b.isEmpty ? [] : [0..<b.count])
+        }
+
+        // 共通の先頭・末尾を落とす。ログの行は大半が共通なので、これだけで DP がほぼ消える。
+        var p = 0
+        while p < a.count && p < b.count && a[p] == b[p] { p += 1 }
+        var s = 0
+        while s < a.count - p && s < b.count - p && a[a.count - 1 - s] == b[b.count - 1 - s] { s += 1 }
+
+        let aMid = Array(a[p..<(a.count - s)])
+        let bMid = Array(b[p..<(b.count - s)])
+        if aMid.isEmpty && bMid.isEmpty { return ([], []) }
+        if aMid.isEmpty { return ([], [p..<(p + bMid.count)]) }
+        if bMid.isEmpty { return ([p..<(p + aMid.count)], []) }
+
+        // 中央だけ LCS。
+        let n = aMid.count, m = bMid.count
+        var dp = [[Int]](repeating: [Int](repeating: 0, count: m + 1), count: n + 1)
+        for i in stride(from: n - 1, through: 0, by: -1) {
+            for j in stride(from: m - 1, through: 0, by: -1) {
+                dp[i][j] = aMid[i] == bMid[j] ? dp[i + 1][j + 1] + 1
+                                              : max(dp[i + 1][j], dp[i][j + 1])
+            }
+        }
+
+        var lOut: [Range<Int>] = [], rOut: [Range<Int>] = []
+        var i = 0, j = 0
+        var lRun: Int? = nil, rRun: Int? = nil
+        func closeL(_ end: Int) { if let s0 = lRun { lOut.append((p + s0)..<(p + end)); lRun = nil } }
+        func closeR(_ end: Int) { if let s0 = rRun { rOut.append((p + s0)..<(p + end)); rRun = nil } }
+
+        while i < n && j < m {
+            if aMid[i] == bMid[j] {
+                closeL(i); closeR(j)
+                i += 1; j += 1
+            } else if dp[i + 1][j] >= dp[i][j + 1] {
+                if lRun == nil { lRun = i }
+                i += 1
+            } else {
+                if rRun == nil { rRun = j }
+                j += 1
+            }
+        }
+        closeL(i); closeR(j)
+        if i < n { lOut.append((p + i)..<(p + n)) }
+        if j < m { rOut.append((p + j)..<(p + m)) }
+        return (lOut, rOut)
+    }
+}

--- a/Sources/MrEditor/Core/DiffModel.swift
+++ b/Sources/MrEditor/Core/DiffModel.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// 並べて見るときの 1 行（左右のどちらか、または両方）。
+struct DiffRow {
+    enum Kind { case equal, delete, insert, replace }
+    let kind: Kind
+    /// 左ファイルの行番号（0 始まり）。右にしか無い行では nil＝左は空白で埋める。
+    let left: Int?
+    /// 右ファイルの行番号（0 始まり）。左にしか無い行では nil。
+    let right: Int?
+}
+
+/// diff の表示モデル。
+///
+/// **行を実体化しない。** 8,600 万行の diff で `[DiffRow]` を作ると、それだけで 1GB を超えて
+/// 「本文は抱えない」という設計と矛盾する。持つのは差分の手（ops）とその累積行数だけで、
+/// 画面に出る行だけを二分探索でその場に組み立てる。ops の数は差分の塊の数なので、たかが知れている。
+struct DiffModel {
+    let ops: [DiffOp]
+    /// ops[i] までの累積表示行数。二分探索用。
+    private let cumulative: [Int]
+    /// 並べたときの総行数。
+    let rowCount: Int
+    /// 差分の塊の先頭行（「次の差分へ」で飛ぶ先）。
+    let hunkStarts: [Int]
+
+    init(ops: [DiffOp]) {
+        self.ops = ops
+        var cum: [Int] = []
+        var hunks: [Int] = []
+        var total = 0
+        var prevWasDiff = false
+        cum.reserveCapacity(ops.count)
+        for op in ops {
+            let isDiff: Bool
+            let rows: Int
+            switch op {
+            case let .equal(_, _, c):                       rows = c; isDiff = false
+            case let .delete(_, c):                         rows = c; isDiff = true
+            case let .insert(_, c):                         rows = c; isDiff = true
+            case let .replace(_, lc, _, rc):                rows = max(lc, rc); isDiff = true
+            }
+            if isDiff && !prevWasDiff { hunks.append(total) }
+            prevWasDiff = isDiff
+            total += rows
+            cum.append(total)
+        }
+        self.cumulative = cum
+        self.rowCount = total
+        self.hunkStarts = hunks
+    }
+
+    var isIdentical: Bool { ops.count == 1 && ops.first.map { if case .equal = $0 { return true } else { return false } } == true }
+
+    /// 差分のある行数（変更・追加・削除の合計。ステータス表示用）。
+    var changedRowCount: Int {
+        ops.reduce(0) { acc, op in
+            switch op {
+            case .equal: return acc
+            case let .delete(_, c): return acc + c
+            case let .insert(_, c): return acc + c
+            case let .replace(_, lc, _, rc): return acc + max(lc, rc)
+            }
+        }
+    }
+
+    /// 表示行 row が、左右のどの行に当たるか。O(log ops)。
+    func row(at row: Int) -> DiffRow? {
+        guard row >= 0, row < rowCount else { return nil }
+        // cumulative は単調増加。row < cumulative[i] となる最小の i を探す。
+        var lo = 0, hi = cumulative.count - 1
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if cumulative[mid] <= row { lo = mid + 1 } else { hi = mid }
+        }
+        let base = lo == 0 ? 0 : cumulative[lo - 1]
+        let offset = row - base
+        switch ops[lo] {
+        case let .equal(l, r, _):
+            return DiffRow(kind: .equal, left: l + offset, right: r + offset)
+        case let .delete(l, _):
+            return DiffRow(kind: .delete, left: l + offset, right: nil)
+        case let .insert(r, _):
+            return DiffRow(kind: .insert, left: nil, right: r + offset)
+        case let .replace(l, lc, r, rc):
+            return DiffRow(kind: .replace,
+                           left: offset < lc ? l + offset : nil,
+                           right: offset < rc ? r + offset : nil)
+        }
+    }
+
+    /// row 以降で最初の差分の先頭。無ければ nil。
+    func nextHunk(after row: Int) -> Int? { hunkStarts.first { $0 > row } }
+    /// row より前で最後の差分の先頭。
+    func previousHunk(before row: Int) -> Int? { hunkStarts.last { $0 < row } }
+}

--- a/Sources/MrEditor/Core/DiffModel.swift
+++ b/Sources/MrEditor/Core/DiffModel.swift
@@ -111,6 +111,27 @@ struct DiffModel {
         return out
     }
 
+    /// 選択範囲の本文を組む（コピー用）。
+    ///
+    /// `line(row)` は「その列のその行の文字列。相手側にしか無い行（画面では空白で埋めている行）
+    /// なら nil」を返す。**埋め草の行は飛ばす** —— 存在しない行をコピーして空行を混ぜたら、
+    /// 貼り付け先で嘘になる。
+    func selectedText(from start: (row: Int, idx: Int),
+                      to end: (row: Int, idx: Int),
+                      line: (Int) -> String?) -> String {
+        guard start.row <= end.row, start.row >= 0, end.row < rowCount else { return "" }
+        var parts: [String] = []
+        for row in start.row...end.row {
+            guard let text = line(row) else { continue }      // 埋め草は飛ばす
+            let u = Array(text.utf16)
+            let from = (row == start.row) ? min(max(0, start.idx), u.count) : 0
+            let to   = (row == end.row)   ? min(max(0, end.idx), u.count)   : u.count
+            guard from <= to else { continue }
+            parts.append(String(utf16CodeUnits: Array(u[from..<to]), count: to - from))
+        }
+        return parts.joined(separator: "\n")
+    }
+
     /// row 以降で最初の差分の先頭。無ければ nil。
     func nextHunk(after row: Int) -> Int? { hunkStarts.first { $0 > row } }
     /// row より前で最後の差分の先頭。

--- a/Sources/MrEditor/Core/DiffModel.swift
+++ b/Sources/MrEditor/Core/DiffModel.swift
@@ -89,6 +89,28 @@ struct DiffModel {
         }
     }
 
+    /// スクロールバーに描くための、差分の位置（0...1）と種類。
+    /// 差分が数十万箇所ある場合に全部描いても潰れるだけなので、上限で間引く。
+    func markers(limit: Int = 600) -> [(position: Double, kind: DiffRow.Kind)] {
+        guard rowCount > 0 else { return [] }
+        var out: [(Double, DiffRow.Kind)] = []
+        var acc = 0
+        var diffs: [(Int, DiffRow.Kind)] = []
+        for op in ops {
+            switch op {
+            case let .equal(_, _, c):        acc += c
+            case let .delete(_, c):          diffs.append((acc, .delete)); acc += c
+            case let .insert(_, c):          diffs.append((acc, .insert)); acc += c
+            case let .replace(_, lc, _, rc): diffs.append((acc, .replace)); acc += max(lc, rc)
+            }
+        }
+        let step = max(1, diffs.count / limit)
+        for i in Swift.stride(from: 0, to: diffs.count, by: step) {
+            out.append((Double(diffs[i].0) / Double(rowCount), diffs[i].1))
+        }
+        return out
+    }
+
     /// row 以降で最初の差分の先頭。無ければ nil。
     func nextHunk(after row: Int) -> Int? { hunkStarts.first { $0 > row } }
     /// row より前で最後の差分の先頭。

--- a/Sources/MrEditor/Core/DiffSource.swift
+++ b/Sources/MrEditor/Core/DiffSource.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// diff に食わせる「行の列」。
+///
+/// これを 1 枚かませることで、入口が 3 つ（2 ファイルを選ぶ／開いているタブ同士／
+/// クリップボード）あってもコアは 1 本で済む。ファイルは mmap のまま、クリップボードは
+/// メモリ上の文字列のまま、同じ口に流れる。
+protocol DiffSource {
+    /// 表示名（タブ名・見出し用）。
+    var displayName: String { get }
+    /// 行数。
+    var lineCount: Int { get }
+    /// 行のハッシュ列（全行分）。diff の入力。
+    func lineHashes() -> [LineHash]
+    /// i 行目の中身。**可視行の描画にしか呼ばれない**（全行を文字列化してはいけない）。
+    func line(at index: Int) -> String
+}
+
+// MARK: - ハッシュ
+
+/// バイト列を 128 ビットにする。FNV-1a を 2 本、別の基底で回す。
+/// 衝突すると diff が差分を見落とすので、ここをケチらない（[[LineHash]] の説明を参照）。
+struct LineHasher {
+    private var a: UInt64 = 0xcbf29ce484222325
+    private var b: UInt64 = 0x9e3779b97f4a7c15
+
+    mutating func feed(_ byte: UInt8) {
+        a = (a ^ UInt64(byte)) &* 0x100000001b3
+        b = (b ^ UInt64(byte)) &* 0xff51afd7ed558ccd
+    }
+    var value: LineHash { LineHash(a: a, b: b) }
+
+    /// 生バイト列を 0x0A で切って、行ごとのハッシュにする。行末の 0x0D は落とす
+    /// （CRLF と LF の違いだけで「全行が違う」と言わないため）。
+    static func hashLines(_ buf: UnsafeRawBufferPointer) -> [LineHash] {
+        var out: [LineHash] = []
+        out.reserveCapacity(max(16, buf.count / 64))
+        guard let base = buf.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return out }
+        var h = LineHasher()
+        var pending = false          // 現在の行に 1 バイトでも入ったか（末尾の空行判定用）
+        var prevCR = false
+        for i in 0..<buf.count {
+            let c = base[i]
+            if c == 0x0A {
+                out.append(h.value)
+                h = LineHasher()
+                pending = false
+                prevCR = false
+            } else {
+                if prevCR { h.feed(0x0D) }        // CR の次が LF 以外なら本物の CR として食わせる
+                if c == 0x0D { prevCR = true; pending = true; continue }
+                prevCR = false
+                h.feed(c)
+                pending = true
+            }
+        }
+        if pending || buf.count == 0 { out.append(h.value) }
+        return out
+    }
+}
+
+// MARK: - ファイル（mmap のまま）
+
+/// ファイルを mmap して行を供給する。行の中身は要求されたときだけ読む。
+final class FileDiffSource: DiffSource {
+    let displayName: String
+    private let buffer: FileBuffer
+    private let index: LineIndex
+    private let encoding: DetectedEncoding
+
+    /// **メインスレッドから呼んではいけない。** 索引を作り切るまで戻らない（10GB で約 9 秒）。
+    /// `LineIndex` の完了通知はメインスレッドへ回されるので、メインで待つと即デッドロックする。
+    init?(url: URL) {
+        precondition(!Thread.isMainThread, "FileDiffSource はメインスレッドで作らない（索引の完了待ちで固まる）")
+        guard let buffer = FileBuffer(url: url) else { return nil }
+        self.buffer = buffer
+        self.displayName = url.lastPathComponent
+        // 判定は先頭だけ見れば足りる（10GB 全部を Data に起こしたら本末転倒）。
+        let head = buffer.data(in: 0..<min(buffer.count, 64 << 10))
+        self.encoding = EncodingDetector.detect(head)
+        self.index = LineIndex(buffer: buffer)
+        // 行の中身を引くのに疎索引が要る。diff は全行を触るので、ここで作り切る。
+        let done = DispatchSemaphore(value: 0)
+        index.buildInBackground(progress: { _ in }, completion: { done.signal() })
+        done.wait()
+    }
+
+    var lineCount: Int { index.displayLineCount }
+
+    func lineHashes() -> [LineHash] {
+        buffer.withBytes(in: 0..<buffer.count) { LineHasher.hashLines($0) }
+    }
+
+    func line(at i: Int) -> String {
+        guard i >= 0, i < lineCount else { return "" }
+        let start = index.byteOffset(ofLineStart: i)
+        let end = (i + 1 < lineCount) ? index.byteOffset(ofLineStart: i + 1) : buffer.count
+        guard end > start else { return "" }
+        let data = buffer.data(in: start..<end)
+        let text = String(data: data, encoding: encoding.stringEncoding)
+            ?? String(decoding: data, as: UTF8.self)
+        return text.trimmingCharacters(in: CharacterSet(charactersIn: "\r\n"))
+    }
+}
+
+// MARK: - メモリ上のテキスト（クリップボード・未保存のタブ）
+
+/// 文字列を行に切って供給する。クリップボード比較と、未保存タブの比較に使う。
+final class TextDiffSource: DiffSource {
+    let displayName: String
+    private let lines: [String]
+
+    init(text: String, displayName: String) {
+        self.displayName = displayName
+        // 末尾の改行 1 個は「行」を増やさない（ファイル側の扱いと揃える）。
+        var t = text
+        if t.hasSuffix("\r\n") { t.removeLast(2) } else if t.hasSuffix("\n") { t.removeLast() }
+        self.lines = t.isEmpty ? [""] : t.components(separatedBy: .newlines)
+    }
+
+    var lineCount: Int { lines.count }
+
+    func lineHashes() -> [LineHash] {
+        lines.map { line in
+            var h = LineHasher()
+            for b in line.utf8 { h.feed(b) }
+            return h.value
+        }
+    }
+
+    func line(at i: Int) -> String { (i >= 0 && i < lines.count) ? lines[i] : "" }
+}
+
+// MARK: - メモリ予算
+
+/// diff が積む索引は **1 行 16 バイト**（128 ビットのハッシュ）。閲覧と違い、これは
+/// 本当にアプリが抱えるメモリなので、機械に載るかを先に確かめる。
+///
+/// 固定の行数上限にしないのは、8GB の MacBook Air と 64GB の Mac Studio で
+/// 同じ操作が片方だけ死ぬのが最悪だから。**積んでいる RAM から予算を決める。**
+enum DiffBudget {
+
+    /// 物理メモリのうち diff に使ってよい割合。
+    /// ハッシュ列（16B/行 × 2 ファイル）に加え、アンカー探索の出現表が同程度乗るため、
+    /// 見積もりは実測の 2.5 倍を見ておく。
+    static let fraction = 0.25
+    static let overheadFactor = 2.5
+
+    static func estimatedBytes(leftLines: Int, rightLines: Int) -> Int {
+        Int(Double((leftLines + rightLines) * MemoryLayout<LineHash>.size) * overheadFactor)
+    }
+
+    static var allowedBytes: Int {
+        Int(Double(ProcessInfo.processInfo.physicalMemory) * fraction)
+    }
+
+    /// 収まるか。収まらないなら、黙って落ちるのではなく理由を出して断る。
+    static func fits(leftLines: Int, rightLines: Int) -> Bool {
+        estimatedBytes(leftLines: leftLines, rightLines: rightLines) <= allowedBytes
+    }
+
+    static func describe(leftLines: Int, rightLines: Int) -> String {
+        let needMB = Double(estimatedBytes(leftLines: leftLines, rightLines: rightLines)) / 1_048_576
+        let haveMB = Double(allowedBytes) / 1_048_576
+        return String(format: "%.0f 行の比較には約 %.0f MB 必要ですが、この Mac で diff に使える上限は約 %.0f MB です。",
+                      Double(leftLines + rightLines), needMB, haveMB)
+    }
+}

--- a/Sources/MrEditor/Core/LineDiff.swift
+++ b/Sources/MrEditor/Core/LineDiff.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+/// 行のハッシュ。**128 ビット**にしてある。
+///
+/// 64 ビットだと 8,600 万行で誕生日衝突が 10^-4 オーダーに乗る。diff で衝突が起きると
+/// 「違う行を同じと言う」＝**黙って差分を見落とす**ことになり、閲覧側の「落とさない」より
+/// たちが悪い。16 バイト/行のコストを払って潰す（10GB・86,420,337 行で 1.4GB）。
+struct LineHash: Hashable {
+    let a: UInt64
+    let b: UInt64
+}
+
+/// diff の 1 手。行の範囲で表す。
+enum DiffOp: Equatable {
+    /// 両方に同じ行が count 行続く。
+    case equal(left: Int, right: Int, count: Int)
+    /// 左にしかない（削除）。
+    case delete(left: Int, count: Int)
+    /// 右にしかない（追加）。
+    case insert(right: Int, count: Int)
+    /// 置き換え（左の一塊が右の一塊になった）。行内差分はこのブロックの中で取る。
+    case replace(left: Int, leftCount: Int, right: Int, rightCount: Int)
+}
+
+/// 行単位の diff。
+///
+/// **patience diff**（両側で 1 回しか出てこない行＝アンカーを見つけ、その間を再帰）を採る。
+/// 巨大なログで Myers を素直に回すと O(ND) が破裂するが、patience は
+///   - 共通の先頭・末尾を落とす（ログは大抵ここで大半が消える）
+///   - アンカー間の小さな区間だけを詳しく見る
+/// ので、メモリも時間も行数に対してほぼ線形に収まる。
+///
+/// アンカーが 1 つも無い区間（全行が重複だらけ、等）は、区間が小さければ Myers、
+/// 大きければ丸ごと replace として畳む（**嘘をつかず、諦めたことが分かる形**にする）。
+enum LineDiff {
+
+    /// アンカーが無い区間に Myers を回してよい上限（左右の行数の積）。
+    /// これを超えたら 1 個の replace に畳む。
+    static let myersCellBudget = 4_000_000
+
+    static func compute(_ left: [LineHash], _ right: [LineHash]) -> [DiffOp] {
+        var ops: [DiffOp] = []
+        diff(left, right, 0..<left.count, 0..<right.count, into: &ops)
+        return coalesce(ops)
+    }
+
+    // MARK: - 本体
+
+    private static func diff(_ l: [LineHash], _ r: [LineHash],
+                            _ lr: Range<Int>, _ rr: Range<Int>,
+                            into ops: inout [DiffOp]) {
+        var lo = lr, ro = rr
+
+        // 共通の先頭
+        var prefix = 0
+        while lo.lowerBound + prefix < lo.upperBound,
+              ro.lowerBound + prefix < ro.upperBound,
+              l[lo.lowerBound + prefix] == r[ro.lowerBound + prefix] {
+            prefix += 1
+        }
+        if prefix > 0 {
+            ops.append(.equal(left: lo.lowerBound, right: ro.lowerBound, count: prefix))
+            lo = (lo.lowerBound + prefix)..<lo.upperBound
+            ro = (ro.lowerBound + prefix)..<ro.upperBound
+        }
+
+        // 共通の末尾
+        var suffix = 0
+        while lo.upperBound - suffix - 1 >= lo.lowerBound,
+              ro.upperBound - suffix - 1 >= ro.lowerBound,
+              l[lo.upperBound - suffix - 1] == r[ro.upperBound - suffix - 1] {
+            suffix += 1
+        }
+        let lMid = lo.lowerBound..<(lo.upperBound - suffix)
+        let rMid = ro.lowerBound..<(ro.upperBound - suffix)
+
+        emitMiddle(l, r, lMid, rMid, into: &ops)
+
+        if suffix > 0 {
+            ops.append(.equal(left: lo.upperBound - suffix, right: ro.upperBound - suffix, count: suffix))
+        }
+    }
+
+    private static func emitMiddle(_ l: [LineHash], _ r: [LineHash],
+                                   _ lr: Range<Int>, _ rr: Range<Int>,
+                                   into ops: inout [DiffOp]) {
+        if lr.isEmpty && rr.isEmpty { return }
+        if lr.isEmpty { ops.append(.insert(right: rr.lowerBound, count: rr.count)); return }
+        if rr.isEmpty { ops.append(.delete(left: lr.lowerBound, count: lr.count)); return }
+
+        // アンカー = 左右それぞれで 1 回だけ出てくる、共通の行。
+        guard let anchors = uniqueAnchors(l, r, lr, rr), !anchors.isEmpty else {
+            // アンカー無し。小さければ Myers、大きければ諦めて replace。
+            if lr.count * rr.count <= myersCellBudget {
+                myers(l, r, lr, rr, into: &ops)
+            } else {
+                ops.append(.replace(left: lr.lowerBound, leftCount: lr.count,
+                                    right: rr.lowerBound, rightCount: rr.count))
+            }
+            return
+        }
+
+        // アンカー列（左昇順・右も昇順になるよう LIS で選抜済み）で区切って再帰。
+        var lPos = lr.lowerBound
+        var rPos = rr.lowerBound
+        for (li, ri) in anchors {
+            diff(l, r, lPos..<li, rPos..<ri, into: &ops)
+            ops.append(.equal(left: li, right: ri, count: 1))
+            lPos = li + 1
+            rPos = ri + 1
+        }
+        diff(l, r, lPos..<lr.upperBound, rPos..<rr.upperBound, into: &ops)
+    }
+
+    /// 左右それぞれの区間で出現回数 1、かつ両方に在る行を拾い、
+    /// 右のインデックスが増加する最長列（LIS）だけ残す＝交差しないアンカー列。
+    private static func uniqueAnchors(_ l: [LineHash], _ r: [LineHash],
+                                      _ lr: Range<Int>, _ rr: Range<Int>) -> [(Int, Int)]? {
+        var lCount: [LineHash: Int] = [:]
+        var lWhere: [LineHash: Int] = [:]
+        lCount.reserveCapacity(lr.count)
+        for i in lr {
+            lCount[l[i], default: 0] += 1
+            lWhere[l[i]] = i
+        }
+        var rCount: [LineHash: Int] = [:]
+        var rWhere: [LineHash: Int] = [:]
+        rCount.reserveCapacity(rr.count)
+        for i in rr {
+            rCount[r[i], default: 0] += 1
+            rWhere[r[i]] = i
+        }
+
+        var pairs: [(Int, Int)] = []
+        for (h, c) in lCount where c == 1 {
+            if rCount[h] == 1, let li = lWhere[h], let ri = rWhere[h] {
+                pairs.append((li, ri))
+            }
+        }
+        if pairs.isEmpty { return nil }
+        pairs.sort { $0.0 < $1.0 }
+
+        // 右インデックスの LIS（狭義単調増加）。
+        var tails: [Int] = []          // tails[k] = 長さ k+1 の列の末尾の「右index」
+        var tailIdx: [Int] = []        // その pairs 上の位置
+        var prev = [Int](repeating: -1, count: pairs.count)
+        for (i, p) in pairs.enumerated() {
+            var lo = 0, hi = tails.count
+            while lo < hi {
+                let mid = (lo + hi) / 2
+                if tails[mid] < p.1 { lo = mid + 1 } else { hi = mid }
+            }
+            if lo > 0 { prev[i] = tailIdx[lo - 1] }
+            if lo == tails.count { tails.append(p.1); tailIdx.append(i) }
+            else { tails[lo] = p.1; tailIdx[lo] = i }
+        }
+        var out: [(Int, Int)] = []
+        var k = tails.isEmpty ? -1 : tailIdx[tails.count - 1]
+        while k >= 0 { out.append(pairs[k]); k = prev[k] }
+        out.reverse()
+        return out
+    }
+
+    /// 小さい区間だけに使う Myers（O(ND)）。区間の外へは出ない。
+    private static func myers(_ l: [LineHash], _ r: [LineHash],
+                              _ lr: Range<Int>, _ rr: Range<Int>,
+                              into ops: inout [DiffOp]) {
+        let n = lr.count, m = rr.count
+        // 素朴な LCS（DP）。myersCellBudget で面積を抑えてあるので現実的。
+        var dp = [[Int]](repeating: [Int](repeating: 0, count: m + 1), count: n + 1)
+        for i in stride(from: n - 1, through: 0, by: -1) {
+            for j in stride(from: m - 1, through: 0, by: -1) {
+                dp[i][j] = (l[lr.lowerBound + i] == r[rr.lowerBound + j])
+                    ? dp[i + 1][j + 1] + 1
+                    : max(dp[i + 1][j], dp[i][j + 1])
+            }
+        }
+        var i = 0, j = 0
+        while i < n && j < m {
+            if l[lr.lowerBound + i] == r[rr.lowerBound + j] {
+                ops.append(.equal(left: lr.lowerBound + i, right: rr.lowerBound + j, count: 1))
+                i += 1; j += 1
+            } else if dp[i + 1][j] >= dp[i][j + 1] {
+                ops.append(.delete(left: lr.lowerBound + i, count: 1)); i += 1
+            } else {
+                ops.append(.insert(right: rr.lowerBound + j, count: 1)); j += 1
+            }
+        }
+        if i < n { ops.append(.delete(left: lr.lowerBound + i, count: n - i)) }
+        if j < m { ops.append(.insert(right: rr.lowerBound + j, count: m - j)) }
+    }
+
+    // MARK: - 整形
+
+    /// 連続する同種の手をまとめ、隣り合う delete+insert は replace に畳む
+    /// （「消して足した」より「書き換わった」と見せたほうが読める。行内差分もここに効く）。
+    static func coalesce(_ ops: [DiffOp]) -> [DiffOp] {
+        var merged: [DiffOp] = []
+        for op in ops {
+            guard let last = merged.last else { merged.append(op); continue }
+            switch (last, op) {
+            case let (.equal(l1, r1, c1), .equal(l2, r2, c2)) where l1 + c1 == l2 && r1 + c1 == r2:
+                merged[merged.count - 1] = .equal(left: l1, right: r1, count: c1 + c2)
+            case let (.delete(l1, c1), .delete(l2, c2)) where l1 + c1 == l2:
+                merged[merged.count - 1] = .delete(left: l1, count: c1 + c2)
+            case let (.insert(r1, c1), .insert(r2, c2)) where r1 + c1 == r2:
+                merged[merged.count - 1] = .insert(right: r1, count: c1 + c2)
+            default:
+                merged.append(op)
+            }
+        }
+
+        var out: [DiffOp] = []
+        var k = 0
+        while k < merged.count {
+            if case let .delete(l, lc) = merged[k], k + 1 < merged.count,
+               case let .insert(r, rc) = merged[k + 1] {
+                out.append(.replace(left: l, leftCount: lc, right: r, rightCount: rc))
+                k += 2
+            } else if case let .insert(r, rc) = merged[k], k + 1 < merged.count,
+                      case let .delete(l, lc) = merged[k + 1] {
+                out.append(.replace(left: l, leftCount: lc, right: r, rightCount: rc))
+                k += 2
+            } else {
+                out.append(merged[k])
+                k += 1
+            }
+        }
+        return out
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -323,7 +323,109 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
 
     /// サイドバー／タイトル用の表示名（未保存の新規ドキュメントは「名称未設定」）。
     private func displayName(of v: DocumentPane) -> String {
-        v.fileURL?.lastPathComponent ?? L("doc.untitled")
+        if let d = v as? DiffViewer { return d.displayTitle }   // diff は 1 ファイルに属さない
+        return v.fileURL?.lastPathComponent ?? L("doc.untitled")
+    }
+
+    // MARK: - diff（3 つの入口とも、ここに集まる）
+
+    /// アクティブなペインが diff なら、それ（「次/前の差分へ」のメニュー用）。
+    var activeDiffViewer: DiffViewer? { activeViewer as? DiffViewer }
+
+
+    /// 比較タブを開く。ソースの用意（mmap・索引）と diff は背景で走る。
+    /// `makeSources` は**背景スレッドで呼ばれる**（ここでメインを止めると 10GB で固まる）。
+    func openDiff(title: String, makeSources: @escaping () -> (DiffSource, DiffSource)?) {
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+        let v = DiffViewer()
+        install(v)
+        viewers.append(v)
+        reloadSidebar()
+        activate(viewers.count - 1)
+
+        v.onCompared = { [weak self] in self?.reloadSidebar() }
+        v.beginCompare(title: title, makeSources: makeSources, onFailure: { [weak self, weak v] message in
+            guard let self, let v, let i = self.viewers.firstIndex(where: { $0 === v }) else { return }
+            self.closeDocument(at: i)
+            let alert = NSAlert()
+            alert.messageText = L("diff.failedTitle")
+            alert.informativeText = message
+            alert.alertStyle = .warning
+            alert.runModal()
+        })
+    }
+
+    /// 入口 1: 2 つのファイルを選んで比べる。
+    func compareFiles() {
+        let panel = NSOpenPanel()
+        panel.message = L("diff.chooseTwo")
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        guard panel.runModal() == .OK, panel.urls.count == 2 else {
+            if panel.urls.count == 1 { NSSound.beep() }   // 1 つでは比べられない
+            return
+        }
+        let urls = panel.urls
+        let title = "\(urls[0].lastPathComponent) ↔ \(urls[1].lastPathComponent)"
+        openDiff(title: title) {
+            guard let l = FileDiffSource(url: urls[0]), let r = FileDiffSource(url: urls[1]) else { return nil }
+            return (l, r)
+        }
+    }
+
+    /// 入口 2: 開いているタブ 2 つ（アクティブと、その 1 つ前）を比べる。
+    /// 未保存のタブも本文で比べられる（ディスク上のファイルでなく、いま見えているものを比べる）。
+    func compareOpenDocuments() {
+        let comparable = viewers.enumerated().filter { !($0.element is DiffViewer) }
+        guard comparable.count >= 2 else { NSSound.beep(); return }
+        let pick = comparable.suffix(2).map { $0.element }
+        // 未保存の本文はメインスレッドで先に取る（ペインの状態はメインでしか触れない）。
+        let recipes = pick.map { diffRecipe(for: $0) }
+        let title = "\(displayName(of: pick[0])) ↔ \(displayName(of: pick[1]))"
+        openDiff(title: title) {
+            guard let l = recipes[0].makeSource(), let r = recipes[1].makeSource() else { return nil }
+            return (l, r)
+        }
+    }
+
+    /// 入口 3: クリップボードの中身と、いま開いているドキュメントを比べる。
+    func compareWithClipboard() {
+        guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else {
+            NSSound.beep(); return
+        }
+        let clipName = L("diff.clipboard")
+        guard let active = activeViewer, !(active is DiffViewer) else {
+            openDiff(title: clipName) {
+                (TextDiffSource(text: "", displayName: L("doc.untitled")),
+                 TextDiffSource(text: text, displayName: clipName))
+            }
+            return
+        }
+        let recipe = diffRecipe(for: active)
+        let title = "\(displayName(of: active)) ↔ \(clipName)"
+        openDiff(title: title) {
+            guard let l = recipe.makeSource() else { return nil }
+            return (l, TextDiffSource(text: text, displayName: clipName))
+        }
+    }
+
+    /// ペインを diff の入力にする「作り方」。**ペインの状態はメインで読み取り**、
+    /// 実際の mmap と索引の構築（重い）は背景で走らせる。
+    private struct DiffRecipe {
+        let makeSource: () -> DiffSource?
+    }
+
+    /// 保存済みならファイルを mmap、未保存なら本文をそのまま比べる（いま見えているものを比べる）。
+    private func diffRecipe(for pane: DocumentPane) -> DiffRecipe {
+        let name = displayName(of: pane)
+        if let text = pane.restorableText, pane.isDirty || pane.fileURL == nil {
+            return DiffRecipe { TextDiffSource(text: text, displayName: name) }
+        }
+        if let url = pane.fileURL {
+            return DiffRecipe { FileDiffSource(url: url) }
+        }
+        return DiffRecipe { nil }
     }
 
     // MARK: - アクティブなドキュメントの能力（メニュー検証用）
@@ -423,8 +525,10 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// 読み取り専用バナーの表示可否を更新する（編集不可のペイン＝LargeFileViewer のときだけ出す）。
     private func updateReadOnlyBanner() {
         // 構造化表示による読み取り専用は専用バナーで案内するため除外する。
+        // diff も除外する（「大きすぎて編集できません」は嘘。そもそも編集する画面ではない）。
         let isReadOnly = activeViewer != nil && !(activeViewer?.canEdit ?? false)
             && activeViewer?.structuredMode == nil
+            && !(activeViewer is DiffViewer)
         readOnlyBanner.isHidden = !(isReadOnly && !readOnlyBannerDismissed)
     }
 

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -151,3 +151,18 @@
 "update.failedMessage" = "The network was unreachable, or the release information could not be read. Please try again later.";
 "prefs.autoUpdateCheck" = "Check for updates on launch";
 "prefs.updates" = "Updates";
+
+/* 比較（diff） */
+"menu.compare" = "Compare (Diff)";
+"menu.compare.files" = "Compare Two Files…";
+"menu.compare.openDocs" = "Compare Open Documents";
+"menu.compare.clipboard" = "Compare with Clipboard";
+"menu.compare.next" = "Next Difference";
+"menu.compare.previous" = "Previous Difference";
+"diff.chooseTwo" = "Choose two files to compare";
+"diff.clipboard" = "Clipboard";
+"diff.comparing" = "Comparing…";
+"diff.identical" = "Identical";
+"diff.summary" = "%d hunks, %d lines differ";
+"diff.failedTitle" = "Could not compare";
+"diff.cannotRead" = "The file could not be read.";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -151,3 +151,18 @@
 "update.failedMessage" = "ネットワークに接続できないか、リリース情報を取得できませんでした。時間をおいて試してください。";
 "prefs.autoUpdateCheck" = "起動時にアップデートを確認する";
 "prefs.updates" = "アップデート";
+
+/* 比較（diff） */
+"menu.compare" = "比較（diff）";
+"menu.compare.files" = "2 つのファイルを比較…";
+"menu.compare.openDocs" = "開いているドキュメントを比較";
+"menu.compare.clipboard" = "クリップボードと比較";
+"menu.compare.next" = "次の差分へ";
+"menu.compare.previous" = "前の差分へ";
+"diff.chooseTwo" = "比較する 2 つのファイルを選んでください";
+"diff.clipboard" = "クリップボード";
+"diff.comparing" = "比較中…";
+"diff.identical" = "同一";
+"diff.summary" = "%d 箇所・%d 行が異なる";
+"diff.failedTitle" = "比較できませんでした";
+"diff.cannotRead" = "ファイルを読めませんでした。";

--- a/Sources/MrEditor/UI/DiffScroller.swift
+++ b/Sources/MrEditor/UI/DiffScroller.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+/// 差分の位置を溝（knob slot）に描くスクローラ。
+///
+/// 8,600 万行を並べたとき、「どこに差分があるか」はスクロールバーでしか分からない。
+/// 差分が上の方に 3 箇所、末尾に 1 箇所、という全体像が一目で見えることが、
+/// 巨大ファイルの diff では本文と同じくらい効く。
+final class DiffScroller: NSScroller {
+
+    /// 差分の位置（0...1 の相対位置と、その種類）。溝に色の目盛りとして描く。
+    struct Marker {
+        enum Kind { case delete, insert, replace }
+        let position: Double
+        let kind: Kind
+    }
+
+    var markers: [Marker] = [] { didSet { needsDisplay = true } }
+
+    private func color(_ k: Marker.Kind) -> NSColor {
+        switch k {
+        case .delete:  return NSColor.systemRed.withAlphaComponent(0.75)
+        case .insert:  return NSColor.systemGreen.withAlphaComponent(0.75)
+        case .replace: return NSColor.systemYellow.withAlphaComponent(0.75)
+        }
+    }
+
+    override func drawKnobSlot(in slotRect: NSRect, highlight flag: Bool) {
+        super.drawKnobSlot(in: slotRect, highlight: flag)
+        guard !markers.isEmpty else { return }
+
+        // 目盛りは最低 2pt の高さを持たせる（1 行分の差分でも見えるように）。
+        let h = max(2.0, slotRect.height / 400)
+        for m in markers {
+            let y = slotRect.minY + CGFloat(m.position) * (slotRect.height - h)
+            color(m.kind).setFill()
+            NSRect(x: slotRect.minX + 2, y: y, width: slotRect.width - 4, height: h).fill()
+        }
+    }
+}

--- a/Sources/MrEditor/UI/StatusBarView.swift
+++ b/Sources/MrEditor/UI/StatusBarView.swift
@@ -113,10 +113,11 @@ final class StatusBarView: NSView {
 
     func update(_ state: ViewerState) {
         guard !isShowingMessage else { return }
-        let size = Self.formatBytes(state.fileSize)
         let lines = Self.formatNumber(state.lineCount)
         let lineLabel = state.lineCountIsExact ? L("status.lines", lines) : L("status.linesApprox", lines)
-        var text = "\(state.encodingName)    \(lineLabel)    \(size)"
+        // サイズは意味があるときだけ出す（diff は左右 2 ファイルあるので「0 B」は嘘になる）。
+        var text = "\(state.encodingName)    \(lineLabel)"
+        if state.fileSize > 0 { text += "    \(Self.formatBytes(state.fileSize))" }
         if !state.lineCountIsExact {
             let pct = Int(state.indexProgress * 100)
             text += "    " + L("status.indexing", pct)

--- a/Sources/MrEditor/Viewer/DiffViewer.swift
+++ b/Sources/MrEditor/Viewer/DiffViewer.swift
@@ -31,7 +31,7 @@ final class DiffViewer: NSView, DocumentPane {
 
     private let leftView = DocumentView()
     private let rightView = DocumentView()
-    private let scroller = NSScroller(frame: NSRect(x: 0, y: 0, width: 16, height: 100))
+    private let scroller = DiffScroller(frame: NSRect(x: 0, y: 0, width: 16, height: 100))
     private let header = NSView()
     private let leftLabel = NSTextField(labelWithString: "")
     private let rightLabel = NSTextField(labelWithString: "")
@@ -154,6 +154,15 @@ final class DiffViewer: NSView, DocumentPane {
                     : L("diff.summary", m.hunkStarts.count, m.changedRowCount)
                 // 最初の差分まで飛ぶ（先頭が数万行同じ、はログでは普通）。
                 self.topRow = m.hunkStarts.first.map { max(0, $0 - 3) } ?? 0
+                self.scroller.markers = m.markers().map {
+                    DiffScroller.Marker(position: $0.position, kind: {
+                        switch $0.kind {
+                        case .delete:  return .delete
+                        case .insert:  return .insert
+                        default:       return .replace
+                        }
+                    }($0))
+                }
                 self.refresh()
                 self.onCompared?()
             }
@@ -253,13 +262,16 @@ final class DiffViewer: NSView, DocumentPane {
     }
 
     private func emitState() {
-        guard let model, let left, let right else { return }
-        onStateChange?(ViewerState(encodingName: "diff",
+        guard let model else { return }
+        // ファイルサイズの欄は diff では意味がない（左右 2 つある）。差分の要約を出す。
+        let label = model.isIdentical
+            ? L("diff.identical")
+            : L("diff.summary", model.hunkStarts.count, model.changedRowCount)
+        onStateChange?(ViewerState(encodingName: label,
                                    lineCount: model.rowCount,
                                    lineCountIsExact: true,
                                    fileSize: 0,
                                    indexProgress: 1.0))
-        _ = (left, right)
     }
 
     // MARK: - 差分間の移動
@@ -277,7 +289,19 @@ final class DiffViewer: NSView, DocumentPane {
         refresh()
     }
 
+    /// 左右のカラムを同じ水平位置に保つ。
+    private func setHorizontalOffset(_ x: CGFloat) {
+        leftView.setHorizontalOffset(x)
+        rightView.setHorizontalOffset(leftView.horizontalOffset)   // クランプ後の値で揃える
+    }
+
     private func handleKeyDown(_ event: NSEvent) {
+        let step = leftView.lineHeight * 4
+        switch event.keyCode {
+        case 123: setHorizontalOffset(leftView.horizontalOffset - step); return   // ←
+        case 124: setHorizontalOffset(leftView.horizontalOffset + step); return   // →
+        default: break
+        }
         switch event.keyCode {
         case 125: topRow += 1; refresh()                       // ↓
         case 126: topRow -= 1; refresh()                       // ↑
@@ -290,6 +314,10 @@ final class DiffViewer: NSView, DocumentPane {
     }
 
     private func handleScrollWheel(_ event: NSEvent) {
+        // 横は左右そろえて動かす。片方だけずれたら「並べて比べる」が成立しない。
+        if event.scrollingDeltaX != 0 {
+            setHorizontalOffset(leftView.horizontalOffset - event.scrollingDeltaX)
+        }
         var delta = event.scrollingDeltaY
         if !event.hasPreciseScrollingDeltas { delta *= leftView.lineHeight }
         scrollAccumulator += delta

--- a/Sources/MrEditor/Viewer/DiffViewer.swift
+++ b/Sources/MrEditor/Viewer/DiffViewer.swift
@@ -50,6 +50,24 @@ final class DiffViewer: NSView, DocumentPane {
     /// 行内差分のキャッシュ（可視行のぶんだけ。スクロールで捨てる）。
     private var charDiffCache: [Int: (left: [Range<Int>], right: [Range<Int>])] = [:]
 
+    // MARK: - 選択（片方の列の中だけ。左右にまたがる選択は意味を成さない）
+
+    private enum Side { case left, right }
+    /// 選択の起点と終点。表示行（絶対）と行内 UTF-16 オフセットで持つ。
+    private var selSide: Side?
+    private var selAnchor: (row: Int, idx: Int)?
+    private var selFocus: (row: Int, idx: Int)?
+
+    private func view(_ side: Side) -> DocumentView { side == .left ? leftView : rightView }
+    private func source(_ side: Side) -> DiffSource? { side == .left ? left : right }
+
+    /// その行の、その列に出ている文字列（相手側にしか無い行なら空）。
+    private func text(_ side: Side, row: Int) -> String {
+        guard let model, let r = model.row(at: row), let src = source(side) else { return "" }
+        let line = side == .left ? r.left : r.right
+        return line.map { src.line(at: $0) } ?? ""
+    }
+
     // MARK: - 色（テーマの背景に馴染ませる。ライト/ダークどちらでも読める濃度にする）
 
     private var addBG: NSColor { NSColor.systemGreen.withAlphaComponent(0.16) }
@@ -90,11 +108,15 @@ final class DiffViewer: NSView, DocumentPane {
         divider.layer?.backgroundColor = theme.separator.cgColor
         addSubview(divider)
 
-        for v in [leftView, rightView] {
+        for (v, side) in [(leftView, Side.left), (rightView, Side.right)] {
             // 隣のカラムへはみ出させない（折り返し無しの長い行も、背景の塗りも）。
             v.clipsToBounds = true
             v.onScrollWheel = { [weak self] in self?.handleScrollWheel($0) }
             v.onKeyDown = { [weak self] in self?.handleKeyDown($0) }
+            v.onMouseDown = { [weak self] in self?.beginSelection(side, $0) }
+            v.onMouseDragged = { [weak self] in self?.extendSelection(side, $0) }
+            v.onCopy = { [weak self] in self?.copySelection() }
+            v.onSelectAll = { [weak self] in self?.selectAll(side) }
             addSubview(v)
         }
 
@@ -231,6 +253,9 @@ final class DiffViewer: NSView, DocumentPane {
         leftView.lines = lTexts;   rightView.lines = rTexts
         leftView.lineNumbers = lNums; rightView.lineNumbers = rNums
         leftView.rowBackgrounds = lBGs; rightView.rowBackgrounds = rBGs
+        let visible = topRow..<(topRow + count)
+        leftView.selectionByRow = selectionRows(.left, visible: visible)
+        rightView.selectionByRow = selectionRows(.right, visible: visible)
         leftView.needsDisplay = true; rightView.needsDisplay = true
 
         // キャッシュは可視付近だけ残す（延々スクロールしても太らない）。
@@ -272,6 +297,84 @@ final class DiffViewer: NSView, DocumentPane {
                                    lineCountIsExact: true,
                                    fileSize: 0,
                                    indexProgress: 1.0))
+    }
+
+    // MARK: - 選択とコピー
+
+    /// クリックした列で選択を始める。もう片方の列の選択は捨てる
+    /// （左右にまたがる選択は「並べて比べる」画面では意味を成さない）。
+    private func beginSelection(_ side: Side, _ event: NSEvent) {
+        let v = view(side)
+        let p = v.convert(event.locationInWindow, from: nil)
+        guard let hit = v.index(at: p) else { return }
+        let row = topRow + hit.row
+        if event.modifierFlags.contains(.shift), selSide == side, selAnchor != nil {
+            selFocus = (row, hit.utf16Index)          // Shift+クリックで範囲を伸ばす
+        } else {
+            selSide = side
+            selAnchor = (row, hit.utf16Index)
+            selFocus = (row, hit.utf16Index)
+        }
+        window?.makeFirstResponder(v)
+        refresh()
+    }
+
+    private func extendSelection(_ side: Side, _ event: NSEvent) {
+        guard selSide == side else { return }
+        let v = view(side)
+        let p = v.convert(event.locationInWindow, from: nil)
+        guard let hit = v.index(at: p) else { return }
+        selFocus = (topRow + hit.row, hit.utf16Index)
+        refresh()
+    }
+
+    /// その列の全行を選ぶ。巨大ファイルでも選択自体は範囲を持つだけなので安い
+    /// （コピーするときに初めて行を読む）。
+    private func selectAll(_ side: Side) {
+        guard let model, model.rowCount > 0 else { return }
+        selSide = side
+        selAnchor = (0, 0)
+        let last = model.rowCount - 1
+        selFocus = (last, text(side, row: last).utf16.count)
+        refresh()
+    }
+
+    /// 選択の正規化（起点 ≤ 終点）。
+    private func normalizedSelection() -> (start: (row: Int, idx: Int), end: (row: Int, idx: Int))? {
+        guard let a = selAnchor, let f = selFocus else { return nil }
+        if a.row < f.row || (a.row == f.row && a.idx <= f.idx) { return (a, f) }
+        return (f, a)
+    }
+
+    /// 選択されている本文をクリップボードへ。相手側にしか無い行（空白で埋めた行）は飛ばす
+    /// ―― 存在しない行をコピーして空行を混ぜたら、貼り付け先で嘘になる。
+    private func copySelection() {
+        guard let side = selSide, let model, let sel = normalizedSelection() else { NSSound.beep(); return }
+        let text = model.selectedText(from: sel.start, to: sel.end) { [weak self] row in
+            guard let self, let r = model.row(at: row) else { return nil }
+            let exists = (side == .left) ? r.left != nil : r.right != nil
+            return exists ? self.text(side, row: row) : nil    // 埋め草の行は nil＝飛ばす
+        }
+        guard !text.isEmpty else { NSSound.beep(); return }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(text, forType: .string)
+    }
+
+    /// 可視行の選択ハイライトを組む（DocumentView に渡す形へ）。
+    private func selectionRows(_ side: Side, visible: Range<Int>) -> [Int: DocumentView.RowSelection] {
+        guard selSide == side, let sel = normalizedSelection() else { return [:] }
+        var out: [Int: DocumentView.RowSelection] = [:]
+        for row in visible where row >= sel.start.row && row <= sel.end.row {
+            let u = text(side, row: row).utf16.count
+            let from = (row == sel.start.row) ? min(sel.start.idx, u) : 0
+            let to   = (row == sel.end.row)   ? min(sel.end.idx, u)   : u
+            guard from <= to else { continue }
+            out[row - visible.lowerBound] = DocumentView.RowSelection(
+                range: NSRange(location: from, length: to - from),
+                extendsToLineEnd: row < sel.end.row)     // 行をまたぐ選択は行末まで帯を伸ばす
+        }
+        return out
     }
 
     // MARK: - 差分間の移動

--- a/Sources/MrEditor/Viewer/DiffViewer.swift
+++ b/Sources/MrEditor/Viewer/DiffViewer.swift
@@ -1,0 +1,368 @@
+import AppKit
+
+/// 2 つのソースを並べて差分を見るペイン。
+///
+/// 巨大ファイルの流儀をそのまま踏襲する: **見えている行しか組み立てない**。
+/// 差分の手（`DiffModel`）は行を実体化せず、画面に出る数十行だけをその場で左右に組む。
+/// 8,600 万行の diff でも、描画側が持つのは 1 画面分の `NSAttributedString` だけ。
+///
+/// 読み取り専用。編集・検索・追従は持たない（`DocumentPane` の既定実装に委ねる）。
+final class DiffViewer: NSView, DocumentPane {
+
+    // MARK: - DocumentPane
+
+    /// diff は特定の 1 ファイルに属さない（左右 2 つある）。サイドバー名は `displayTitle` を使う。
+    var fileURL: URL? { nil }
+    var onStateChange: ((ViewerState) -> Void)?
+    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)?
+    var onDropFiles: (([URL]) -> Void)?
+    var onDirtyChange: ((Bool) -> Void)?
+
+    var supportsSearch: Bool { false }
+    var supportsFollow: Bool { false }
+    var supportsStructured: Bool { false }
+    var canPrint: Bool { false }
+    func printDocument() {}
+
+    /// サイドバーとタイトルに出す名前。
+    private(set) var displayTitle: String = "Diff"
+
+    // MARK: - 中身
+
+    private let leftView = DocumentView()
+    private let rightView = DocumentView()
+    private let scroller = NSScroller(frame: NSRect(x: 0, y: 0, width: 16, height: 100))
+    private let header = NSView()
+    private let leftLabel = NSTextField(labelWithString: "")
+    private let rightLabel = NSTextField(labelWithString: "")
+    private let summary = NSTextField(labelWithString: "")
+    private let divider = NSView()
+
+    private var left: DiffSource?
+    private var right: DiffSource?
+    private var model: DiffModel?
+
+    private var topRow = 0
+    private var scrollAccumulator: CGFloat = 0
+    private let scrollerWidth: CGFloat = 16
+    private let headerHeight: CGFloat = 28
+
+    /// 行内差分のキャッシュ（可視行のぶんだけ。スクロールで捨てる）。
+    private var charDiffCache: [Int: (left: [Range<Int>], right: [Range<Int>])] = [:]
+
+    // MARK: - 色（テーマの背景に馴染ませる。ライト/ダークどちらでも読める濃度にする）
+
+    private var addBG: NSColor { NSColor.systemGreen.withAlphaComponent(0.16) }
+    private var delBG: NSColor { NSColor.systemRed.withAlphaComponent(0.16) }
+    private var modBG: NSColor { NSColor.systemYellow.withAlphaComponent(0.14) }
+    /// 相手側に行が無いところ（空白で埋める側）。中身が無いことを示す薄いグレー。
+    private var fillerBG: NSColor { NSColor.secondaryLabelColor.withAlphaComponent(0.07) }
+    /// 行内で実際に変わった文字。帯より濃く塗る。
+    private var addInline: NSColor { NSColor.systemGreen.withAlphaComponent(0.38) }
+    private var delInline: NSColor { NSColor.systemRed.withAlphaComponent(0.38) }
+
+    // MARK: - 組み立て
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setup() {
+        let theme = EditorTheme.current()
+
+        header.wantsLayer = true
+        header.layer?.backgroundColor = theme.chromeBackground.cgColor
+        addSubview(header)
+        for (label, align) in [(leftLabel, NSTextAlignment.left), (rightLabel, .left)] {
+            label.font = .systemFont(ofSize: 11, weight: .medium)
+            label.textColor = theme.chromeText
+            label.alignment = align
+            header.addSubview(label)
+        }
+        summary.font = .systemFont(ofSize: 11)
+        summary.textColor = theme.chromeSecondaryText
+        summary.alignment = .right
+        header.addSubview(summary)
+
+        divider.wantsLayer = true
+        divider.layer?.backgroundColor = theme.separator.cgColor
+        addSubview(divider)
+
+        for v in [leftView, rightView] {
+            // 隣のカラムへはみ出させない（折り返し無しの長い行も、背景の塗りも）。
+            v.clipsToBounds = true
+            v.onScrollWheel = { [weak self] in self?.handleScrollWheel($0) }
+            v.onKeyDown = { [weak self] in self?.handleKeyDown($0) }
+            addSubview(v)
+        }
+
+        scroller.scrollerStyle = .legacy
+        scroller.knobStyle = .default
+        scroller.target = self
+        scroller.action = #selector(scrollerAction(_:))
+        addSubview(scroller)
+
+        applyCurrentFontSize()
+        applyDisplaySettings()
+    }
+
+    // MARK: - 入口
+
+    /// 比較を始める（**メインスレッドから呼ぶ**）。ソースの用意と diff の計算は背景で走らせ、
+    /// 済んだらメインで描画する。10GB 同士だと索引と diff で数十秒かかるので、
+    /// ここを同期にするとウィンドウが固まる（実際に固めた）。
+    ///
+    /// `makeSources` は**背景スレッドで呼ばれる**。ここで mmap と索引を作る。
+    func beginCompare(title: String,
+                      makeSources: @escaping () -> (DiffSource, DiffSource)?,
+                      onFailure: @escaping (String) -> Void) {
+        displayTitle = title
+        summary.stringValue = L("diff.comparing")
+        leftLabel.stringValue = ""
+        rightLabel.stringValue = ""
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let sources = makeSources() else {
+                DispatchQueue.main.async { onFailure(L("diff.cannotRead")) }
+                return
+            }
+            let (l, r) = sources
+
+            // 索引は 1 行 16 バイト。閲覧と違い本当にメモリを使うので、機械に載るか先に見る。
+            guard DiffBudget.fits(leftLines: l.lineCount, rightLines: r.lineCount) else {
+                let msg = DiffBudget.describe(leftLines: l.lineCount, rightLines: r.lineCount)
+                DispatchQueue.main.async { onFailure(msg) }
+                return
+            }
+
+            let ops = LineDiff.compute(l.lineHashes(), r.lineHashes())
+            let m = DiffModel(ops: ops)
+
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.left = l
+                self.right = r
+                self.model = m
+                self.displayTitle = "\(l.displayName) ↔ \(r.displayName)"
+                self.leftLabel.stringValue = l.displayName
+                self.rightLabel.stringValue = r.displayName
+                self.charDiffCache.removeAll()
+                self.summary.stringValue = m.isIdentical
+                    ? L("diff.identical")
+                    : L("diff.summary", m.hunkStarts.count, m.changedRowCount)
+                // 最初の差分まで飛ぶ（先頭が数万行同じ、はログでは普通）。
+                self.topRow = m.hunkStarts.first.map { max(0, $0 - 3) } ?? 0
+                self.refresh()
+                self.onCompared?()
+            }
+        }
+    }
+
+    /// 比較が終わったときの通知（サイドバー名の更新用）。
+    var onCompared: (() -> Void)?
+
+    @discardableResult func open(url: URL) -> Bool { false }   // diff ペインは compare(_:_:) で作る
+
+    // MARK: - 描画（見えている行だけ組む）
+
+    private var visibleRowCount: Int {
+        max(1, Int((bounds.height - headerHeight) / max(1, leftView.lineHeight)))
+    }
+    private var maxTopRow: Int { max(0, (model?.rowCount ?? 0) - visibleRowCount) }
+
+    private func refresh() {
+        guard let model, let left, let right else { return }
+        topRow = min(max(0, topRow), maxTopRow)
+
+        let count = min(visibleRowCount, max(0, model.rowCount - topRow))
+        var lTexts: [NSAttributedString] = [], rTexts: [NSAttributedString] = []
+        var lNums: [Int] = [], rNums: [Int] = []
+        var lBGs: [NSColor?] = [], rBGs: [NSColor?] = []
+        lTexts.reserveCapacity(count); rTexts.reserveCapacity(count)
+
+        for k in 0..<count {
+            let rowIdx = topRow + k
+            guard let row = model.row(at: rowIdx) else { break }
+
+            let lStr = row.left.map { left.line(at: $0) } ?? ""
+            let rStr = row.right.map { right.line(at: $0) } ?? ""
+
+            // 行内差分は「変更行」だけ。可視分しか計算しない。
+            var lRanges: [Range<Int>] = [], rRanges: [Range<Int>] = []
+            if row.kind == .replace, row.left != nil, row.right != nil {
+                if let cached = charDiffCache[rowIdx] {
+                    lRanges = cached.left; rRanges = cached.right
+                } else {
+                    let d = CharDiff.ranges(left: lStr, right: rStr)
+                    charDiffCache[rowIdx] = d
+                    lRanges = d.left; rRanges = d.right
+                }
+            }
+
+            lTexts.append(attributed(lStr, inline: lRanges, color: delInline))
+            rTexts.append(attributed(rStr, inline: rRanges, color: addInline))
+            lNums.append(row.left ?? DocumentView.noLineNumber)
+            rNums.append(row.right ?? DocumentView.noLineNumber)
+
+            switch row.kind {
+            case .equal:
+                lBGs.append(nil); rBGs.append(nil)
+            case .delete:
+                lBGs.append(delBG); rBGs.append(fillerBG)
+            case .insert:
+                lBGs.append(fillerBG); rBGs.append(addBG)
+            case .replace:
+                lBGs.append(row.left == nil ? fillerBG : modBG)
+                rBGs.append(row.right == nil ? fillerBG : modBG)
+            }
+        }
+
+        leftView.lines = lTexts;   rightView.lines = rTexts
+        leftView.lineNumbers = lNums; rightView.lineNumbers = rNums
+        leftView.rowBackgrounds = lBGs; rightView.rowBackgrounds = rBGs
+        leftView.needsDisplay = true; rightView.needsDisplay = true
+
+        // キャッシュは可視付近だけ残す（延々スクロールしても太らない）。
+        if charDiffCache.count > 2_000 {
+            let keep = topRow..<(topRow + count)
+            charDiffCache = charDiffCache.filter { keep.contains($0.key) }
+        }
+
+        updateScroller()
+        emitState()
+    }
+
+    /// 行内で変わった文字だけを濃く塗った 1 行。
+    private func attributed(_ s: String, inline: [Range<Int>], color: NSColor) -> NSAttributedString {
+        let attr = NSMutableAttributedString(string: s, attributes: leftView.textAttributes)
+        guard !inline.isEmpty else { return attr }
+        let chars = Array(s)
+        for r in inline {
+            guard r.lowerBound >= 0, r.upperBound <= chars.count, r.lowerBound < r.upperBound else { continue }
+            // Character 単位の範囲 → UTF-16 の範囲へ（絵文字を割らない）。
+            let pre = String(chars[0..<r.lowerBound]).utf16.count
+            let len = String(chars[r.lowerBound..<r.upperBound]).utf16.count
+            let ns = NSRange(location: pre, length: len)
+            if ns.location + ns.length <= attr.length {
+                attr.addAttribute(.backgroundColor, value: color, range: ns)
+            }
+        }
+        return attr
+    }
+
+    private func emitState() {
+        guard let model, let left, let right else { return }
+        onStateChange?(ViewerState(encodingName: "diff",
+                                   lineCount: model.rowCount,
+                                   lineCountIsExact: true,
+                                   fileSize: 0,
+                                   indexProgress: 1.0))
+        _ = (left, right)
+    }
+
+    // MARK: - 差分間の移動
+
+    /// 次の差分へ。
+    func nextHunk() {
+        guard let model, let next = model.nextHunk(after: topRow + 2) else { NSSound.beep(); return }
+        topRow = max(0, next - 3)
+        refresh()
+    }
+    /// 前の差分へ。
+    func previousHunk() {
+        guard let model, let prev = model.previousHunk(before: topRow + 2) else { NSSound.beep(); return }
+        topRow = max(0, prev - 3)
+        refresh()
+    }
+
+    private func handleKeyDown(_ event: NSEvent) {
+        switch event.keyCode {
+        case 125: topRow += 1; refresh()                       // ↓
+        case 126: topRow -= 1; refresh()                       // ↑
+        case 121: topRow += visibleRowCount - 1; refresh()     // PageDown
+        case 116: topRow -= visibleRowCount - 1; refresh()     // PageUp
+        case 115: topRow = 0; refresh()                        // Home
+        case 119: topRow = maxTopRow; refresh()                // End
+        default: break
+        }
+    }
+
+    private func handleScrollWheel(_ event: NSEvent) {
+        var delta = event.scrollingDeltaY
+        if !event.hasPreciseScrollingDeltas { delta *= leftView.lineHeight }
+        scrollAccumulator += delta
+        let lines = Int(scrollAccumulator / leftView.lineHeight)
+        if lines != 0 {
+            scrollAccumulator -= CGFloat(lines) * leftView.lineHeight
+            topRow -= lines
+            refresh()
+        }
+    }
+
+    @objc private func scrollerAction(_ sender: NSScroller) {
+        let page = max(1, visibleRowCount - 1)
+        switch sender.hitPart {
+        case .knob, .knobSlot: topRow = Int(Double(maxTopRow) * sender.doubleValue)
+        case .decrementPage: topRow -= page
+        case .incrementPage: topRow += page
+        case .decrementLine: topRow -= 1
+        case .incrementLine: topRow += 1
+        default: break
+        }
+        refresh()
+    }
+
+    private func updateScroller() {
+        let total = model?.rowCount ?? 0
+        scroller.isEnabled = total > visibleRowCount
+        scroller.knobProportion = total > 0 ? CGFloat(visibleRowCount) / CGFloat(total) : 1
+        scroller.doubleValue = maxTopRow > 0 ? Double(topRow) / Double(maxTopRow) : 0
+    }
+
+    // MARK: - レイアウト
+
+    override func layout() {
+        super.layout()
+        let w = bounds.width, h = bounds.height
+        header.frame = NSRect(x: 0, y: h - headerHeight, width: w, height: headerHeight)
+        let colW = max(0, (w - scrollerWidth - 1) / 2)
+        leftLabel.frame = NSRect(x: 10, y: 5, width: colW - 20, height: 18)
+        rightLabel.frame = NSRect(x: colW + 11, y: 5, width: colW - 130, height: 18)
+        summary.frame = NSRect(x: w - scrollerWidth - 240, y: 5, width: 230, height: 18)
+
+        let bodyH = max(0, h - headerHeight)
+        leftView.frame = NSRect(x: 0, y: 0, width: colW, height: bodyH)
+        divider.frame = NSRect(x: colW, y: 0, width: 1, height: bodyH)
+        rightView.frame = NSRect(x: colW + 1, y: 0, width: colW, height: bodyH)
+        scroller.frame = NSRect(x: w - scrollerWidth, y: 0, width: scrollerWidth, height: bodyH)
+        refresh()
+    }
+
+    // MARK: - DocumentPane の残り
+
+    func reEmitState() { emitState() }
+    func focusContent() { window?.makeFirstResponder(leftView) }
+    func ensureVisibleLayout() { refresh() }
+
+    func applyCurrentFontSize() {
+        for v in [leftView, rightView] { v.configure(font: EditorFont.current()) }
+        needsLayout = true
+        refresh()
+    }
+    func applyLineWrap() {
+        // diff は左右の行を突き合わせて見るもの。折り返すと行が縦にずれて対応が崩れるので、
+        // 折り返しは常に無効（横スクロールで見る）。
+        for v in [leftView, rightView] { v.wrapEnabled = false }
+        refresh()
+    }
+    func applyDisplaySettings() {
+        for v in [leftView, rightView] {
+            v.highlightCurrentLine = false      // diff の帯と喧嘩する
+            v.cursorShape = AppSettings.cursorShape
+            v.configure(font: EditorFont.current())   // タブ幅・行間・配色を織り込む
+        }
+        refresh()
+    }
+}

--- a/Sources/MrEditor/Viewer/DocumentView.swift
+++ b/Sources/MrEditor/Viewer/DocumentView.swift
@@ -44,6 +44,11 @@ final class DocumentView: NSView {
     /// 現在の検索一致がある行（可視リスト内のインデックス）。帯で強調。nil なら強調なし。
     var activeRow: Int? = nil
     private let activeLineColor = NSColor.systemTeal.withAlphaComponent(0.14)
+    /// 行ごとの背景色（diff の追加/削除/変更の帯）。要素は `lines` と同じ並び。空なら塗らない。
+    /// ガター（行番号）まで含めて塗るので、行が「どちら側に無いか」も色で分かる。
+    var rowBackgrounds: [NSColor?] = []
+    /// 行番号を出さない行（diff で相手側にしか無い行＝空白で埋める行）。`lineNumbers` の値がこれ。
+    static let noLineNumber = -1
     /// 上から順に描画する行。
     var lines: [NSAttributedString] = [] { didSet { layoutsDirty = true } }
 
@@ -148,7 +153,10 @@ final class DocumentView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         backgroundColor.setFill()
-        dirtyRect.fill()
+        // **dirtyRect をそのまま塗らない。** NSView は既定でクリップしないため、dirtyRect が
+        // 自分の bounds を超えて（ウィンドウ全体まで）来ると、隣に並んだビューを塗り潰す。
+        // 単独表示では全面を塗るので露見しなかったが、diff で左右に並べた瞬間に左が消えた。
+        dirtyRect.intersection(bounds).fill()
 
         // ガター背景
         let gutterRect = NSRect(x: 0, y: 0, width: gutterWidth, height: bounds.height)
@@ -169,6 +177,12 @@ final class DocumentView: NSView {
         for (i, layout) in rowLayouts.enumerated() {
             if y > bounds.height { break }
             let rowH = layout.height
+
+            // diff の行帯（ガターごと塗る＝「この行は相手側に無い」が色で分かる）
+            if i < rowBackgrounds.count, let bg = rowBackgrounds[i] {
+                bg.setFill()
+                NSRect(x: 0, y: y, width: bounds.width, height: rowH).fill()
+            }
 
             // キャレット行の帯（選択が無いときのみ・折り返し分の高さ全体）
             if highlightCurrentLine, caret?.row == i, selectionByRow[i] == nil {
@@ -192,7 +206,10 @@ final class DocumentView: NSView {
 
             // ガター（行番号・右寄せ・先頭サブ行の高さに合わせる）
             let lineNo = (lineNumbers != nil && i < lineNumbers!.count) ? lineNumbers![i] : firstLineNumber + i
-            let numStr = NSAttributedString(string: "\(lineNo + 1)", attributes: gutterAttributes)
+            // diff で相手側にしか無い行は番号を出さない（存在しない行に番号を振らない）。
+            let numStr = lineNo == DocumentView.noLineNumber
+                ? NSAttributedString(string: "", attributes: gutterAttributes)
+                : NSAttributedString(string: "\(lineNo + 1)", attributes: gutterAttributes)
             let numSize = numStr.size()
             let numX = gutterWidth - gutterRightPadding - numSize.width
             numStr.draw(with: NSRect(x: max(2, numX), y: y, width: numSize.width, height: lineHeight), options: numOpts)

--- a/Sources/MrEditor/Viewer/DocumentView.swift
+++ b/Sources/MrEditor/Viewer/DocumentView.swift
@@ -196,14 +196,6 @@ final class DocumentView: NSView {
                 NSRect(x: gutterWidth, y: y, width: max(0, bounds.width - gutterWidth), height: rowH).fill()
             }
 
-            // 選択ハイライト（折り返しをまたいで内包矩形で塗る）
-            if let sel = selectionByRow[i] {
-                selectionColor.setFill()
-                let origin = NSPoint(x: contentX - xOff, y: y)
-                layout.enumerateSelectionRects(sel.range, extendToEnd: sel.extendsToLineEnd,
-                                               origin: origin, viewWidth: bounds.width) { NSBezierPath(rect: $0).fill() }
-            }
-
             // ガター（行番号・右寄せ・先頭サブ行の高さに合わせる）
             let lineNo = (lineNumbers != nil && i < lineNumbers!.count) ? lineNumbers![i] : firstLineNumber + i
             // diff で相手側にしか無い行は番号を出さない（存在しない行に番号を振らない）。
@@ -213,6 +205,22 @@ final class DocumentView: NSView {
             let numSize = numStr.size()
             let numX = gutterWidth - gutterRightPadding - numSize.width
             numStr.draw(with: NSRect(x: max(2, numX), y: y, width: numSize.width, height: lineHeight), options: numOpts)
+
+            // ここから先（選択・本文・キャレット）は横スクロールで左へずれる。
+            // ガターの上に本文が乗らないよう、本文領域へクリップする。
+            NSGraphicsContext.saveGraphicsState()
+            NSBezierPath(rect: NSRect(x: gutterWidth, y: 0,
+                                      width: max(0, bounds.width - gutterWidth),
+                                      height: bounds.height)).setClip()
+            defer { NSGraphicsContext.restoreGraphicsState() }
+
+            // 選択ハイライト（折り返しをまたいで内包矩形で塗る）
+            if let sel = selectionByRow[i] {
+                selectionColor.setFill()
+                let origin = NSPoint(x: contentX - xOff, y: y)
+                layout.enumerateSelectionRects(sel.range, extendToEnd: sel.extendsToLineEnd,
+                                               origin: origin, viewWidth: bounds.width) { NSBezierPath(rect: $0).fill() }
+            }
 
             // 本文（折り返し分をまとめて描画。折り返し無しは水平オフセットを引く）
             layout.draw(at: NSPoint(x: contentX - xOff, y: y))

--- a/Tests/MrEditorTests/DiffModelTests.swift
+++ b/Tests/MrEditorTests/DiffModelTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import MrEditor
+
+/// 並べて見るときの行モデルと、選択範囲のコピー。
+final class DiffModelTests: XCTestCase {
+
+    /// 左 [a, b, c, d] → 右 [a, X, c, d, e] 相当の手。
+    /// 表示行: 0=a(equal) 1=b↔X(replace) 2=c(equal) 3=d(equal) 4=e(insert)
+    private func sampleModel() -> DiffModel {
+        DiffModel(ops: [
+            .equal(left: 0, right: 0, count: 1),
+            .replace(left: 1, leftCount: 1, right: 1, rightCount: 1),
+            .equal(left: 2, right: 2, count: 2),
+            .insert(right: 4, count: 1),
+        ])
+    }
+
+    func testRowMapping() {
+        let m = sampleModel()
+        XCTAssertEqual(m.rowCount, 5)
+
+        XCTAssertEqual(m.row(at: 0)?.left, 0)
+        XCTAssertEqual(m.row(at: 0)?.right, 0)
+
+        XCTAssertEqual(m.row(at: 1)?.kind, .replace)
+        XCTAssertEqual(m.row(at: 1)?.left, 1)
+        XCTAssertEqual(m.row(at: 1)?.right, 1)
+
+        XCTAssertEqual(m.row(at: 3)?.left, 3)
+
+        // 右にしかない行。左は埋め草（nil）。
+        XCTAssertEqual(m.row(at: 4)?.kind, .insert)
+        XCTAssertNil(m.row(at: 4)?.left)
+        XCTAssertEqual(m.row(at: 4)?.right, 4)
+
+        XCTAssertNil(m.row(at: 5))
+    }
+
+    /// 削除・追加・変更の**開始行**が差分の頭として拾えること（「次の差分へ」の飛び先）。
+    func testHunkNavigation() {
+        let m = sampleModel()
+        XCTAssertEqual(m.hunkStarts, [1, 4])
+        XCTAssertEqual(m.nextHunk(after: 0), 1)
+        XCTAssertEqual(m.nextHunk(after: 1), 4)
+        XCTAssertNil(m.nextHunk(after: 4))
+        XCTAssertEqual(m.previousHunk(before: 4), 1)
+        XCTAssertNil(m.previousHunk(before: 1))
+    }
+
+    func testChangedCounts() {
+        let m = sampleModel()
+        XCTAssertEqual(m.changedRowCount, 2)   // replace 1 行 ＋ insert 1 行
+        XCTAssertFalse(m.isIdentical)
+    }
+
+    // MARK: - コピー
+
+    /// 左の列でコピーする。行 4 は右にしか無い＝左では埋め草なので、**空行を混ぜない**。
+    func testCopySkipsFillerRows() {
+        let m = sampleModel()
+        let leftLines = ["a", "b", "c", "d"]
+        let text = m.selectedText(from: (row: 2, idx: 0), to: (row: 4, idx: 0)) { row in
+            m.row(at: row)?.left.map { leftLines[$0] }     // 左に無ければ nil
+        }
+        // 行 2(c) と 3(d) だけ。行 4 は左に存在しないので飛ばす（"c\nd\n" にしない）。
+        XCTAssertEqual(text, "c\nd")
+    }
+
+    /// 行の途中から途中まで（ドラッグ選択）。
+    func testCopyPartialRange() {
+        let m = sampleModel()
+        let lines = ["alpha", "bravo", "charlie", "delta"]
+        let text = m.selectedText(from: (row: 0, idx: 2), to: (row: 2, idx: 4)) { row in
+            m.row(at: row)?.left.map { lines[$0] }
+        }
+        XCTAssertEqual(text, "pha\nbravo\nchar")
+    }
+
+    /// 日本語（サロゲートペアを含む）を割らない。
+    func testCopyDoesNotSplitSurrogatePairs() {
+        let m = DiffModel(ops: [.equal(left: 0, right: 0, count: 1)])
+        let line = "あ👨‍👩‍👦い"
+        let all = m.selectedText(from: (row: 0, idx: 0), to: (row: 0, idx: line.utf16.count)) { _ in line }
+        XCTAssertEqual(all, line)
+    }
+
+    /// 選択が空、範囲外でも落ちない。
+    func testCopyDegenerateRanges() {
+        let m = sampleModel()
+        XCTAssertEqual(m.selectedText(from: (row: 1, idx: 0), to: (row: 0, idx: 0)) { _ in "x" }, "")
+        XCTAssertEqual(m.selectedText(from: (row: 0, idx: 0), to: (row: 99, idx: 0)) { _ in "x" }, "")
+    }
+
+    /// スクロールバーの差分マーカーは、差分の位置（0...1）に立つ。
+    func testMarkers() {
+        let m = sampleModel()
+        let markers = m.markers()
+        XCTAssertEqual(markers.count, 2)
+        XCTAssertEqual(markers[0].kind, .replace)
+        XCTAssertEqual(markers[0].position, 1.0 / 5.0, accuracy: 0.001)
+        XCTAssertEqual(markers[1].kind, .insert)
+        XCTAssertEqual(markers[1].position, 4.0 / 5.0, accuracy: 0.001)
+    }
+}

--- a/Tests/MrEditorTests/DiffSourceTests.swift
+++ b/Tests/MrEditorTests/DiffSourceTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import MrEditor
+
+/// diff の入力（ファイル / メモリ上テキスト）。
+/// **行が読めること**が全て。左が空のまま並ぶ diff は無価値。
+final class DiffSourceTests: XCTestCase {
+
+    private func tempFile(_ content: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("difftest-\(UUID().uuidString).log")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// FileDiffSource はメインスレッドで作れない（索引の完了待ちで固まる）ので、背景で作る。
+    private func makeFileSource(_ url: URL) throws -> FileDiffSource {
+        var result: FileDiffSource?
+        let done = expectation(description: "source")
+        DispatchQueue.global().async {
+            result = FileDiffSource(url: url)
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 10)
+        return try XCTUnwrap(result)
+    }
+
+    func testFileSourceReadsLines() throws {
+        let url = try tempFile("one\ntwo\nthree\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let src = try makeFileSource(url)
+
+        XCTAssertEqual(src.lineCount, 3)
+        XCTAssertEqual(src.line(at: 0), "one")
+        XCTAssertEqual(src.line(at: 1), "two")
+        XCTAssertEqual(src.line(at: 2), "three")
+        XCTAssertEqual(src.lineHashes().count, 3)
+    }
+
+    func testFileSourceWithJapaneseAndCRLF() throws {
+        let url = try tempFile("あいう\r\nかきく\r\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let src = try makeFileSource(url)
+        XCTAssertEqual(src.line(at: 0), "あいう")   // CR が残らない
+        XCTAssertEqual(src.line(at: 1), "かきく")
+    }
+
+    func testTextSourceReadsLines() {
+        let src = TextDiffSource(text: "one\ntwo\nthree\n", displayName: "clip")
+        XCTAssertEqual(src.lineCount, 3)
+        XCTAssertEqual(src.line(at: 0), "one")
+        XCTAssertEqual(src.line(at: 2), "three")
+    }
+
+    /// ファイルとクリップボードで、同じ中身が同じハッシュになる（＝差分ゼロになる）。
+    /// ここがズレると「同じものを比べたのに全行が違う」と出る。
+    func testFileAndTextAgreeOnIdenticalContent() throws {
+        let text = "alpha\nbravo\ncharlie\n"
+        let url = try tempFile(text)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let f = try makeFileSource(url)
+        let t = TextDiffSource(text: text, displayName: "clip")
+
+        XCTAssertEqual(f.lineCount, t.lineCount)
+        XCTAssertEqual(f.lineHashes(), t.lineHashes())
+
+        let ops = LineDiff.compute(f.lineHashes(), t.lineHashes())
+        XCTAssertEqual(ops, [.equal(left: 0, right: 0, count: 3)])
+    }
+}
+
+/// アプリで左カラムが空白になった件の再現用。
+/// 実ログ規模（4,000 行）で、途中の行が読めるか。
+extension DiffSourceTests {
+    func testFileSourceReadsMiddleLineOfLargerFile() throws {
+        let lines = (0..<4000).map { "2026-06-26 12:00:00.\(String(format: "%03d", $0 % 1000)) [INFO] request_id=\($0)" }
+        let url = try tempFile(lines.joined(separator: "\n") + "\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let src = try makeFileSource(url)
+
+        XCTAssertEqual(src.lineCount, 4000)
+        XCTAssertEqual(src.line(at: 0), lines[0])
+        XCTAssertEqual(src.line(at: 117), lines[117])     // アプリで空白だったあたり
+        XCTAssertEqual(src.line(at: 3999), lines[3999])
+    }
+}

--- a/Tests/MrEditorTests/LineDiffTests.swift
+++ b/Tests/MrEditorTests/LineDiffTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import MrEditor
+
+/// 行 diff。**差分を見落とさないこと**が全て。
+/// 「op を左に適用したら右になる」を不変条件として、乱択でも壊れないことを見る。
+final class LineDiffTests: XCTestCase {
+
+    private func hashes(_ lines: [String]) -> [LineHash] {
+        lines.map { line in
+            var h = LineHasher()
+            for b in line.utf8 { h.feed(b) }
+            return h.value
+        }
+    }
+
+    /// ops を左の行列に適用して、右の行列を復元できるか。
+    /// これが通る限り「差分の見落とし」も「作り話」も無い。
+    private func apply(_ ops: [DiffOp], to left: [String], expecting right: [String]) -> [String] {
+        var out: [String] = []
+        for op in ops {
+            switch op {
+            case let .equal(l, _, c):            out.append(contentsOf: left[l..<(l + c)])
+            case .delete:                        break
+            case let .insert(r, c):              out.append(contentsOf: right[r..<(r + c)])
+            case let .replace(_, _, r, rc):      out.append(contentsOf: right[r..<(r + rc)])
+            }
+        }
+        return out
+    }
+
+    private func check(_ a: [String], _ b: [String], file: StaticString = #filePath, line: UInt = #line) {
+        let ops = LineDiff.compute(hashes(a), hashes(b))
+        XCTAssertEqual(apply(ops, to: a, expecting: b), b, "適用結果が右と一致しない", file: file, line: line)
+    }
+
+    func testIdentical() {
+        let a = ["x", "y", "z"]
+        let ops = LineDiff.compute(hashes(a), hashes(a))
+        XCTAssertEqual(ops, [.equal(left: 0, right: 0, count: 3)])
+    }
+
+    func testInsertInMiddle() {
+        check(["a", "b", "d"], ["a", "b", "c", "d"])
+    }
+
+    func testDeleteInMiddle() {
+        check(["a", "b", "c", "d"], ["a", "d"])
+    }
+
+    func testReplaceIsCoalesced() {
+        // 消して足した、ではなく「書き換わった」と見せる（行内差分をここに掛けるため）。
+        let ops = LineDiff.compute(hashes(["a", "x", "c"]), hashes(["a", "y", "c"]))
+        XCTAssertEqual(ops, [
+            .equal(left: 0, right: 0, count: 1),
+            .replace(left: 1, leftCount: 1, right: 1, rightCount: 1),
+            .equal(left: 2, right: 2, count: 1),
+        ])
+    }
+
+    func testEmptySides() {
+        check([], ["a", "b"])
+        check(["a", "b"], [])
+        check([], [])
+    }
+
+    func testNothingInCommon() {
+        check(["a", "b", "c"], ["x", "y", "z"])
+    }
+
+    /// 同じ行が大量に重複していてアンカーが取れない状況（ログでは普通に起きる）。
+    func testHighlyRepetitiveLines() {
+        let a = [String](repeating: "same", count: 200) + ["tail"]
+        let b = ["head"] + [String](repeating: "same", count: 200)
+        check(a, b)
+    }
+
+    /// 巨大な非アンカー区間は replace に畳む（諦めても、嘘はつかない＝復元はできる）。
+    func testHugeUnanchoredBlockFoldsToReplace() {
+        let a = (0..<3000).map { _ in "dup" }
+        let b = (0..<3000).map { _ in "other" }
+        let ops = LineDiff.compute(hashes(a), hashes(b))
+        XCTAssertEqual(apply(ops, to: a, expecting: b), b)
+        XCTAssertEqual(ops.count, 1)
+        guard case .replace = ops[0] else { return XCTFail("replace に畳まれていない: \(ops)") }
+    }
+
+    /// 乱択。ログを想定して「一部の行を書き換え・挿入・削除」した右を作り、往復を見る。
+    func testRandomEdits() {
+        var rng = SystemRandomNumberGenerator()
+        for trial in 0..<200 {
+            let n = Int.random(in: 0...80, using: &rng)
+            let a = (0..<n).map { "line \($0 % 17)" }   // わざと重複を作る
+            var b = a
+            for _ in 0..<Int.random(in: 0...10, using: &rng) {
+                guard !b.isEmpty else { b.append("new"); continue }
+                switch Int.random(in: 0...2, using: &rng) {
+                case 0: b.insert("ins \(Int.random(in: 0...99, using: &rng))", at: Int.random(in: 0...b.count, using: &rng))
+                case 1: b.remove(at: Int.random(in: 0..<b.count, using: &rng))
+                default: b[Int.random(in: 0..<b.count, using: &rng)] = "mod \(Int.random(in: 0...99, using: &rng))"
+                }
+            }
+            let ops = LineDiff.compute(hashes(a), hashes(b))
+            XCTAssertEqual(apply(ops, to: a, expecting: b), b, "trial \(trial): a=\(a) b=\(b) ops=\(ops)")
+        }
+    }
+
+    /// CRLF と LF の違いだけで「全行が違う」と言わない。
+    func testCRLFAndLFHashTheSame() {
+        let lf = Array("a\nb\n".utf8)
+        let crlf = Array("a\r\nb\r\n".utf8)
+        let h1 = lf.withUnsafeBytes { LineHasher.hashLines($0) }
+        let h2 = crlf.withUnsafeBytes { LineHasher.hashLines($0) }
+        XCTAssertEqual(h1, h2)
+    }
+}
+
+/// 行内の文字差分。
+final class CharDiffTests: XCTestCase {
+
+    func testSingleCharChange() {
+        let (l, r) = CharDiff.ranges(left: "status=200", right: "status=500")
+        XCTAssertEqual(l, [7..<8])
+        XCTAssertEqual(r, [7..<8])
+    }
+
+    func testInsertionOnly() {
+        let (l, r) = CharDiff.ranges(left: "abc", right: "abXc")
+        XCTAssertEqual(l, [])
+        XCTAssertEqual(r, [2..<3])
+    }
+
+    func testIdenticalHasNoRanges() {
+        let (l, r) = CharDiff.ranges(left: "同じ行", right: "同じ行")
+        XCTAssertTrue(l.isEmpty && r.isEmpty)
+    }
+
+    /// 絵文字・結合文字を割らない（Character 単位で数える）。
+    func testGraphemeSafety() {
+        let (l, r) = CharDiff.ranges(left: "あ👨‍👩‍👦い", right: "あ👨‍👩‍👦う")
+        XCTAssertEqual(l, [2..<3])
+        XCTAssertEqual(r, [2..<3])
+    }
+
+    /// 長すぎる行は行内差分を諦める（DP を回さない）。
+    func testVeryLongLineFallsBack() {
+        let a = String(repeating: "a", count: CharDiff.maxLineLength + 1)
+        let b = String(repeating: "b", count: CharDiff.maxLineLength + 1)
+        let (l, r) = CharDiff.ranges(left: a, right: b)
+        XCTAssertEqual(l, [0..<a.count])
+        XCTAssertEqual(r, [0..<b.count])
+    }
+}


### PR DESCRIPTION
ロードマップで「無料の目玉・シェア engine」とされていた **ローカル diff**。

## 入口は 3 つ、コアは 1 本

`DiffSource` を 1 枚かませ、ファイル（mmap）もメモリ上のテキストも同じ口に流す。

- **2 つのファイルを選ぶ**（⇧⌘D）
- **開いているドキュメント同士**（未保存の本文もそのまま比べる＝いま見えているものを比べる）
- **クリップボードと比較**

差分間の移動は ⇧⌘] / ⇧⌘[。

## メモリ

閲覧の看板（本文は 1 バイトも抱えない）を崩さないため:

- `DiffModel` は**行を実体化しない**。持つのは差分の手（ops）と累積行数だけで、画面に出る数十行を二分探索でその場に組む。
- ただし **diff 自体は 1 行 16 バイトの索引を要する**（128 ビットハッシュ。閲覧と違い、本当にメモリを使う）。10GB・86,420,337 行で実測 1.4GB。
- 固定の行数上限にせず、`DiffBudget` が **物理メモリから予算を決める**。載らない機械では黙って落ちずに理由を出して断る（8GB の Air と 64GB の Studio で同じ操作が片方だけ死ぬのが最悪なので）。

## 正しさ

- ハッシュは **128 ビット**。64 ビットだと 8,600 万行で衝突が無視できず、diff が「違う行を同じ」と言う＝**黙って差分を見落とす**。
- 乱択 200 試行で「**ops を左に適用したら右になる**」を検証。見落としも作り話も出ない。
- アンカーが取れない巨大区間は replace に畳む（諦めても嘘はつかない）。

## ついでに直した描画バグ

`DocumentView.draw` が `dirtyRect` をそのまま塗っていた。NSView は既定でクリップしないので、dirtyRect が bounds を超えると**隣のビューを塗り潰す**。単独表示では全面を塗るため露見しなかったが、左右に並べた途端に左カラムが消えた。

---

153 tests green。10GB の通常表示に回帰なし。

**次のスライス候補**: 巨大ファイル同士のストリーム diff（予算超過時）、横スクロールの左右同期、URL 比較。

🤖 Generated with [Claude Code](https://claude.com/claude-code)