### PR TITLE
マージの矢印を VoiceOver / E2E から押せるようにする

### DIFF
--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "diff.saveMerged" = "Save";
 "diff.saveFailed" = "Could not save the merged result";
 "diff.adopted" = "%d taken";
+"diff.a11y.take" = "Push this difference to the right";
+"diff.a11y.undo" = "Undo push";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "diff.saveMerged" = "保存";
 "diff.saveFailed" = "マージ結果を保存できませんでした";
 "diff.adopted" = "%d 箇所を取り込み";
+"diff.a11y.take" = "この差分を右へ取り込む";
+"diff.a11y.undo" = "取り込みを取り消す";

--- a/Sources/MrEditor/UI/MergeGutter.swift
+++ b/Sources/MrEditor/UI/MergeGutter.swift
@@ -115,4 +115,39 @@ final class MergeGutter: NSView {
                           cursor: .pointingHand)
         }
     }
+
+    // MARK: - アクセシビリティ
+
+    /// 矢印を**本物のボタンとして公開する**。
+    ///
+    /// VoiceOver から押せるようになる（実利）。同時に、E2E テストが**座標に頼らず**
+    /// 名前で押せるようになる ―― 座標クリックの検証は、ウィンドウ位置が 4pt ずれた
+    /// だけで嘘の結果を出す（実際に 4 回続けて騙された）。
+    override func isAccessibilityElement() -> Bool { false }
+
+    override func accessibilityRole() -> NSAccessibility.Role? { .group }
+
+    override func accessibilityChildren() -> [Any]? {
+        rows.enumerated().compactMap { i, row -> MergeArrowElement? in
+            guard row.isHead, let op = row.hunkOp else { return nil }
+            let e = MergeArrowElement()
+            e.setAccessibilityParent(self)
+            e.setAccessibilityRole(.button)
+            e.setAccessibilityLabel(L(row.adopted ? "diff.a11y.undo" : "diff.a11y.take"))
+            e.setAccessibilityIdentifier("merge-arrow-\(op)")
+            e.setAccessibilityFrameInParentSpace(
+                NSRect(x: 0, y: CGFloat(i) * lineHeight, width: bounds.width, height: lineHeight))
+            e.onPress = { [weak self] in self?.onToggle?(op) }
+            return e
+        }
+    }
+}
+
+/// ガターの矢印 1 つ。押せる（VoiceOver / E2E から）。
+final class MergeArrowElement: NSAccessibilityElement {
+    var onPress: (() -> Void)?
+    override func accessibilityPerformPress() -> Bool {
+        onPress?()
+        return true
+    }
 }


### PR DESCRIPTION
矢印を**本物のボタン**として公開する（`NSAccessibilityElement`、identifier = `merge-arrow-<op>`）。

- **VoiceOver から押せる**（実利）
- **E2E テストが座標に頼らず名前で押せる** —— 座標クリックの検証は、ウィンドウ位置が 4pt ずれただけで嘘の結果を出す（実際にそれで 4 回続けて騙された）

174 tests green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)