### PR TITLE
LP/README/site の整合性を正し、性能値を 1.2.1 で測り直す

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -34,7 +34,7 @@ macOS でテキストを表示する定番は `NSTextView` ですが、内部の
 
 設計の詳細は [docs/ARCHITECTURE_v0.1.md](docs/ARCHITECTURE_v0.1.md) を参照してください。
 
-## 機能（1.0）
+## 機能（1.2）
 
 **表示**
 - 任意サイズの巨大テキストを開ける（10GB で検証済み）。表示開始はほぼ一瞬。
@@ -134,32 +134,33 @@ python3 scripts/gen_testdata.py --size 10G --jp --out testdata/test_10gb.log
 sh scripts/make_dmg.sh
 ```
 
-## 性能（2026-07-12 実測 / 10.00GB・86,420,337 行・日本語 UTF-8）
+## 性能（2026-07-15 実測 / 10.00GB・86,420,337 行・日本語 UTF-8）
 
-配布と同じビルド（`swift build -c release --arch arm64 --arch x86_64`）、Apple Silicon で計測。
+配布と同じ 1.2.1 ビルド（`swift build -c release --arch arm64 --arch x86_64`）、Apple Silicon で計測。
 
 | 指標 | 結果 |
 |---|---|
-| 表示開始まで（first paint） | 65〜83ms |
-| 全索引の構築（背景・表示はブロックしない） | 9.1〜9.5 秒 |
+| 表示開始まで（first paint） | 55〜90ms |
+| 全索引の構築（背景・表示はブロックしない） | 9.3〜10.2 秒 |
 | 末尾行へのシーク | 0.1ms |
-| ファイル本体のページ | resident 4.2GB・**dirty 0 バイト** |
-| アプリの実メモリ | 開いた状態で 162MB（何も開いていなければ 32MB） |
+| ファイル本体のページ | resident 約 4GB・**dirty 0 バイト** |
+| アプリの実メモリ | 約 130MB（何も開いていなくてもほぼ同じ） |
 
 下の 2 行は必ずセットで読んでください。**開いた 10GB のコストは 0 です**。マップするだけで
 コピーせず、`vmmap` がそのファイルに帰属させる dirty は 0 バイト —— resident なページは
-ファイルバックドで、OS がいつでも捨てられます。アプリ側の 162MB はウィンドウの描画バッファと、
-10GB をマップするためのカーネルのページテーブルであって、あなたのログではありません。索引構築中に
-`ps` の RSS が数 GB に見えるのも同じ理由で、同じくらい意味がありません。
+ファイルバックドで、OS がいつでも捨てられます。アプリ側の約 130MB はウィンドウの描画バッファと、
+10GB をマップするためのカーネルのページテーブルであって、ファイルを開いていてもいなくてもほとんど
+変わらず、あなたのログではありません。索引構築中に `ps` の RSS が数 GB に見えるのも同じ理由で、
+同じくらい意味がありません。
 
 手元で再現するには:
 
 ```sh
 MREDITOR_TIMING=1 .build/MrEditor.app/Contents/MacOS/MrEditor testdata/test_10gb.log
-# → first paint: 81.3 ms
-# → index complete: 9.06 s (86420337 lines)
+# → first paint: 74.9 ms
+# → index complete: 9.98 s (86420337 lines)
 
-vmmap $(pgrep -x MrEditor) | grep test_10gb.log     # → 10.0G  4.2G  0K  (vsize resident dirty)
+vmmap $(pgrep -x MrEditor) | grep test_10gb.log     # → 10.0G  4.4G  0K  (vsize resident dirty; resident は変動・dirty は 0 のまま)
 ```
 
 ## ロードマップ

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ approach (klogg / glogg / lnav):
 
 See [docs/ARCHITECTURE_v0.1.md](docs/ARCHITECTURE_v0.1.md) for the full design.
 
-## Features (1.0)
+## Features (1.2)
 
 **Viewing**
 - Opens arbitrarily large text files (validated at 10 GB) with near-instant first paint.
@@ -136,32 +136,33 @@ Build a distributable disk image (`.build/MrEditor-1.2.1.dmg`):
 sh scripts/make_dmg.sh
 ```
 
-## Performance (measured 2026-07-12, 10.00 GB / 86,420,337 lines, Japanese UTF-8)
+## Performance (measured 2026-07-15, 10.00 GB / 86,420,337 lines, Japanese UTF-8)
 
-Measured on the shipping build (`swift build -c release --arch arm64 --arch x86_64`), Apple Silicon.
+Measured on the shipping 1.2.1 build (`swift build -c release --arch arm64 --arch x86_64`), Apple Silicon.
 
 | Metric | Result |
 |---|---|
