### PR TITLE
diff の予算係数を実測値へ（2.5 → 6.5）

### DIFF
--- a/Sources/MrEditor/Core/DiffSource.swift
+++ b/Sources/MrEditor/Core/DiffSource.swift
@@ -141,10 +141,18 @@ final class TextDiffSource: DiffSource {
 enum DiffBudget {
 
     /// 物理メモリのうち diff に使ってよい割合。
-    /// ハッシュ列（16B/行 × 2 ファイル）に加え、アンカー探索の出現表が同程度乗るため、
-    /// 見積もりは実測の 2.5 倍を見ておく。
     static let fraction = 0.25
-    static let overheadFactor = 2.5
+
+    /// ハッシュ列（16B/行 × 2 ファイル）に対して、実際に積み上がる総量の倍率。
+    ///
+    /// **実測値**（2026-07-13、配布と同じ最適化ビルド、1GB × 2 ＝ 8,712,081 行）:
+    ///   行ハッシュ 270 MB → ピーク実メモリ 1,765 MB ＝ **6.5 倍**。
+    /// 差分の大半は `LineDiff.uniqueAnchors` が区間ごとに作る出現表（Dictionary）。
+    ///
+    /// 当初は 2.5 と置いていたが、これは**推測で、2.6 倍の過小評価だった**。
+    /// 10GB × 2 で判定を無理に通したところ、実際に 8.8GB を超えて落ちた
+    /// （この係数なら正しく断る）。数字は測ってから書く。
+    static let overheadFactor = 6.5
 
     static func estimatedBytes(leftLines: Int, rightLines: Int) -> Int {
         Int(Double((leftLines + rightLines) * MemoryLayout<LineHash>.size) * overheadFactor)


### PR DESCRIPTION
`DiffBudget.overheadFactor` は**推測で 2.5** と置いていた。実測したら **6.5**（2.6 倍の過小評価）。

## 実測（配布と同じ最適化ビルド）

**1GB × 2（8,712,081 行）**

| | |
|---|---|
| 合計時間 | 5.4 秒 |
| 行ハッシュ（2本） | 270 MB |
| ピーク実メモリ | **1,765 MB** |
| 倍率 | **6.5×** |

仕込んだ差分（100,000 行目の書き換え・4,000,000 行目の挿入・6,000,000 行目の欠落）を、位置も種類も正確に検出。

**10GB × 2** は判定を無理に通したところ **8.8GB を超えて落ちた**。係数 6.5 なら正しく断る（見積り 17GB > 上限 6GB）。2.5 のままだと「予算判定を通ったのに落ちる」という最悪の形になっていた。

## 効果

この係数で **予測 1,728 MB に対し実測 1,765 MB（誤差 2%）**。24GB の機械なら左右あわせて約 6,200 万行（1 ファイル ≒ 3.5GB のログ）まで。

10GB 同士の diff は現実の使い方ではないので、限界は正直に断る形で残す。

161 tests green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)