### PR TITLE
編集ツールボックス: エンコード群（URL/Base64/HTML）＋行操作

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -449,7 +449,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
         addTransformItems(TextTransform.caseGroup)        // 大文字/小文字/…
         formatMenu.addItem(.separator())
-        addTransformItems(TextTransform.encodingGroup)    // URL/Base64 エンコード・デコード
+        addTransformItems(TextTransform.encodingGroup)    // URL/Base64/HTML エンコード・デコード
+        formatMenu.addItem(.separator())
+        addTransformItems(TextTransform.lineGroup)        // 行ソート/重複削除/逆順/連番
         formatMenu.addItem(.separator())
         // 選択を外部コマンドに通して置換（sort / jq / sed … その場フィルタ）。
         let filterItem = NSMenuItem(title: L("menu.format.filter"),

--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -438,13 +438,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         mainMenu.addItem(formatMenuItem)
         let formatMenu = NSMenu(title: L("menu.format"))
         formatMenuItem.submenu = formatMenu
-        for t in TextTransform.allCases {
-            let it = NSMenuItem(title: L(t.localizationKey),
-                                action: #selector(applyTextTransform(_:)), keyEquivalent: "")
-            it.tag = t.rawValue
-            it.target = self
-            formatMenu.addItem(it)
+        func addTransformItems(_ transforms: [TextTransform]) {
+            for t in transforms {
+                let it = NSMenuItem(title: L(t.localizationKey),
+                                    action: #selector(applyTextTransform(_:)), keyEquivalent: "")
+                it.tag = t.rawValue
+                it.target = self
+                formatMenu.addItem(it)
+            }
         }
+        addTransformItems(TextTransform.caseGroup)        // 大文字/小文字/…
+        formatMenu.addItem(.separator())
+        addTransformItems(TextTransform.encodingGroup)    // URL/Base64 エンコード・デコード
         formatMenu.addItem(.separator())
         // 選択を外部コマンドに通して置換（sort / jq / sed … その場フィルタ）。
         let filterItem = NSMenuItem(title: L("menu.format.filter"),

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -78,6 +78,10 @@
 "menu.format.lowercase" = "lowercase";
 "menu.format.titlecase" = "Title Case";
 "menu.format.togglecase" = "Toggle Case";
+"menu.format.urlEncode" = "URL Encode";
+"menu.format.urlDecode" = "URL Decode";
+"menu.format.base64Encode" = "Base64 Encode";
+"menu.format.base64Decode" = "Base64 Decode";
 "menu.format.filter" = "Filter Through Command…";
 
 "filter.prompt" = "Filter selection through command";

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -82,6 +82,13 @@
 "menu.format.urlDecode" = "URL Decode";
 "menu.format.base64Encode" = "Base64 Encode";
 "menu.format.base64Decode" = "Base64 Decode";
+"menu.format.htmlEncode" = "HTML Encode";
+"menu.format.htmlDecode" = "HTML Decode";
+"menu.format.sortAscending" = "Sort Lines (Ascending)";
+"menu.format.sortDescending" = "Sort Lines (Descending)";
+"menu.format.uniqueLines" = "Remove Duplicate Lines";
+"menu.format.reverseLines" = "Reverse Lines";
+"menu.format.numberLines" = "Number Lines";
 "menu.format.filter" = "Filter Through Command…";
 
 "filter.prompt" = "Filter selection through command";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -78,6 +78,10 @@
 "menu.format.lowercase" = "小文字に";
 "menu.format.titlecase" = "各単語の先頭を大文字に";
 "menu.format.togglecase" = "大文字・小文字を反転";
+"menu.format.urlEncode" = "URL エンコード";
+"menu.format.urlDecode" = "URL デコード";
+"menu.format.base64Encode" = "Base64 エンコード";
+"menu.format.base64Decode" = "Base64 デコード";
 "menu.format.filter" = "外部コマンドに通す…";
 
 "filter.prompt" = "選択を外部コマンドに通す";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -82,6 +82,13 @@
 "menu.format.urlDecode" = "URL デコード";
 "menu.format.base64Encode" = "Base64 エンコード";
 "menu.format.base64Decode" = "Base64 デコード";
+"menu.format.htmlEncode" = "HTML エンコード";
+"menu.format.htmlDecode" = "HTML デコード";
+"menu.format.sortAscending" = "行をソート（昇順）";
+"menu.format.sortDescending" = "行をソート（降順）";
+"menu.format.uniqueLines" = "重複行を削除";
+"menu.format.reverseLines" = "行を逆順に";
+"menu.format.numberLines" = "行に連番を振る";
 "menu.format.filter" = "外部コマンドに通す…";
 
 "filter.prompt" = "選択を外部コマンドに通す";

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -181,7 +181,7 @@ extension DocumentPane {
     /// 選択テキストに純粋変換を適用する。selectedText/replaceSelection の上に載るだけ。
     func applyTextTransform(_ transform: TextTransform) {
         guard let source = selectedText, !source.isEmpty else { NSSound.beep(); return }
-        let result = transform.apply(source)
+        guard let result = transform.apply(source) else { NSSound.beep(); return }   // 変換不能（不正入力）
         guard result != source else { return }   // 変化なしはアンドゥを積まない
         replaceSelection(with: result)
     }

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -602,10 +602,19 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             encodingName: encoding.displayName,
             lineCount: lineCount(of: logicalText),
             lineCountIsExact: true,
-            fileSize: byteSize,
+            // クリーン時は読み込み時の実ディスクサイズ（正確・安価）。編集中は保存されるバイト数をライブ計算。
+            fileSize: isDirty ? liveByteSize : byteSize,
             indexProgress: 1.0
         )
         onStateChange?(state)
+    }
+
+    /// 現在のバッファを保存したときのバイト数（EOL 正規化＋保存エンコード込み）。
+    /// 表現不能なエンコードのときは UTF-8 での概算に落とす。
+    private var liveByteSize: Int {
+        let normalized = lineEnding.normalize(logicalText)
+        let n = normalized.lengthOfBytes(using: encoding.stringEncoding)
+        return (n > 0 || normalized.isEmpty) ? n : normalized.utf8.count
     }
 
     /// 行数（末尾に改行がなければその行も 1 行として数える）。空文字列は 0 行。

--- a/Sources/MrEditor/Viewer/TextTransforms.swift
+++ b/Sources/MrEditor/Viewer/TextTransforms.swift
@@ -3,23 +3,38 @@ import Foundation
 /// 編集ツールボックスの純粋なテキスト変換（String→String）。
 /// バックエンド（NSTextView / PieceTable）に依存せず、両ペインから同じロジックを使う。
 enum TextTransform: Int, CaseIterable {
+    // ケース変換
     case uppercase
     case lowercase
     case titlecase
     case togglecase
+    // エンコード／デコード
+    case urlEncode
+    case urlDecode
+    case base64Encode
+    case base64Decode
+
+    /// ケース変換グループ（書式メニューの第1グループ）。
+    static let caseGroup: [TextTransform] = [.uppercase, .lowercase, .titlecase, .togglecase]
+    /// エンコード／デコードグループ（書式メニューの第2グループ）。
+    static let encodingGroup: [TextTransform] = [.urlEncode, .urlDecode, .base64Encode, .base64Decode]
 
     /// メニュー項目のローカライズキー。
     var localizationKey: String {
         switch self {
-        case .uppercase:  return "menu.format.uppercase"
-        case .lowercase:  return "menu.format.lowercase"
-        case .titlecase:  return "menu.format.titlecase"
-        case .togglecase: return "menu.format.togglecase"
+        case .uppercase:    return "menu.format.uppercase"
+        case .lowercase:    return "menu.format.lowercase"
+        case .titlecase:    return "menu.format.titlecase"
+        case .togglecase:   return "menu.format.togglecase"
+        case .urlEncode:    return "menu.format.urlEncode"
+        case .urlDecode:    return "menu.format.urlDecode"
+        case .base64Encode: return "menu.format.base64Encode"
+        case .base64Decode: return "menu.format.base64Decode"
         }
     }
 
-    /// 選択文字列に変換を適用して返す。
-    func apply(_ s: String) -> String {
+    /// 選択文字列に変換を適用して返す。`nil` は変換不能（不正な入力など）＝呼び出し側はビープして本文を変えない。
+    func apply(_ s: String) -> String? {
         switch self {
         case .uppercase:  return s.uppercased()
         case .lowercase:  return s.lowercased()
@@ -28,6 +43,18 @@ enum TextTransform: Int, CaseIterable {
             c.isUppercase ? Character(c.lowercased()) :
             c.isLowercase ? Character(c.uppercased()) : c
         })
+        case .urlEncode:  return s.addingPercentEncoding(withAllowedCharacters: Self.urlUnreserved)
+        case .urlDecode:  return s.removingPercentEncoding
+        case .base64Encode: return Data(s.utf8).base64EncodedString()
+        case .base64Decode:
+            // 改行入りの折り返し Base64 も通す（不明文字は無視）。復号後が UTF-8 でなければ nil。
+            guard let data = Data(base64Encoded: s, options: .ignoreUnknownCharacters),
+                  let text = String(data: data, encoding: .utf8) else { return nil }
+            return text
         }
     }
+
+    /// RFC 3986 の unreserved（これ以外を % エンコードする）。
+    private static let urlUnreserved = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 }

--- a/Sources/MrEditor/Viewer/TextTransforms.swift
+++ b/Sources/MrEditor/Viewer/TextTransforms.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// 編集ツールボックスの純粋なテキスト変換（String→String）。
 /// バックエンド（NSTextView / PieceTable）に依存せず、両ペインから同じロジックを使う。
+/// 行操作系は「選択されたテキストをそのまま分割して処理」する（フィルタ ⌥⌘R と同じ考え方）。
 enum TextTransform: Int, CaseIterable {
     // ケース変換
     case uppercase
@@ -13,23 +14,40 @@ enum TextTransform: Int, CaseIterable {
     case urlDecode
     case base64Encode
     case base64Decode
+    case htmlEncode
+    case htmlDecode
+    // 行操作
+    case sortAscending
+    case sortDescending
+    case uniqueLines
+    case reverseLines
+    case numberLines
 
     /// ケース変換グループ（書式メニューの第1グループ）。
     static let caseGroup: [TextTransform] = [.uppercase, .lowercase, .titlecase, .togglecase]
-    /// エンコード／デコードグループ（書式メニューの第2グループ）。
-    static let encodingGroup: [TextTransform] = [.urlEncode, .urlDecode, .base64Encode, .base64Decode]
+    /// エンコード／デコードグループ（第2グループ）。
+    static let encodingGroup: [TextTransform] = [.urlEncode, .urlDecode, .base64Encode, .base64Decode, .htmlEncode, .htmlDecode]
+    /// 行操作グループ（第3グループ）。
+    static let lineGroup: [TextTransform] = [.sortAscending, .sortDescending, .uniqueLines, .reverseLines, .numberLines]
 
     /// メニュー項目のローカライズキー。
     var localizationKey: String {
         switch self {
-        case .uppercase:    return "menu.format.uppercase"
-        case .lowercase:    return "menu.format.lowercase"
-        case .titlecase:    return "menu.format.titlecase"
-        case .togglecase:   return "menu.format.togglecase"
-        case .urlEncode:    return "menu.format.urlEncode"
-        case .urlDecode:    return "menu.format.urlDecode"
-        case .base64Encode: return "menu.format.base64Encode"
-        case .base64Decode: return "menu.format.base64Decode"
+        case .uppercase:      return "menu.format.uppercase"
+        case .lowercase:      return "menu.format.lowercase"
+        case .titlecase:      return "menu.format.titlecase"
+        case .togglecase:     return "menu.format.togglecase"
+        case .urlEncode:      return "menu.format.urlEncode"
+        case .urlDecode:      return "menu.format.urlDecode"
+        case .base64Encode:   return "menu.format.base64Encode"
+        case .base64Decode:   return "menu.format.base64Decode"
+        case .htmlEncode:     return "menu.format.htmlEncode"
+        case .htmlDecode:     return "menu.format.htmlDecode"
+        case .sortAscending:  return "menu.format.sortAscending"
+        case .sortDescending: return "menu.format.sortDescending"
+        case .uniqueLines:    return "menu.format.uniqueLines"
+        case .reverseLines:   return "menu.format.reverseLines"
+        case .numberLines:    return "menu.format.numberLines"
         }
     }
 
@@ -51,10 +69,113 @@ enum TextTransform: Int, CaseIterable {
             guard let data = Data(base64Encoded: s, options: .ignoreUnknownCharacters),
                   let text = String(data: data, encoding: .utf8) else { return nil }
             return text
+        case .htmlEncode: return Self.htmlEncode(s)
+        case .htmlDecode: return Self.htmlDecode(s)
+        case .sortAscending:  return Self.sortLines(s, by: <)
+        case .sortDescending: return Self.sortLines(s, by: >)
+        case .uniqueLines:    return Self.uniqueLines(s)
+        case .reverseLines:   return Self.mapLines(s) { Array($0.reversed()) }
+        case .numberLines:    return Self.numberLines(s)
         }
     }
 
     /// RFC 3986 の unreserved（これ以外を % エンコードする）。
     private static let urlUnreserved = CharacterSet(
         charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+    // MARK: - HTML エンティティ
+
+    private static func htmlEncode(_ s: String) -> String {
+        var out = ""
+        out.reserveCapacity(s.count)
+        for ch in s {
+            switch ch {
+            case "&":  out += "&amp;"
+            case "<":  out += "&lt;"
+            case ">":  out += "&gt;"
+            case "\"": out += "&quot;"
+            case "'":  out += "&#39;"
+            default:   out.append(ch)
+            }
+        }
+        return out
+    }
+
+    /// 数値参照（10 進 / 16 進）と主要な名前付きエンティティを1パスで復号する。
+    /// 未知のエンティティはそのまま残す（壊さない）。
+    private static func htmlDecode(_ s: String) -> String {
+        let ns = s as NSString
+        let matches = htmlEntityRegex.matches(in: s, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return s }
+        var out = ""
+        var last = 0
+        for m in matches {
+            out += ns.substring(with: NSRange(location: last, length: m.range.location - last))
+            let body = ns.substring(with: m.range(at: 1))   // & と ; を除いた中身
+            out += decodeEntityBody(body) ?? ns.substring(with: m.range)
+            last = m.range.location + m.range.length
+        }
+        out += ns.substring(with: NSRange(location: last, length: ns.length - last))
+        return out
+    }
+
+    private static func decodeEntityBody(_ body: String) -> String? {
+        if body.hasPrefix("#") {
+            let num = body.dropFirst()
+            let scalar: UInt32? = (num.first == "x" || num.first == "X")
+                ? UInt32(num.dropFirst(), radix: 16) : UInt32(num, radix: 10)
+            guard let value = scalar, let u = Unicode.Scalar(value) else { return nil }
+            return String(u)
+        }
+        return htmlNamed[body].map(String.init)
+    }
+
+    private static let htmlEntityRegex =
+        try! NSRegularExpression(pattern: "&(#[0-9]+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);")
+
+    private static let htmlNamed: [String: Character] = [
+        "amp": "&", "lt": "<", "gt": ">", "quot": "\"", "apos": "'", "nbsp": "\u{00A0}",
+        "copy": "\u{00A9}", "reg": "\u{00AE}", "trade": "\u{2122}", "hellip": "\u{2026}",
+        "mdash": "\u{2014}", "ndash": "\u{2013}", "lsquo": "\u{2018}", "rsquo": "\u{2019}",
+        "ldquo": "\u{201C}", "rdquo": "\u{201D}", "middot": "\u{00B7}", "bull": "\u{2022}",
+    ]
+
+    // MARK: - 行操作
+
+    /// 末尾改行を保ったまま行に分割する（分割で生じる末尾の空要素を落とす）。
+    private static func splitLines(_ s: String) -> (lines: [String], trailingNewline: Bool) {
+        let hasTrailing = s.hasSuffix("\n")
+        var lines = s.components(separatedBy: "\n")
+        if hasTrailing { lines.removeLast() }
+        return (lines, hasTrailing)
+    }
+
+    private static func joinLines(_ lines: [String], trailingNewline: Bool) -> String {
+        lines.joined(separator: "\n") + (trailingNewline ? "\n" : "")
+    }
+
+    private static func sortLines(_ s: String, by areInIncreasingOrder: (String, String) -> Bool) -> String {
+        let (lines, trailing) = splitLines(s)
+        return joinLines(lines.sorted(by: areInIncreasingOrder), trailingNewline: trailing)
+    }
+
+    /// 重複行を削除（初出の順序を保つ）。
+    private static func uniqueLines(_ s: String) -> String {
+        let (lines, trailing) = splitLines(s)
+        var seen = Set<String>()
+        let unique = lines.filter { seen.insert($0).inserted }
+        return joinLines(unique, trailingNewline: trailing)
+    }
+
+    private static func mapLines(_ s: String, _ transform: ([String]) -> [String]) -> String {
+        let (lines, trailing) = splitLines(s)
+        return joinLines(transform(lines), trailingNewline: trailing)
+    }
+
+    /// 各行の先頭に 1 始まりの連番＋タブを付ける。
+    private static func numberLines(_ s: String) -> String {
+        let (lines, trailing) = splitLines(s)
+        let numbered = lines.enumerated().map { "\($0.offset + 1)\t\($0.element)" }
+        return joinLines(numbered, trailingNewline: trailing)
+    }
 }

--- a/Tests/MrEditorTests/EditableViewerTests.swift
+++ b/Tests/MrEditorTests/EditableViewerTests.swift
@@ -214,6 +214,18 @@ final class EditableViewerTests: XCTestCase {
         XCTAssertEqual(v._testText, "hello")
     }
 
+    /// 編集後、ステータスのバイト数が保存を待たずライブ更新される（行数だけでなくサイズも）。
+    func testStatusByteSizeUpdatesLiveAfterEdit() {
+        let v = EditableViewer()
+        var last: ViewerState?
+        v.onStateChange = { last = $0 }
+        v._testSetText("ab")
+        v._testSelect(NSRange(location: 0, length: 2))
+        v.applyTextTransform(.base64Encode)           // "ab"(2B) → "YWI="(4B)
+        XCTAssertEqual(v._testText, "YWI=")
+        XCTAssertEqual(last?.fileSize, 4)             // 2 のまま据え置きでなく 4 に更新
+    }
+
     // MARK: 印刷（プリントダイアログの「PDF として保存」が PDF 出力を兼ねる）
 
     /// 小ファイルの編集ペインは印刷できる。巨大ファイルのビューアは印刷できない

--- a/Tests/MrEditorTests/TextTransformsTests.swift
+++ b/Tests/MrEditorTests/TextTransformsTests.swift
@@ -48,9 +48,54 @@ final class TextTransformsTests: XCTestCase {
         XCTAssertNil(TextTransform.base64Decode.apply("////"))          // 有効 Base64 だが UTF-8 でない
     }
 
+    // MARK: HTML エンティティ
+
+    func testHtmlEncodeEscapesFive() {
+        XCTAssertEqual(TextTransform.htmlEncode.apply("<a href=\"x\">Tom & 'Jerry'</a>"),
+                       "&lt;a href=&quot;x&quot;&gt;Tom &amp; &#39;Jerry&#39;&lt;/a&gt;")
+    }
+    func testHtmlDecodeNamedNumericAndHex() {
+        XCTAssertEqual(TextTransform.htmlDecode.apply("&lt;p&gt;A&amp;B &#169; &#x1F600;"),
+                       "<p>A&B © 😀")
+    }
+    func testHtmlDecodeIsSinglePassNotRecursive() {
+        // "&amp;lt;" は「&lt;」に一度だけ復号し、さらに "<" まで進めない。
+        XCTAssertEqual(TextTransform.htmlDecode.apply("&amp;lt;"), "&lt;")
+    }
+    func testHtmlDecodeLeavesUnknownEntity() {
+        XCTAssertEqual(TextTransform.htmlDecode.apply("&bogus; &amp;"), "&bogus; &")
+    }
+    func testHtmlRoundTrip() {
+        let s = "if (a < b && c > d) x=\"1\";"
+        let enc = try! XCTUnwrap(TextTransform.htmlEncode.apply(s))
+        XCTAssertEqual(TextTransform.htmlDecode.apply(enc), s)
+    }
+
+    // MARK: 行操作
+
+    func testSortAscendingAndDescending() {
+        XCTAssertEqual(TextTransform.sortAscending.apply("banana\napple\ncherry"), "apple\nbanana\ncherry")
+        XCTAssertEqual(TextTransform.sortDescending.apply("banana\napple\ncherry"), "cherry\nbanana\napple")
+    }
+    func testSortPreservesTrailingNewline() {
+        XCTAssertEqual(TextTransform.sortAscending.apply("b\na\n"), "a\nb\n")   // 末尾改行を保ち空行を先頭に出さない
+    }
+    func testUniqueLinesKeepsFirstOccurrenceOrder() {
+        XCTAssertEqual(TextTransform.uniqueLines.apply("b\na\nb\nc\na"), "b\na\nc")
+    }
+    func testReverseLines() {
+        XCTAssertEqual(TextTransform.reverseLines.apply("1\n2\n3"), "3\n2\n1")
+        XCTAssertEqual(TextTransform.reverseLines.apply("1\n2\n3\n"), "3\n2\n1\n")
+    }
+    func testNumberLines() {
+        XCTAssertEqual(TextTransform.numberLines.apply("foo\nbar\nbaz"), "1\tfoo\n2\tbar\n3\tbaz")
+    }
+
     func testEmptyString() {
         // 空入力でもクラッシュしない（ケース系は "" を返す）。
         XCTAssertEqual(TextTransform.uppercase.apply(""), "")
         XCTAssertEqual(TextTransform.base64Encode.apply(""), "")
+        XCTAssertEqual(TextTransform.sortAscending.apply(""), "")
+        XCTAssertEqual(TextTransform.numberLines.apply(""), "1\t")   // 空1行に連番
     }
 }

--- a/Tests/MrEditorTests/TextTransformsTests.swift
+++ b/Tests/MrEditorTests/TextTransformsTests.swift
@@ -19,7 +19,38 @@ final class TextTransformsTests: XCTestCase {
         XCTAssertEqual(TextTransform.uppercase.apply("こんにちはabc"), "こんにちはABC")
         XCTAssertEqual(TextTransform.togglecase.apply("あA1z"), "あa1Z")
     }
+
+    // MARK: エンコード／デコード
+
+    func testUrlEncodeReservedAndSpace() {
+        XCTAssertEqual(TextTransform.urlEncode.apply("a b&c=?/"), "a%20b%26c%3D%3F%2F")
+    }
+    func testUrlEncodeMultibyte() {
+        XCTAssertEqual(TextTransform.urlEncode.apply("あ"), "%E3%81%82")   // UTF-8 3 バイト
+    }
+    func testUrlRoundTrip() {
+        let s = "https://例え.test/path?q=a b&x=1"
+        let encoded = try! XCTUnwrap(TextTransform.urlEncode.apply(s))
+        XCTAssertEqual(TextTransform.urlDecode.apply(encoded), s)
+    }
+    func testBase64RoundTripIncludingMultibyte() {
+        XCTAssertEqual(TextTransform.base64Encode.apply("hello"), "aGVsbG8=")
+        XCTAssertEqual(TextTransform.base64Decode.apply("aGVsbG8="), "hello")
+        let s = "日本語 mixed 🚀"
+        let enc = try! XCTUnwrap(TextTransform.base64Encode.apply(s))
+        XCTAssertEqual(TextTransform.base64Decode.apply(enc), s)
+    }
+    func testBase64DecodeIgnoresWrappingNewlines() {
+        XCTAssertEqual(TextTransform.base64Decode.apply("aGVs\nbG8="), "hello")
+    }
+    func testBase64DecodeInvalidReturnsNil() {
+        XCTAssertNil(TextTransform.base64Decode.apply("hello"))          // 4 の倍数でない
+        XCTAssertNil(TextTransform.base64Decode.apply("////"))          // 有効 Base64 だが UTF-8 でない
+    }
+
     func testEmptyString() {
-        for t in TextTransform.allCases { XCTAssertEqual(t.apply(""), "") }
+        // 空入力でもクラッシュしない（ケース系は "" を返す）。
+        XCTAssertEqual(TextTransform.uppercase.apply(""), "")
+        XCTAssertEqual(TextTransform.base64Encode.apply(""), "")
     }
 }


### PR DESCRIPTION
書式メニューを **エンコード群** と **行操作** で拡充。すべて純関数で #37 の seam（`selectedText` / `replaceSelection` ＋ `TextTransform`）にそのまま乗る。復号系は不正入力に備え `apply` を Optional 化済み（`nil`＝変換不能＝ビープ・本文不変）。

## エンコード／デコード
- **URL** — RFC 3986 unreserved 以外を % エンコード / `removingPercentEncoding`。
- **Base64** — 折り返し改行入りも復号（`ignoreUnknownCharacters`）、復号後が UTF-8 でなければ変換不能。
- **HTML エンティティ** — encode は `& < > " '` を実体参照へ。decode は数値参照(10進/16進)＋主要な名前付きを**1パス**で復号（`&amp;lt;` を二重復号しない・未知の実体はそのまま残す）。

## 行操作
選択テキストをそのまま行分割して処理（フィルタ ⌥⌘R と同じ考え方・末尾改行を保つ）。
- 行をソート（昇順 / 降順）
- 重複行を削除（初出の順序を保持）
- 行を逆順に
- 行に連番を振る（1 始まり＋タブ）

## ついでに直した既存バグ
小ファイルペインの**ステータス・バイト数が編集後に更新されない**問題を修正（`byteSize` が読み込み/保存でしか更新されず、行数はライブなのにサイズだけ据え置きだった）。クリーン時は実ディスクサイズ、dirty 時は保存されるバイト数（EOL 正規化＋保存エンコード込み）をライブ計算。

## 検証
- マルチバイト往復・不正入力の扱い・単一パス HTML 復号・ソートの末尾改行保持などをテスト。
- 全 **241 green**（+17）。
- 配布 `.app` で Base64 往復・書式メニュー全グループ・行ソート・バイト数ライブ更新を実機確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)