-| Time to first paint | 65–83 ms |
-| Full background index | 9.1–9.5 s (does not block display) |
+| Time to first paint | 55–90 ms |
+| Full background index | 9.3–10.2 s (does not block display) |
 | Seek to last line | 0.1 ms |
-| The file's own pages | 4.2 GB resident, **0 bytes dirty** |
-| App physical footprint | 162 MB with the file open (32 MB with nothing open) |
+| The file's own pages | ~4 GB resident, **0 bytes dirty** |
+| App physical footprint | ~130 MB — about the same with nothing open |
 
 The last two rows are the honest picture, so read them together. The 10 GB you opened costs
 nothing: it is mapped, not copied, and `vmmap` attributes **0 dirty bytes** to it — the resident
-pages are file-backed and the OS can drop them whenever it likes. The app's own 162 MB is window
-backing store and the kernel page tables for a 10 GB mapping; it is not your log. `ps` RSS reads
-several GB during indexing for the same reason, and means just as little.
+pages are file-backed and the OS can drop them whenever it likes. The app's own ~130 MB is window
+backing store and the kernel page tables for a 10 GB mapping; it barely moves whether the file is
+open or not, and none of it is your log. `ps` RSS reads several GB during indexing for the same
+reason, and means just as little.
 
 Reproduce it yourself:
 
 ```sh
 MREDITOR_TIMING=1 .build/MrEditor.app/Contents/MacOS/MrEditor testdata/test_10gb.log
-# → first paint: 81.3 ms
-# → index complete: 9.06 s (86420337 lines)
+# → first paint: 74.9 ms
+# → index complete: 9.98 s (86420337 lines)
 
-vmmap $(pgrep -x MrEditor) | grep test_10gb.log     # → 10.0G  4.2G  0K  (vsize resident dirty)
+vmmap $(pgrep -x MrEditor) | grep test_10gb.log     # → 10.0G  4.4G  0K  (vsize resident dirty; resident varies, dirty stays 0)
 ```
 
 ## Roadmap

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -143,7 +143,7 @@
     <div class="stat"><div class="n">80<small>ms</small></div><div class="l">until the first line shows</div></div>
     <div class="stat"><div class="n">0.1<small>ms</small></div><div class="l">to jump to line 86,420,337</div></div>
   </div>
-  <p class="note stats-note">Zero is not a rounding. The file is mapped, never copied: with all 10 GB open, <code>vmmap</code> reports 4.2 GB resident and <strong>0 bytes dirty</strong> for it — pages the OS can drop at any moment, holding nothing of ours. The app itself has a 162 MB footprint (32 MB of that before you open anything); that is window buffers and the page tables for a 10 GB mapping, not your log. Measured 2026-07-12 on the shipping 1.0.2 build.</p>
+  <p class="note stats-note">Zero is not a rounding. The file is mapped, never copied: with all 10 GB open, <code>vmmap</code> reports about 4 GB resident and <strong>0 bytes dirty</strong> for it — pages the OS can drop at any moment, holding nothing of ours. The app's own footprint is about 130 MB, and it stays about that whether or not the file is open: opening 10 GB adds only the page tables for the mapping, not your log. Measured 2026-07-15 on the shipping 1.2.1 build.</p>
 
   <section>
     <div class="eyebrow">The visual</div>

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -143,7 +143,7 @@
     <div class="stat"><div class="n">80<small>ms</small></div><div class="l">最初の行が出るまで</div></div>
     <div class="stat"><div class="n">0.1<small>ms</small></div><div class="l">86,420,337 行目へ跳ぶ</div></div>
   </div>
-  <p class="note stats-note">0 は四捨五入ではありません。ファイルはマップするだけで、コピーしません。10 GB を開いた状態で <code>vmmap</code> を見ると、そのファイルは resident 4.2 GB・<strong>dirty は 0 バイト</strong> —— OS がいつでも捨てられるページで、アプリは 1 バイトも抱えていません。アプリ自体の実メモリは 162 MB（うち 32 MB は何も開いていないときの分）。その中身はウィンドウの描画バッファと、10 GB をマップするためのページテーブルであって、あなたのログではありません。2026-07-12、配布版 1.0.2 で実測。</p>
+  <p class="note stats-note">0 は四捨五入ではありません。ファイルはマップするだけで、コピーしません。10 GB を開いた状態で <code>vmmap</code> を見ると、そのファイルは resident 約 4 GB・<strong>dirty は 0 バイト</strong> —— OS がいつでも捨てられるページで、アプリは 1 バイトも抱えていません。アプリ自体の実メモリは約 130 MB。しかもファイルを開いていてもいなくてもほぼ同じで、10 GB を開いて増えるのはマッピングのページテーブルだけ、あなたのログではありません。2026-07-15、配布版 1.2.1 で実測。</p>
 
   <section>
     <div class="eyebrow">ビュー</div>

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -154,8 +154,8 @@
     <div class="stat"><div class="n">0.1<small>ms</small></div><div class="l" data-en="to jump to line 86,420,337" data-ja="86,420,337 行目へ跳ぶ"></div></div>
   </div>
   <p class="note stats-note"
-     data-en="Zero is not a rounding. The file is mapped, never copied: with all 10 GB open, <code>vmmap</code> reports 4.2 GB resident and <strong>0 bytes dirty</strong> for it — pages the OS can drop at any moment, holding nothing of ours. The app itself has a 162 MB footprint (32 MB of that before you open anything); that is window buffers and the page tables for a 10 GB mapping, not your log. Measured 2026-07-12 on the shipping 1.0.2 build."
-     data-ja="0 は四捨五入ではありません。ファイルはマップするだけで、コピーしません。10 GB を開いた状態で <code>vmmap</code> を見ると、そのファイルは resident 4.2 GB・<strong>dirty は 0 バイト</strong> —— OS がいつでも捨てられるページで、アプリは 1 バイトも抱えていません。アプリ自体の実メモリは 162 MB（うち 32 MB は何も開いていないときの分）。その中身はウィンドウの描画バッファと、10 GB をマップするためのページテーブルであって、あなたのログではありません。2026-07-12、配布版 1.0.2 で実測。"></p>
+     data-en="Zero is not a rounding. The file is mapped, never copied: with all 10 GB open, <code>vmmap</code> reports about 4 GB resident and <strong>0 bytes dirty</strong> for it — pages the OS can drop at any moment, holding nothing of ours. The app's own footprint is about 130 MB, and it stays about that whether or not the file is open: opening 10 GB adds only the page tables for the mapping, not your log. Measured 2026-07-15 on the shipping 1.2.1 build."
+     data-ja="0 は四捨五入ではありません。ファイルはマップするだけで、コピーしません。10 GB を開いた状態で <code>vmmap</code> を見ると、そのファイルは resident 約 4 GB・<strong>dirty は 0 バイト</strong> —— OS がいつでも捨てられるページで、アプリは 1 バイトも抱えていません。アプリ自体の実メモリは約 130 MB。しかもファイルを開いていてもいなくてもほぼ同じで、10 GB を開いて増えるのはマッピングのページテーブルだけ、あなたのログではありません。2026-07-15、配布版 1.2.1 で実測。"></p>
 
   <section>
     <div class="eyebrow" data-en="The visual" data-ja="ビュー"></div>


### PR DESCRIPTION
## 概要
LP・README（日英）・生成物 site の横断整合性チェックで見つかった不整合を修正し、あわせて性能値を配布 1.2.1 で**測り直して**更新しました。

## 修正内容
- **機能見出し** `(1.0)` → `(1.2)`（en/ja）— 中身は v1.1 比較・v1.2 マージまで含むのに 1.0 表記のままだった
- **性能節を 2026-07-15・配布 1.2.1 の実測に更新**（10.00GB / 86,420,337 行・日本語 UTF-8）
  | 指標 | 旧 | 新（実測） |
  |---|---|---|
  | first paint | 65–83ms | **55–90ms** |
  | 全索引 | 9.1–9.5s | **9.3–10.2s** |
  | resident / dirty | 4.2GB / 0 | **~4GB / 0**（不変を再確認） |
  | footprint | 162MB（空32MB） | **~130MB（空でもほぼ同じ）** |
- **実メモリの訂正**: 「10GB を開いても開かなくても ~130MB ＝ 開くコストは実質 0」。旧「162MB・空 32MB」は 1.0 以前の値の使い回しで**両方とも誤り**だった（むしろ開閉でメモリがほぼ動かない、という強い訴求に反転）
- **LP 0バイト注記**の測定日/ビルドを `2026-07-12・1.0.2` → `2026-07-15・1.2.1` に
- `site/index.{en,ja}.html` は `build_site.py` で再生成（手編集なし）

## 据え置いた箇所（意図的）
stat タイル（10GB / 0B / 80ms / 0.1ms）、gif・動画キャプション（特定録画そのものの描写: 9.1s・89,292,800・137,111・27秒）、ヘッドライン `~80ms`、行数 `86,420,337`。いずれも現行値として有効、または特定の記録物のため。

## 検証
- 配布と同じ 1.2.1 universal release ビルド × `testdata/test_10gb.log` で `MREDITOR_TIMING` / `vmmap` により 3–4 回計測
- i18n キーは ja/en 157 件一致（差分なし）、生成物 site はソースと同期
- 旧値の grep スイープ: 製品ドキュメントに残存ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)