### PR TITLE
行表示の充実とマルチカーソル・連番パラメータ化・ケース維持置換を追加

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -197,6 +197,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         windowController?.filterActiveSelectionThroughCommand()
     }
 
+    @objc private func splitLines(_ sender: Any?) {
+        windowController?.splitActiveSelectionIntoLines()
+    }
+
+    @objc private func numberLines(_ sender: Any?) {
+        windowController?.numberActiveSelectionLines()
+    }
+
+    // マルチカーソル（キャレットを上下に足す／同じ語を次々に選ぶ）。
+    @objc private func addCaretAbove(_ sender: Any?) { windowController?.addCaretToActive(above: true) }
+    @objc private func addCaretBelow(_ sender: Any?) { windowController?.addCaretToActive(above: false) }
+    @objc private func selectNextOccurrence(_ sender: Any?) { windowController?.selectNextOccurrenceInActive() }
+
     // MARK: - 最近使った項目
 
     @objc private func openRecent(_ sender: NSMenuItem) {
@@ -289,8 +302,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case #selector(toggleJsonQuery(_:)):
             item.state = c.jsonQueryIsActive ? .on : .off
             return c.canJsonQuery
-        case #selector(applyTextTransform(_:)), #selector(filterThroughCommand(_:)):
+        case #selector(applyTextTransform(_:)), #selector(filterThroughCommand(_:)),
+             #selector(splitLines(_:)), #selector(numberLines(_:)):
             return c.canTransformText   // 編集可能なペインでのみ有効
+        case #selector(addCaretAbove(_:)), #selector(addCaretBelow(_:)), #selector(selectNextOccurrence(_:)):
+            return c.canMultiCursor     // マルチカーソルは小ファイルの編集ペインのみ
 
         default:
             return true
@@ -441,6 +457,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         findPrevItem.target = self
         editMenu.addItem(findPrevItem)
 
+        // マルチカーソル（小ファイルの編集ペインのみ。⌘クリックでも足せる）。
+        editMenu.addItem(.separator())
+        let caretAbove = NSMenuItem(title: L("menu.addCaretAbove"),
+                                    action: #selector(addCaretAbove(_:)), keyEquivalent: "\u{F700}")
+        caretAbove.keyEquivalentModifierMask = [.command, .option]
+        caretAbove.target = self
+        editMenu.addItem(caretAbove)
+        let caretBelow = NSMenuItem(title: L("menu.addCaretBelow"),
+                                    action: #selector(addCaretBelow(_:)), keyEquivalent: "\u{F701}")
+        caretBelow.keyEquivalentModifierMask = [.command, .option]
+        caretBelow.target = self
+        editMenu.addItem(caretBelow)
+        let nextOccurrence = NSMenuItem(title: L("menu.selectNextOccurrence"),
+                                        action: #selector(selectNextOccurrence(_:)), keyEquivalent: "d")
+        nextOccurrence.target = self
+        editMenu.addItem(nextOccurrence)
+
         // 書式メニュー（編集ツールボックス：選択テキストの変換）
         let formatMenuItem = NSMenuItem()
         mainMenu.addItem(formatMenuItem)
@@ -460,6 +493,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         addTransformItems(TextTransform.encodingGroup)    // URL/Base64/HTML エンコード・デコード
         formatMenu.addItem(.separator())
         addTransformItems(TextTransform.lineGroup)        // 行ソート/重複削除/逆順/連番
+        // 連番と行の分割はパラメータを取るのでダイアログ付き（分割は連結の逆操作）。
+        let numberItem = NSMenuItem(title: L("menu.format.numberLines"),
+                                    action: #selector(numberLines(_:)), keyEquivalent: "")
+        numberItem.target = self
+        formatMenu.addItem(numberItem)
+        let splitItem = NSMenuItem(title: L("menu.format.splitLines"),
+                                   action: #selector(splitLines(_:)), keyEquivalent: "")
+        splitItem.target = self
+        formatMenu.addItem(splitItem)
         formatMenu.addItem(.separator())
         // 選択を外部コマンドに通して置換（sort / jq / sed … その場フィルタ）。
         let filterItem = NSMenuItem(title: L("menu.format.filter"),

--- a/Sources/MrEditor/AppSettings.swift
+++ b/Sources/MrEditor/AppSettings.swift
@@ -142,6 +142,8 @@ enum AppSettings {
     private static let tabWidthKey = "MrEditor.tabWidth"
     private static let lineSpacingKey = "MrEditor.lineSpacing"
     private static let highlightCurrentLineKey = "MrEditor.highlightCurrentLine"
+    private static let showLineNumbersKey = "MrEditor.showLineNumbers"
+    private static let showInvisiblesKey = "MrEditor.showInvisibles"
     private static let cursorShapeKey = "MrEditor.cursorShape"
     private static let sessionKey = "MrEditor.session"
     private static let autoUpdateCheckKey = "MrEditor.automaticUpdateChecks"
@@ -174,6 +176,19 @@ enum AppSettings {
     static var highlightCurrentLine: Bool {
         get { defaults.object(forKey: highlightCurrentLineKey) as? Bool ?? true }
         set { defaults.set(newValue, forKey: highlightCurrentLineKey); postDisplayChanged() }
+    }
+
+    /// 行番号（ガター）を表示するか。既定 true。
+    /// 巨大ファイル側は自前ガター、小ファイル側は NSRulerView が担うが、設定は 1 つ。
+    static var showLineNumbers: Bool {
+        get { defaults.object(forKey: showLineNumbersKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: showLineNumbersKey); postDisplayChanged() }
+    }
+
+    /// 不可視文字（タブ・改行・全角スペース・行末の半角スペース）を記号で見せるか。既定 false。
+    static var showInvisibles: Bool {
+        get { defaults.bool(forKey: showInvisiblesKey) }
+        set { defaults.set(newValue, forKey: showInvisiblesKey); postDisplayChanged() }
     }
 
     /// キャレット形状。

--- a/Sources/MrEditor/Core/CasePreserving.swift
+++ b/Sources/MrEditor/Core/CasePreserving.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// 置換で「元の語の大文字小文字を引き継ぐ」ためのロジック（UI 非依存の純関数）。
+///
+/// 検索を大小区別なしで走らせると `Timeout` / `timeout` / `TIMEOUT` が 1 つの
+/// パターンで採れるが、素直に置換すると全部同じ綴りになってしまう。ここでは
+/// **一致した実際の文字列**から書式を読み取り、置換文字列へ同じ書式を移す。
+enum CasePreserving {
+    /// 一致文字列から読み取れる書式。判定できないものは `mixed`＝置換文字列をそのまま使う。
+    enum Style {
+        case upper       // TIMEOUT
+        case lower       // timeout
+        case capitalized // Timeout
+        case mixed       // timeOut / t1 / 記号のみ など
+    }
+
+    /// 一致文字列 `matched` の書式を読み取る。英字（cased 文字）が無ければ `mixed`。
+    static func style(of matched: String) -> Style {
+        let cased = matched.filter { $0.isCased }
+        guard !cased.isEmpty else { return .mixed }
+        if cased.allSatisfy({ $0.isUppercase }) {
+            // 1 文字の大文字は "A" → capitalized とも取れるが、upper として扱えば
+            // 置換文字列が 1 文字でも複数文字でも自然な結果になる。
+            return .upper
+        }
+        if cased.allSatisfy({ $0.isLowercase }) { return .lower }
+        if let first = cased.first, first.isUppercase,
+           cased.dropFirst().allSatisfy({ $0.isLowercase }) { return .capitalized }
+        return .mixed
+    }
+
+    /// 一致文字列 `matched` の書式を `replacement` へ移して返す。
+    /// `mixed`（判定できない／英字が無い）のときは置換文字列を一切いじらない。
+    static func apply(_ replacement: String, matching matched: String) -> String {
+        switch style(of: matched) {
+        case .upper:  return replacement.uppercased()
+        case .lower:  return replacement.lowercased()
+        case .capitalized:
+            // 先頭の英字だけ大文字にし、残りは打たれたまま（`newValue` → `NewValue`）。
+            guard let i = replacement.firstIndex(where: { $0.isCased }) else { return replacement }
+            return replacement.replacingCharacters(in: i...i, with: replacement[i].uppercased())
+        case .mixed:  return replacement
+        }
+    }
+}
+
+private extension Character {
+    /// 大文字・小文字の区別を持つ文字か（日本語・数字・記号は false＝書式の判定に使わない）。
+    var isCased: Bool { isUppercase || isLowercase }
+}

--- a/Sources/MrEditor/Core/InvisibleGlyphs.swift
+++ b/Sources/MrEditor/Core/InvisibleGlyphs.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// 不可視文字の可視化に使う記号と、1 行のどこに何を描くかの算出（純ロジック・UI 非依存）。
+///
+/// 両ペイン（`DocumentView` の自前描画と `EditorTextView` の NSTextView 描画）が
+/// 同じ結果を使うので、見た目が一致する。**本文は書き換えない**（記号は重ねて描くだけ）。
+/// タブを "→" に置換してしまうと桁揃えもキャレットのバイト対応も壊れるため。
+///
+/// 半角スペースは全部に点を打つと本文が読めなくなるので**行末の連なりだけ**出す
+/// （消し忘れの行末空白は見えて嬉しい情報、文中の空白はノイズ）。全角スペースは
+/// 日本語ファーストの要なので位置に関係なく出す。
+enum InvisibleGlyphs {
+    static let tab = "→"
+    static let eol = "¬"
+    static let ideographicSpace = "□"
+    static let trailingSpace = "·"
+
+    /// 行内のどの UTF-16 位置にどの記号を描くか。
+    struct Marker: Equatable {
+        /// 行文字列内の UTF-16 オフセット（その文字の**上に**記号を描く）。
+        let utf16Index: Int
+        let glyph: String
+    }
+
+    /// 1 行の文字列（改行を含まない）から記号の並びを返す。改行記号は行末に別途描くので含めない。
+    static func markers(in line: String) -> [Marker] {
+        let ns = line as NSString
+        guard ns.length > 0 else { return [] }
+
+        // 行末の半角スペースの連なり（この位置以降のスペースだけ点を打つ）。
+        var trailingStart = ns.length
+        while trailingStart > 0, ns.character(at: trailingStart - 1) == 0x0020 { trailingStart -= 1 }
+
+        var out: [Marker] = []
+        for i in 0..<ns.length {
+            switch ns.character(at: i) {
+            case 0x0009: out.append(Marker(utf16Index: i, glyph: tab))
+            case 0x3000: out.append(Marker(utf16Index: i, glyph: ideographicSpace))
+            case 0x0020 where i >= trailingStart: out.append(Marker(utf16Index: i, glyph: trailingSpace))
+            default: break
+            }
+        }
+        return out
+    }
+}

--- a/Sources/MrEditor/Core/LineStartIndex.swift
+++ b/Sources/MrEditor/Core/LineStartIndex.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// 文字列内の位置（UTF-16）から「何行目・何桁目」を引くための行頭索引。
+///
+/// 小ファイル編集ペイン（`NSTextView`）が、ステータスバーのキャレット位置表示と
+/// 行番号ガターの描画に使う。行頭オフセットを一度だけ数えて配列に持ち、以降は
+/// 二分探索で引く（本文が変わったら作り直す）。
+///
+/// 巨大ファイル側は `LineIndex`（mmap の疎索引）が同じ役目を担う。こちらは
+/// 全文をメモリに持つ小ファイル専用で、8MB＝数十万行でも配列 1 本に収まる。
+struct LineStartIndex {
+    /// 各行の先頭 UTF-16 オフセット。空文字列でも 1 要素（0）持つ＝「1 行目がある」。
+    private let lineStarts: [Int]
+
+    init(_ text: NSString) {
+        var starts = [0]
+        let length = text.length
+        var i = 0
+        while i < length {
+            if text.character(at: i) == 0x000A { starts.append(i + 1) }
+            i += 1
+        }
+        lineStarts = starts
+    }
+
+    init(_ text: String) { self.init(text as NSString) }
+
+    /// 行数（末尾が改行なら、その後ろの空行も 1 行と数える＝キャレットが置ける行）。
+    var lineCount: Int { lineStarts.count }
+
+    /// UTF-16 位置 `location` を含む行の 0 始まり行番号。
+    func lineIndex(at location: Int) -> Int {
+        guard location > 0 else { return 0 }
+        var lo = 0, hi = lineStarts.count - 1
+        while lo < hi {
+            let mid = (lo + hi + 1) / 2
+            if lineStarts[mid] <= location { lo = mid } else { hi = mid - 1 }
+        }
+        return lo
+    }
+
+    /// 0 始まり行番号 `line` の先頭 UTF-16 オフセット。
+    func start(ofLine line: Int) -> Int {
+        lineStarts[min(max(0, line), lineStarts.count - 1)]
+    }
+
+    /// UTF-16 位置 `location` の (行, 桁)。ともに 1 始まり。
+    /// 桁は行頭からの**文字数**（サロゲートペアや結合文字を 1 と数える）＋1。
+    func position(at location: Int, in text: NSString) -> (line: Int, column: Int) {
+        let loc = min(max(0, location), text.length)
+        let line = lineIndex(at: loc)
+        let head = start(ofLine: line)
+        let column = head < loc ? text.substring(with: NSRange(location: head, length: loc - head)).count : 0
+        return (line + 1, column + 1)
+    }
+}

--- a/Sources/MrEditor/Core/SettingsBundle.swift
+++ b/Sources/MrEditor/Core/SettingsBundle.swift
@@ -41,6 +41,10 @@ struct SettingsBundle: Codable, Equatable {
     var backgroundOpacity: Double?
     /// ANSI カラー表示（閲覧時）。旧版の共有リンクには無いので optional。
     var ansiColors: Bool?
+    /// 行番号（ガター）の表示。旧版の共有リンクには無いので optional。
+    var showLineNumbers: Bool?
+    /// 不可視文字の表示。旧版の共有リンクには無いので optional。
+    var showInvisibles: Bool?
 
     enum DecodeError: Error, Equatable {
         case malformed          // JSON/base64 が壊れている
@@ -69,7 +73,9 @@ struct SettingsBundle: Codable, Equatable {
             cursorShape: AppSettings.cursorShape.rawValue,
             lineWrap: AppSettings.lineWrap,
             backgroundOpacity: Double(EditorTheme.backgroundOpacity),
-            ansiColors: EditorTheme.ansiColorsEnabled)
+            ansiColors: EditorTheme.ansiColorsEnabled,
+            showLineNumbers: AppSettings.showLineNumbers,
+            showInvisibles: AppSettings.showInvisibles)
     }
 
     // MARK: - 適用
@@ -88,6 +94,8 @@ struct SettingsBundle: Codable, Equatable {
         AppSettings.lineWrap = lineWrap
         if let backgroundOpacity { EditorTheme.backgroundOpacity = CGFloat(backgroundOpacity) }
         if let ansiColors { EditorTheme.ansiColorsEnabled = ansiColors }
+        if let showLineNumbers { AppSettings.showLineNumbers = showLineNumbers }
+        if let showInvisibles { AppSettings.showInvisibles = showInvisibles }
         // 配色（custom 色 → preset の順で確定）
         for key in EditorTheme.ColorKey.allCases {
             if let hex = customColors[key.rawValue], let color = SettingsBundle.color(fromHex: hex) {

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -149,6 +149,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         searchBar.onFilterToggle = { [weak self] on in self?.activeViewer?.setFilterMode(on) }
         searchBar.onReplace = { [weak self] r in self?.activeViewer?.replaceCurrent(with: r) }
         searchBar.onReplaceAll = { [weak self] r in self?.activeViewer?.replaceAll(with: r) }
+        searchBar.onPreserveCaseToggle = { [weak self] on in self?.activeViewer?.setPreserveCase(on) }
 
         // 読み取り専用バナー（本文領域の左上に浮かべる。大ファイルを開いたときだけ表示）
         readOnlyBanner.translatesAutoresizingMaskIntoConstraints = false
@@ -539,6 +540,157 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     func applyActiveTextTransform(_ transform: TextTransform) {
         guard let v = activeViewer, v.canEdit else { NSSound.beep(); return }
         v.applyTextTransform(transform)
+    }
+
+    // MARK: - 行の分割（区切り文字はダイアログで受け取る）
+
+    private static let lastSplitDelimiterKey = "toolbox.lastSplitDelimiter"
+
+    /// 選択した各行を区切り文字で分割する（`行を連結` の逆操作）。
+    func splitActiveSelectionIntoLines() {
+        guard let pane = activeViewer, pane.canEdit,
+              let selection = pane.selectedText, !selection.isEmpty else { NSSound.beep(); return }
+        promptForSplitOptions { [weak self] options in
+            guard let self, let options else { return }
+            UserDefaults.standard.set(options.delimiter, forKey: Self.lastSplitDelimiterKey)
+            // シートを閉じている間に選択が変わっていないか確かめてから置換する。
+            guard self.activeViewer === pane, pane.selectedText == selection else { return }
+            guard let result = LineSplitter.split(selection, options: options) else { NSSound.beep(); return }
+            guard result != selection else { return }   // 変化なしはアンドゥを積まない
+            pane.replaceSelection(with: result)
+        }
+    }
+
+    /// 区切り文字と扱いを訊くシート（前回の区切り文字を初期値に）。
+    private func promptForSplitOptions(completion: @escaping (LineSplitter.Options?) -> Void) {
+        guard let win = window else { completion(nil); return }
+        let alert = NSAlert()
+        alert.messageText = L("split.prompt")
+        alert.informativeText = L("split.message")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.placeholderString = ","
+        field.stringValue = UserDefaults.standard.string(forKey: Self.lastSplitDelimiterKey) ?? ","
+        let label = NSTextField(labelWithString: L("split.delimiter"))
+        let row = NSStackView(views: [label, field])
+        row.orientation = .horizontal
+        row.spacing = 8
+        let trimCheck = NSButton(checkboxWithTitle: L("split.trim"), target: nil, action: nil)
+        let dropCheck = NSButton(checkboxWithTitle: L("split.dropEmpty"), target: nil, action: nil)
+        let stack = NSStackView(views: [row, trimCheck, dropCheck])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
+        stack.frame = NSRect(x: 0, y: 0, width: 360, height: 84)
+        alert.accessoryView = stack
+
+        alert.addButton(withTitle: L("split.run"))      // .alertFirstButtonReturn
+        alert.addButton(withTitle: L("common.cancel"))  // .alertSecondButtonReturn
+        alert.window.initialFirstResponder = field
+        alert.beginSheetModal(for: win) { resp in
+            guard resp == .alertFirstButtonReturn else { completion(nil); return }
+            completion(LineSplitter.Options(delimiter: field.stringValue,
+                                            trimEach: trimCheck.state == .on,
+                                            dropEmpty: dropCheck.state == .on))
+        }
+    }
+
+    // MARK: - 連番（開始・増分・桁埋め・区切りはダイアログで受け取る）
+
+    private static let lastNumberOptionsKey = "toolbox.lastNumberOptions"
+
+    /// 選択した各行の先頭に連番を振る（パラメータ付き＝`TextTransform.numberLines` の一般形）。
+    func numberActiveSelectionLines() {
+        guard let pane = activeViewer, pane.canEdit,
+              let selection = pane.selectedText, !selection.isEmpty else { NSSound.beep(); return }
+        promptForNumberOptions { [weak self] options in
+            guard let self, let options else { return }
+            self.saveNumberOptions(options)
+            // シートを閉じている間に選択が変わっていないか確かめてから置換する。
+            guard self.activeViewer === pane, pane.selectedText == selection else { return }
+            let result = LineNumberer.number(selection, options: options)
+            guard result != selection else { return }   // 変化なしはアンドゥを積まない
+            pane.replaceSelection(with: result)
+        }
+    }
+
+    /// 前回の設定（開始・増分・桁埋め・区切り）を初期値にしたシート。
+    private func promptForNumberOptions(completion: @escaping (LineNumberer.Options?) -> Void) {
+        guard let win = window else { completion(nil); return }
+        let saved = loadNumberOptions()
+        let alert = NSAlert()
+        alert.messageText = L("number.prompt")
+        alert.informativeText = L("number.message")
+
+        func numberField(_ value: Int) -> NSTextField {
+            let f = NSTextField(frame: NSRect(x: 0, y: 0, width: 70, height: 24))
+            f.alignment = .right
+            f.integerValue = value
+            return f
+        }
+        let startField = numberField(saved.start)
+        let stepField = numberField(saved.step)
+        let padField = numberField(saved.padWidth)
+        let sepField = NSTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 24))
+        sepField.stringValue = saved.separator
+        sepField.placeholderString = "\\t"
+
+        func row(_ key: String, _ field: NSTextField) -> NSStackView {
+            let label = NSTextField(labelWithString: L(key))
+            label.setContentHuggingPriority(.required, for: .horizontal)
+            let r = NSStackView(views: [label, field])
+            r.orientation = .horizontal
+            r.spacing = 8
+            return r
+        }
+        let stack = NSStackView(views: [row("number.start", startField), row("number.step", stepField),
+                                        row("number.pad", padField), row("number.separator", sepField)])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
+        stack.frame = NSRect(x: 0, y: 0, width: 360, height: 124)
+        alert.accessoryView = stack
+
+        alert.addButton(withTitle: L("number.run"))     // .alertFirstButtonReturn
+        alert.addButton(withTitle: L("common.cancel"))  // .alertSecondButtonReturn
+        alert.window.initialFirstResponder = startField
+        alert.beginSheetModal(for: win) { resp in
+            guard resp == .alertFirstButtonReturn else { completion(nil); return }
+            completion(LineNumberer.Options(start: startField.integerValue,
+                                            step: stepField.integerValue,
+                                            padWidth: max(0, padField.integerValue),
+                                            separator: sepField.stringValue))
+        }
+    }
+
+    /// 連番の設定は 4 項目あるので 1 つの配列にまとめて覚える（区切りは文字列のまま）。
+    private func saveNumberOptions(_ o: LineNumberer.Options) {
+        UserDefaults.standard.set(["\(o.start)", "\(o.step)", "\(o.padWidth)", o.separator],
+                                  forKey: Self.lastNumberOptionsKey)
+    }
+
+    private func loadNumberOptions() -> LineNumberer.Options {
+        guard let saved = UserDefaults.standard.stringArray(forKey: Self.lastNumberOptionsKey), saved.count == 4
+        else { return LineNumberer.Options() }
+        return LineNumberer.Options(start: Int(saved[0]) ?? 1, step: Int(saved[1]) ?? 1,
+                                    padWidth: Int(saved[2]) ?? 0, separator: saved[3])
+    }
+
+    // MARK: - マルチカーソル（小ファイルの編集ペインのみ）
+
+    /// マルチカーソルのメニューを有効にしてよいか。
+    var canMultiCursor: Bool { activeViewer?.supportsMultiCursor ?? false }
+
+    /// 上／下の行の同じ桁にキャレットを足す（⌥⌘↑ / ⌥⌘↓）。
+    func addCaretToActive(above: Bool) {
+        guard let v = activeViewer, v.supportsMultiCursor else { NSSound.beep(); return }
+        v.addCaret(above: above)
+    }
+
+    /// 選択中の語と同じ次の語を選択に足す（⌘D）。
+    func selectNextOccurrenceInActive() {
+        guard let v = activeViewer, v.supportsMultiCursor else { NSSound.beep(); return }
+        v.selectNextOccurrence()
     }
 
     // MARK: - 外部コマンド・フィルタ（選択を /bin/sh に通して置換）

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "status.lines" = "%@ lines";
 "status.linesApprox" = "~%@ lines";
 "status.indexing" = "Indexing… %d%%";
+"status.caret" = "Ln %@ : Col %@";
 "status.saving" = "Saving… %d%%";
 "save.sheetTitle" = "Saving";
 
@@ -88,10 +89,24 @@
 "menu.format.sortDescending" = "Sort Lines (Descending)";
 "menu.format.uniqueLines" = "Remove Duplicate Lines";
 "menu.format.reverseLines" = "Reverse Lines";
-"menu.format.numberLines" = "Number Lines";
+"menu.format.numberLines" = "Number Lines…";
 "menu.format.joinLines" = "Join Lines";
 "menu.format.indent" = "Indent";
 "menu.format.outdent" = "Outdent";
+"menu.format.splitLines" = "Split Lines…";
+"split.prompt" = "Split lines";
+"split.message" = "Each selected line is split on the delimiter into separate lines. Write \\t for tab and \\n for newline.";
+"split.delimiter" = "Delimiter:";
+"split.trim" = "Trim whitespace around each part";
+"split.dropEmpty" = "Drop empty parts";
+"split.run" = "Split";
+"number.prompt" = "Number lines";
+"number.message" = "Each selected line gets a number in front. Write \\t for tab and \\n for newline in the separator.";
+"number.start" = "Start:";
+"number.step" = "Step:";
+"number.pad" = "Zero-pad width (0 = none):";
+"number.separator" = "Separator:";
+"number.run" = "Number";
 "menu.format.filter" = "Filter Through Command…";
 
 "filter.prompt" = "Filter selection through command";
@@ -120,6 +135,8 @@
 "prefs.lineSpacing.wide" = "Wide";
 "prefs.lineSpacing.wider" = "Widest";
 "prefs.highlightCurrentLine" = "Highlight current line";
+"prefs.showLineNumbers" = "Show line numbers";
+"prefs.showInvisibles" = "Show invisibles (tabs, line breaks, ideographic and trailing spaces)";
 "prefs.cursorShape" = "Cursor";
 "prefs.cursorShape.bar" = "Bar";
 "prefs.cursorShape.block" = "Block";
@@ -190,6 +207,9 @@
 "menu.find" = "Find…";
 "menu.findNext" = "Find Next";
 "menu.findPrev" = "Find Previous";
+"menu.addCaretAbove" = "Add Cursor Above";
+"menu.addCaretBelow" = "Add Cursor Below";
+"menu.selectNextOccurrence" = "Add Next Occurrence to Selection";
 "search.placeholder" = "Find";
 "search.none" = "Not found";
 "search.invalid" = "Invalid pattern";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "status.lines" = "%@ 行";
 "status.linesApprox" = "約 %@ 行";
 "status.indexing" = "索引構築中… %d%%";
+"status.caret" = "行 %@ : 桁 %@";
 "status.saving" = "保存中… %d%%";
 "save.sheetTitle" = "保存しています";
 
@@ -88,10 +89,24 @@
 "menu.format.sortDescending" = "行をソート（降順）";
 "menu.format.uniqueLines" = "重複行を削除";
 "menu.format.reverseLines" = "行を逆順に";
-"menu.format.numberLines" = "行に連番を振る";
+"menu.format.numberLines" = "行に連番を振る…";
 "menu.format.joinLines" = "行を連結";
 "menu.format.indent" = "字下げ";
 "menu.format.outdent" = "字上げ";
+"menu.format.splitLines" = "行の分割…";
+"split.prompt" = "行を分割する";
+"split.message" = "選択した各行を区切り文字で分けて、複数行にします。タブは \\t、改行は \\n と書けます。";
+"split.delimiter" = "区切り文字:";
+"split.trim" = "各要素の前後の空白を取り除く";
+"split.dropEmpty" = "空の要素を捨てる";
+"split.run" = "分割";
+"number.prompt" = "行に連番を振る";
+"number.message" = "選択した各行の先頭に番号を付けます。区切りはタブを \\t、改行を \\n と書けます。";
+"number.start" = "開始:";
+"number.step" = "増分:";
+"number.pad" = "0 埋めの桁数（0＝埋めない）:";
+"number.separator" = "番号と本文の区切り:";
+"number.run" = "連番を振る";
 "menu.format.filter" = "外部コマンドに通す…";
 
 "filter.prompt" = "選択を外部コマンドに通す";
@@ -120,6 +135,8 @@
 "prefs.lineSpacing.wide" = "広め";
 "prefs.lineSpacing.wider" = "最も広い";
 "prefs.highlightCurrentLine" = "現在の行を強調表示";
+"prefs.showLineNumbers" = "行番号を表示";
+"prefs.showInvisibles" = "不可視文字を表示（タブ・改行・全角スペース・行末の空白）";
 "prefs.cursorShape" = "カーソル";
 "prefs.cursorShape.bar" = "バー";
 "prefs.cursorShape.block" = "ブロック";
@@ -190,6 +207,9 @@
 "menu.find" = "検索…";
 "menu.findNext" = "次を検索";
 "menu.findPrev" = "前を検索";
+"menu.addCaretAbove" = "上の行にカーソルを追加";
+"menu.addCaretBelow" = "下の行にカーソルを追加";
+"menu.selectNextOccurrence" = "次の同じ語を選択に追加";
 "search.placeholder" = "検索";
 "search.none" = "見つかりません";
 "search.invalid" = "無効なパターン";

--- a/Sources/MrEditor/UI/LineNumberRulerView.swift
+++ b/Sources/MrEditor/UI/LineNumberRulerView.swift
@@ -1,0 +1,85 @@
+import AppKit
+
+/// 小ファイル編集ペイン（`NSTextView`）の左に行番号を出すガター。
+///
+/// 巨大ファイル側は `DocumentView` が可視行を自前で描くのでガターも自前だが、
+/// 小ファイル側は AppKit のレイアウトに乗っているので `NSRulerView` に載せる。
+/// 見た目（背景・区切り線・文字色・フォント）は `DocumentView` のガターに揃える。
+final class LineNumberRulerView: NSRulerView {
+    /// 行頭索引の供給元。本文が変わると `EditableViewer` が作り直したものを返す。
+    var lineIndexProvider: (() -> LineStartIndex)?
+
+    private let rightPadding: CGFloat = 8
+    private let leftPadding: CGFloat = 6
+
+    init(textView: NSTextView) {
+        super.init(scrollView: textView.enclosingScrollView, orientation: .verticalRuler)
+        clientView = textView
+        ruleThickness = 44
+    }
+
+    required init(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// 行数の桁数とフォントに合わせてガター幅を決める（`DocumentView` と同じ考え方）。
+    func updateThickness() {
+        let font = EditorFont.current()
+        let digits = max(3, String(lineIndexProvider?().lineCount ?? 1).count)
+        let width = ("0" as NSString).size(withAttributes: [.font: font]).width
+        let thickness = ceil(width * CGFloat(digits)) + leftPadding + rightPadding
+        if abs(thickness - ruleThickness) > 0.5 { ruleThickness = thickness }
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        guard let textView = clientView as? NSTextView,
+              let lm = textView.layoutManager, let tc = textView.textContainer else { return }
+
+        // 背景と右端の区切り線（本文側のガターと同じ配色）。
+        let theme = EditorTheme.current()
+        EditorTheme.withBackgroundOpacity(theme.chromeBackground).setFill()
+        bounds.fill()
+        theme.separator.setStroke()
+        let divider = NSBezierPath()
+        divider.move(to: NSPoint(x: bounds.maxX - 0.5, y: bounds.minY))
+        divider.line(to: NSPoint(x: bounds.maxX - 0.5, y: bounds.maxY))
+        divider.stroke()
+
+        let font = EditorFont.current()
+        let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: theme.chromeSecondaryText]
+        let index = lineIndexProvider?() ?? LineStartIndex("")
+        let text = textView.string as NSString
+
+        // 可視範囲（＝スクロール位置）に掛かる論理行だけ番号を描く。
+        let visible = scrollView?.contentView.bounds ?? textView.visibleRect
+        let glyphRange = lm.glyphRange(forBoundingRect: visible, in: tc)
+        let charRange = lm.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+        let lastVisibleChar = NSMaxRange(charRange)
+
+        // ルーラ座標へ移すためのオフセット（スクロール量＋テキストコンテナの余白）。
+        let originY = convert(NSPoint.zero, from: textView).y + textView.textContainerOrigin.y
+
+        var line = index.lineIndex(at: charRange.location)
+        var charIndex = index.start(ofLine: line)
+        while charIndex <= text.length {
+            if charIndex > lastVisibleChar { break }
+            let y: CGFloat
+            if text.length == 0 || charIndex == text.length {
+                // 末尾が改行なら、その後ろの空行（extra line fragment）にも番号を振る。
+                let extra = lm.extraLineFragmentRect
+                if extra.isEmpty { break }
+                y = originY + extra.minY
+            } else {
+                let glyph = lm.glyphIndexForCharacter(at: charIndex)
+                let frag = lm.lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil, withoutAdditionalLayout: true)
+                // 行間を広げると本文の基線は行の下寄りに来る。番号も同じ基線に合わせる。
+                y = originY + frag.minY + lm.location(forGlyphAt: glyph).y - font.ascender
+            }
+            let label = NSAttributedString(string: "\(line + 1)", attributes: attrs)
+            let size = label.size()
+            label.draw(at: NSPoint(x: max(2, ruleThickness - rightPadding - size.width), y: y))
+
+            line += 1
+            if charIndex == text.length { break }
+            charIndex = NSMaxRange(text.lineRange(for: NSRange(location: charIndex, length: 0)))
+        }
+    }
+}

--- a/Sources/MrEditor/UI/PreferencesWindowController.swift
+++ b/Sources/MrEditor/UI/PreferencesWindowController.swift
@@ -132,6 +132,8 @@ private final class DisplayPaneViewController: NSViewController {
     private var tabWidthPopup: NSPopUpButton!
     private var lineSpacingPopup: NSPopUpButton!
     private var highlightCheck: NSButton!
+    private var lineNumbersCheck: NSButton!
+    private var invisiblesCheck: NSButton!
     private var cursorPopup: NSPopUpButton!
     private var noWrapRadio: NSButton!
     private var wrapRadio: NSButton!
@@ -195,9 +197,13 @@ private final class DisplayPaneViewController: NSViewController {
         metricsRow.spacing = 8
         metricsRow.alignment = .firstBaseline
 
-        // --- 現在行ハイライト ---
+        // --- 現在行ハイライト・行番号・不可視文字 ---
         highlightCheck = NSButton(checkboxWithTitle: L("prefs.highlightCurrentLine"),
                                   target: self, action: #selector(highlightChanged(_:)))
+        lineNumbersCheck = NSButton(checkboxWithTitle: L("prefs.showLineNumbers"),
+                                    target: self, action: #selector(lineNumbersChanged(_:)))
+        invisiblesCheck = NSButton(checkboxWithTitle: L("prefs.showInvisibles"),
+                                   target: self, action: #selector(invisiblesChanged(_:)))
 
         // --- カーソル形状 ---
         cursorPopup = NSPopUpButton(frame: .zero, pullsDown: false)
@@ -223,7 +229,8 @@ private final class DisplayPaneViewController: NSViewController {
 
         let stack = makeStack([heading("prefs.font"), fontRow, sample,
                                sep1,
-                               heading("prefs.text"), metricsRow, highlightCheck, cursorRow,
+                               heading("prefs.text"), metricsRow, highlightCheck,
+                               lineNumbersCheck, invisiblesCheck, cursorRow,
                                sep2,
                                heading("prefs.lineWrap"), noWrapRadio, wrapRadio])
         sep1.widthAnchor.constraint(equalToConstant: 400).isActive = true
@@ -246,6 +253,8 @@ private final class DisplayPaneViewController: NSViewController {
         tabWidthPopup.selectItem(withTag: AppSettings.tabWidth)
         lineSpacingPopup.selectItem(withTag: LineSpacing.allCases.firstIndex(of: AppSettings.lineSpacing) ?? 0)
         highlightCheck.state = AppSettings.highlightCurrentLine ? .on : .off
+        lineNumbersCheck.state = AppSettings.showLineNumbers ? .on : .off
+        invisiblesCheck.state = AppSettings.showInvisibles ? .on : .off
         cursorPopup.selectItem(withTag: CursorShape.allCases.firstIndex(of: AppSettings.cursorShape) ?? 0)
         noWrapRadio.state = AppSettings.lineWrap ? .off : .on
         wrapRadio.state = AppSettings.lineWrap ? .on : .off
@@ -278,6 +287,14 @@ private final class DisplayPaneViewController: NSViewController {
 
     @objc private func highlightChanged(_ sender: NSButton) {
         AppSettings.highlightCurrentLine = (sender.state == .on)
+    }
+
+    @objc private func lineNumbersChanged(_ sender: NSButton) {
+        AppSettings.showLineNumbers = (sender.state == .on)
+    }
+
+    @objc private func invisiblesChanged(_ sender: NSButton) {
+        AppSettings.showInvisibles = (sender.state == .on)
     }
 
     @objc private func cursorPicked(_ sender: NSPopUpButton) {

--- a/Sources/MrEditor/UI/SearchBarView.swift
+++ b/Sources/MrEditor/UI/SearchBarView.swift
@@ -18,6 +18,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     private let replaceField = NSTextField()
     private let replaceButton = NSButton()
     private let replaceAllButton = NSButton()
+    private let preserveCaseToggle = NSButton()
 
     var onQueryChange: ((String) -> Void)?
     var onNext: (() -> Void)?
@@ -28,6 +29,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     var onFilterToggle: ((Bool) -> Void)?
     var onReplace: ((String) -> Void)?
     var onReplaceAll: ((String) -> Void)?
+    var onPreserveCaseToggle: ((Bool) -> Void)?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -109,7 +111,18 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         replaceAllButton.target = self
         replaceAllButton.action = #selector(replaceAllTapped)
         replaceAllButton.setContentHuggingPriority(.required, for: .horizontal)
-        let replaceRow = NSStackView(views: [replaceField, replaceButton, replaceAllButton])
+
+        // ケース維持トグル（Aa→aA）。大小区別なしで拾った一致の綴りを置換文字列へ引き継ぐ。
+        preserveCaseToggle.title = "aA"
+        preserveCaseToggle.setButtonType(.pushOnPushOff)
+        preserveCaseToggle.bezelStyle = .roundRect
+        preserveCaseToggle.font = .monospacedSystemFont(ofSize: 11, weight: .semibold)
+        preserveCaseToggle.target = self
+        preserveCaseToggle.action = #selector(preserveCaseTapped)
+        preserveCaseToggle.toolTip = "元の大文字小文字を維持して置換 / Preserve case when replacing"
+        preserveCaseToggle.setContentHuggingPriority(.required, for: .horizontal)
+
+        let replaceRow = NSStackView(views: [replaceField, preserveCaseToggle, replaceButton, replaceAllButton])
         replaceRow.orientation = .horizontal
         replaceRow.spacing = 6
 
@@ -197,6 +210,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     @objc private func caseTapped() { onCaseToggle?(caseToggle.state == .on) }
     @objc private func regexTapped() { onRegexToggle?(regexToggle.state == .on) }
     @objc private func filterTapped() { onFilterToggle?(filterToggle.state == .on) }
+    @objc private func preserveCaseTapped() { onPreserveCaseToggle?(preserveCaseToggle.state == .on) }
     @objc private func replaceTapped() { onReplace?(replaceField.stringValue) }
     @objc private func replaceAllTapped() { onReplaceAll?(replaceField.stringValue) }
 
@@ -207,6 +221,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         caseToggle.state = .off
         regexToggle.state = .off
         filterToggle.state = .off
+        preserveCaseToggle.state = .off
         countLabel.stringValue = ""
     }
 

--- a/Sources/MrEditor/UI/StatusBarView.swift
+++ b/Sources/MrEditor/UI/StatusBarView.swift
@@ -118,6 +118,10 @@ final class StatusBarView: NSView {
         // サイズは意味があるときだけ出す（diff は左右 2 ファイルあるので「0 B」は嘘になる）。
         var text = "\(state.encodingName)    \(lineLabel)"
         if state.fileSize > 0 { text += "    \(Self.formatBytes(state.fileSize))" }
+        // キャレット位置（行:桁）。キャレットのある表示のときだけ出す。
+        if let caret = state.caret {
+            text += "    " + L("status.caret", Self.formatNumber(caret.line), Self.formatNumber(caret.column))
+        }
         if !state.lineCountIsExact {
             let pct = Int(state.indexProgress * 100)
             text += "    " + L("status.indexing", pct)

--- a/Sources/MrEditor/Viewer/DiffViewer.swift
+++ b/Sources/MrEditor/Viewer/DiffViewer.swift
@@ -663,6 +663,8 @@ final class DiffViewer: NSView, DocumentPane {
         for v in [leftView, rightView] {
             v.highlightCurrentLine = false      // diff の帯と喧嘩する
             v.cursorShape = AppSettings.cursorShape
+            v.showLineNumbers = AppSettings.showLineNumbers
+            v.showInvisibles = AppSettings.showInvisibles
             v.configure(font: EditorFont.current())   // タブ幅・行間・配色を織り込む
         }
         refresh()

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -7,6 +7,8 @@ struct ViewerState {
     var lineCountIsExact: Bool
     var fileSize: Int
     var indexProgress: Double // 0...1
+    /// キャレット位置（1 始まりの行・桁）。キャレットの無い表示（フィルタ・構造化・diff）では nil。
+    var caret: (line: Int, column: Int)?
 }
 
 /// 1 ドキュメント＝1 ペインの共通インターフェース。
@@ -126,6 +128,18 @@ protocol DocumentPane: NSView {
     var selectedText: String? { get }
     /// 現在の選択を `text` で置換する（1 アンドゥ／置換後のテキストを選択したまま残す）。
     func replaceSelection(with text: String)
+
+    // MARK: - マルチカーソル（小ファイルの編集ペインのみ）
+
+    /// 複数キャレットに対応するか（メニューの有効化）。巨大ファイルの閲覧ペインは単一キャレットのまま。
+    var supportsMultiCursor: Bool { get }
+    /// 上／下の行の同じ桁にキャレットを足す。
+    func addCaret(above: Bool)
+    /// 選択中の語と同じ次の語を選択に足す（選択が無ければキャレット位置の語を選ぶ）。
+    func selectNextOccurrence()
+
+    /// 置換で元の語の大文字小文字を引き継ぐか（検索バーのトグル）。
+    func setPreserveCase(_ on: Bool)
 }
 
 extension DocumentPane {
@@ -177,6 +191,12 @@ extension DocumentPane {
     // 編集ツールボックスの既定。読み取り専用ペインは選択なし＝何もしない。
     var selectedText: String? { nil }
     func replaceSelection(with text: String) { NSSound.beep() }
+
+    // マルチカーソルの既定（非対応ペイン＝巨大ファイル・diff）。
+    var supportsMultiCursor: Bool { false }
+    func addCaret(above: Bool) {}
+    func selectNextOccurrence() {}
+    func setPreserveCase(_ on: Bool) {}
 
     /// 選択テキストに純粋変換を適用する。selectedText/replaceSelection の上に載るだけ。
     func applyTextTransform(_ transform: TextTransform) {

--- a/Sources/MrEditor/Viewer/DocumentView.swift
+++ b/Sources/MrEditor/Viewer/DocumentView.swift
@@ -54,6 +54,7 @@ final class DocumentView: NSView {
 
     var textAttributes: [NSAttributedString.Key: Any] = [:]
     private var gutterAttributes: [NSAttributedString.Key: Any] = [:]
+    private var invisibleAttributes: [NSAttributedString.Key: Any] = [:]
 
     // MARK: - キャレット / 選択（PieceTableViewer のみ使用。未設定なら描かれない）
 
@@ -79,6 +80,12 @@ final class DocumentView: NSView {
     var highlightCurrentLine = AppSettings.highlightCurrentLine
     /// キャレット形状。
     var cursorShape: CursorShape = AppSettings.cursorShape
+    /// 行番号（ガター）を出すか。false ならガター幅 0 で本文を左端から描く。
+    var showLineNumbers = AppSettings.showLineNumbers
+    /// 不可視文字（タブ・改行・全角スペース・行末スペース）を記号で見せるか。
+    var showInvisibles = AppSettings.showInvisibles
+    /// 改行が続かない可視行（＝文書末尾で改行が無い行）。改行記号を描かない。
+    var rowWithoutEOL: Int?
     /// ブロックカーソルの幅（configure で font から算出）。
     private var caretWidth: CGFloat = 8
     private var currentLineColor = EditorTheme.current().currentLine
@@ -119,8 +126,8 @@ final class DocumentView: NSView {
     func configure(font: NSFont) {
         lineHeight = EditorStyle.lineHeight(for: font)
         caretWidth = EditorStyle.caretWidth(for: font)
-        // 行番号が収まるよう、ガター幅をフォントサイズに追従させる。
-        gutterWidth = max(64, ceil(font.pointSize * 4.5))
+        // 行番号が収まるよう、ガター幅をフォントサイズに追従させる（非表示なら 0）。
+        gutterWidth = showLineNumbers ? max(64, ceil(font.pointSize * 4.5)) : 0
         // 配色（config 連動）を読み直す。
         let theme = EditorTheme.current()
         selectionColor = theme.selection
@@ -137,7 +144,26 @@ final class DocumentView: NSView {
             .font: font,
             .foregroundColor: theme.chromeSecondaryText,
         ]
+        invisibleAttributes = [
+            .font: font,
+            .foregroundColor: theme.chromeSecondaryText.withAlphaComponent(0.7),
+        ]
         layoutsDirty = true
+    }
+
+    /// 1 行ぶんの不可視文字記号を本文の上に重ねる。`drawEOL` が false の行（末尾の改行なし・
+    /// diff の埋め行）には改行記号を出さない。
+    private func drawInvisibles(layout: LineLayout, origin: NSPoint, drawEOL: Bool) {
+        let line = layout.string
+        for marker in InvisibleGlyphs.markers(in: line) {
+            let p = layout.caretPoint(forCharIndex: marker.utf16Index)
+            NSAttributedString(string: marker.glyph, attributes: invisibleAttributes)
+                .draw(at: NSPoint(x: origin.x + p.x, y: origin.y + p.y))
+        }
+        guard drawEOL else { return }
+        let p = layout.caretPoint(forCharIndex: (line as NSString).length)
+        NSAttributedString(string: InvisibleGlyphs.eol, attributes: invisibleAttributes)
+            .draw(at: NSPoint(x: origin.x + p.x, y: origin.y + p.y))
     }
 
     private var contentX: CGFloat { gutterWidth + textLeftPadding }
@@ -167,15 +193,17 @@ final class DocumentView: NSView {
         // 単独表示では全面を塗るので露見しなかったが、diff で左右に並べた瞬間に左が消えた。
         clip.fill()
 
-        // ガター背景
-        let gutterRect = NSRect(x: 0, y: 0, width: gutterWidth, height: bounds.height)
-        EditorTheme.withBackgroundOpacity(gutterBackground).setFill()
-        gutterRect.fill()
-        gutterSeparator.setStroke()
-        let divider = NSBezierPath()
-        divider.move(to: NSPoint(x: gutterWidth - 0.5, y: 0))
-        divider.line(to: NSPoint(x: gutterWidth - 0.5, y: bounds.height))
-        divider.stroke()
+        // ガター背景（行番号を出さない設定なら丸ごと省く）
+        if gutterWidth > 0 {
+            let gutterRect = NSRect(x: 0, y: 0, width: gutterWidth, height: bounds.height)
+            EditorTheme.withBackgroundOpacity(gutterBackground).setFill()
+            gutterRect.fill()
+            gutterSeparator.setStroke()
+            let divider = NSBezierPath()
+            divider.move(to: NSPoint(x: gutterWidth - 0.5, y: 0))
+            divider.line(to: NSPoint(x: gutterWidth - 0.5, y: bounds.height))
+            divider.stroke()
+        }
 
         guard !lines.isEmpty else { return }
         rebuildLayoutsIfNeeded()
@@ -208,12 +236,12 @@ final class DocumentView: NSView {
             // ガター（行番号・右寄せ・先頭サブ行の高さに合わせる）
             let lineNo = (lineNumbers != nil && i < lineNumbers!.count) ? lineNumbers![i] : firstLineNumber + i
             // diff で相手側にしか無い行は番号を出さない（存在しない行に番号を振らない）。
-            let numStr = lineNo == DocumentView.noLineNumber
-                ? NSAttributedString(string: "", attributes: gutterAttributes)
-                : NSAttributedString(string: "\(lineNo + 1)", attributes: gutterAttributes)
-            let numSize = numStr.size()
-            let numX = gutterWidth - gutterRightPadding - numSize.width
-            numStr.draw(with: NSRect(x: max(2, numX), y: y, width: numSize.width, height: lineHeight), options: numOpts)
+            if gutterWidth > 0, lineNo != DocumentView.noLineNumber {
+                let numStr = NSAttributedString(string: "\(lineNo + 1)", attributes: gutterAttributes)
+                let numSize = numStr.size()
+                let numX = gutterWidth - gutterRightPadding - numSize.width
+                numStr.draw(with: NSRect(x: max(2, numX), y: y, width: numSize.width, height: lineHeight), options: numOpts)
+            }
 
             // ここから先（選択・本文・キャレット）は横スクロールで左へずれる。
             // ガターの上に本文が乗らないよう、本文領域へクリップする。
@@ -233,6 +261,12 @@ final class DocumentView: NSView {
 
             // 本文（折り返し分をまとめて描画。折り返し無しは水平オフセットを引く）
             layout.draw(at: NSPoint(x: contentX - xOff, y: y))
+
+            // 不可視文字（本文の上に記号を重ねる。空白と行末にしか置かないので本文と喧嘩しない）
+            if showInvisibles {
+                drawInvisibles(layout: layout, origin: NSPoint(x: contentX - xOff, y: y),
+                               drawEOL: i != rowWithoutEOL && lineNo != DocumentView.noLineNumber)
+            }
 
             // キャレット（形状は config 連動）
             if caretOn, let c = caret, c.row == i {
@@ -436,6 +470,8 @@ private final class LineLayout {
     let rowCount: Int
     let height: CGFloat
     let width: CGFloat
+    /// 行の素の文字列（不可視文字の記号を置く位置の算出に使う）。
+    var string: String { storage.string }
 
     init(_ attr: NSAttributedString, maxWidth: CGFloat, wrap: Bool, lineHeight: CGFloat) {
         storage = NSTextStorage(attributedString: attr)

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -12,6 +12,11 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     private let scrollView = NSScrollView()
     private let textView = EditorTextView()
     private let jsonQueryBar = JsonQueryBar()
+    /// 行番号ガター（config 連動で出し入れする）。
+    private var lineNumberRuler: LineNumberRulerView!
+    /// 行頭索引のキャッシュ（行番号ガターとステータスバーの「行:桁」が共有する）。
+    /// 本文が変わったら捨てて、次に必要になったときに数え直す。
+    private var lineIndexCache: LineStartIndex?
     /// クエリバー表示/非表示で本文の上端を切り替える（片方だけ有効化）。
     private var scrollTopToContainer: NSLayoutConstraint!
     private var scrollTopToBar: NSLayoutConstraint!
@@ -105,6 +110,18 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         scrollView.documentView = textView
         addSubview(scrollView)
 
+        // 行番号ガター。スクロール・本文変更・設定変更で描き直す。
+        let ruler = LineNumberRulerView(textView: textView)
+        ruler.lineIndexProvider = { [weak self] in self?.currentLineIndex() ?? LineStartIndex("") }
+        scrollView.verticalRulerView = ruler
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = AppSettings.showLineNumbers
+        lineNumberRuler = ruler
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        NotificationCenter.default.addObserver(self, selector: #selector(scrolled),
+                                               name: NSView.boundsDidChangeNotification,
+                                               object: scrollView.contentView)
+
         jsonQueryBar.translatesAutoresizingMaskIntoConstraints = false
         jsonQueryBar.isHidden = true
         jsonQueryBar.onQueryChange = { [weak self] q in self?.runJsonQuery(q) }
@@ -127,6 +144,35 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     }
 
     override var isFlipped: Bool { true }
+
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    // MARK: - 行頭索引（行番号ガター・キャレット位置の共有キャッシュ）
+
+    /// 表示中の本文の行頭索引。無ければ数え直してキャッシュする。
+    private func currentLineIndex() -> LineStartIndex {
+        if let cached = lineIndexCache { return cached }
+        let index = LineStartIndex(textView.string as NSString)
+        lineIndexCache = index
+        return index
+    }
+
+    /// 本文を差し替えた／編集したときに呼ぶ（次に必要になったとき数え直す）。
+    private func invalidateLineIndex() {
+        lineIndexCache = nil
+        lineNumberRuler?.updateThickness()
+        lineNumberRuler?.needsDisplay = true
+    }
+
+    @objc private func scrolled() {
+        lineNumberRuler?.needsDisplay = true
+    }
+
+    /// キャレット位置（1 始まりの行・桁）。選択中は選択の先頭を指す。
+    private var caretPosition: (line: Int, column: Int) {
+        let text = textView.string as NSString
+        return currentLineIndex().position(at: textView.selectedRange().location, in: text)
+    }
 
     // MARK: - ファイルを開く
 
@@ -166,6 +212,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         self.byteSize = data.count
         resetStructuredPresentation()
         textView.string = text
+        invalidateLineIndex()
         applyParagraphStyle()                       // タブ幅・行間を本文全体へ
         textView.undoManager?.removeAllActions()   // 読み込みはアンドゥ対象にしない
         textView.setSelectedRange(NSRange(location: 0, length: 0))
@@ -247,6 +294,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         byteSize = text.utf8.count
         resetStructuredPresentation()
         textView.string = text
+        invalidateLineIndex()
         applyParagraphStyle()
         textView.undoManager?.removeAllActions()   // 復元はアンドゥ対象にしない
         textView.setSelectedRange(NSRange(location: 0, length: 0))
@@ -264,6 +312,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         byteSize = 0
         resetStructuredPresentation()
         textView.string = ""
+        invalidateLineIndex()
         textView.undoManager?.removeAllActions()
         textView.setSelectedRange(NSRange(location: 0, length: 0))
         setDirty(false)
@@ -348,7 +397,13 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     func textDidChange(_ notification: Notification) {
         setDirty(true)
         scheduleDraftSave()   // 落ちても直前まで残るよう、未保存の本文をディスクへ
+        invalidateLineIndex() // 行がずれた＝行番号ガターとキャレット位置を数え直す
         emitState()           // 行数・状態を更新
+    }
+
+    /// キャレット移動でステータスバーの「行:桁」を更新する。
+    func textViewDidChangeSelection(_ notification: Notification) {
+        emitState()
     }
 
     // MARK: - 編集ツールボックス（選択の取得・置換。変換/パイプはこの2つに載る）
@@ -369,6 +424,18 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.replaceCharacters(in: range, with: text)
         textView.didChangeText()   // textDidChange 経由で dirty/draft/状態が更新される
         textView.setSelectedRange(NSRange(location: range.location, length: (text as NSString).length))
+    }
+
+    // MARK: - マルチカーソル（NSTextView の不連続選択に載る＝このペインだけ）
+
+    var supportsMultiCursor: Bool { canEdit }
+    func addCaret(above: Bool) {
+        guard canEdit else { NSSound.beep(); return }
+        textView.addCaret(above: above)
+    }
+    func selectNextOccurrence() {
+        guard canEdit else { NSSound.beep(); return }
+        textView.selectNextOccurrence()
     }
 
     // MARK: - DocumentPane
@@ -393,13 +460,19 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     func applyCurrentFontSize() {
         textView.font = EditorFont.current()
         applyParagraphStyle()   // 行高はフォント依存なので再計算する
+        lineNumberRuler?.updateThickness()   // 行番号も同じフォントで描くので幅が変わる
+        lineNumberRuler?.needsDisplay = true
     }
 
     func applyDisplaySettings() {
         textView.cursorShape = AppSettings.cursorShape
         textView.highlightCurrentLine = AppSettings.highlightCurrentLine
+        textView.showInvisibles = AppSettings.showInvisibles
         applyParagraphStyle()   // タブ幅・行間
         applyColors()           // 配色（テーマ）
+        scrollView.rulersVisible = AppSettings.showLineNumbers
+        lineNumberRuler?.updateThickness()
+        lineNumberRuler?.needsDisplay = true
         textView.needsDisplay = true
     }
 
@@ -420,6 +493,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             textView.delegate = self
             applyParagraphStyle(); applyColors()
             textView.setSelectedRange(NSRange(location: 0, length: 0))
+            invalidateLineIndex()
             emitState()
             return
         }
@@ -437,6 +511,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             textView.textStorage?.setAttributedString(readonlyAttributed(pretty))
             textView.delegate = self
             textView.setSelectedRange(NSRange(location: 0, length: 0))
+            invalidateLineIndex()
             return
         }
         preStructuredText = source
@@ -452,6 +527,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.textStorage?.setAttributedString(formatted)
         textView.delegate = self
         textView.setSelectedRange(NSRange(location: 0, length: 0))
+        invalidateLineIndex()
     }
 
     /// 整形済みの読み取り専用テキスト（等幅・CSV/TSV は先頭行を太字）。
@@ -512,6 +588,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             textView.textStorage?.setAttributedString(readonlyAttributed(text))
             textView.delegate = self
             textView.setSelectedRange(NSRange(location: 0, length: 0))
+            invalidateLineIndex()
             jsonQueryBar.setStatus(error: nil)
         } catch {
             jsonQueryBar.setStatus(error: L("jsonquery.error"))
@@ -533,6 +610,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.delegate = self
         applyParagraphStyle(); applyColors()
         textView.setSelectedRange(NSRange(location: 0, length: 0))
+        invalidateLineIndex()
         emitState()
     }
 
@@ -609,7 +687,8 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             lineCountIsExact: true,
             // クリーン時は読み込み時の実ディスクサイズ（正確・安価）。編集中は保存されるバイト数をライブ計算。
             fileSize: isDirty ? liveByteSize : byteSize,
-            indexProgress: 1.0
+            indexProgress: 1.0,
+            caret: caretPosition
         )
         onStateChange?(state)
     }
@@ -636,7 +715,7 @@ extension EditableViewer {
     var _testText: String { textView.string }
     var _testEncoding: DetectedEncoding { encoding }
     var _testLineEnding: LineEnding { lineEnding }
-    func _testSetText(_ s: String) { textView.string = s; setDirty(true) }
+    func _testSetText(_ s: String) { textView.string = s; invalidateLineIndex(); setDirty(true) }
     func _testSelect(_ range: NSRange) { textView.setSelectedRange(range) }
     @discardableResult func _testWrite(to url: URL) -> Bool { write(to: url) }
     var _testJsonQueryActive: Bool { jsonQueryActive }

--- a/Sources/MrEditor/Viewer/EditorTextView.swift
+++ b/Sources/MrEditor/Viewer/EditorTextView.swift
@@ -2,9 +2,13 @@ import AppKit
 
 /// 小ファイル編集用 `NSTextView` の派生。標準の機能（IME・アンドゥ・選択）は
 /// そのままに、キャレット形状と現在行ハイライトだけを config 連動で差し替える。
+/// 加えてマルチカーソル（⌘クリック／⌥⌘↑↓／⌘D）を載せる。複数キャレットの実体は
+/// NSTextView が元から持つ `selectedRanges`（不連続選択）で、範囲計算は `MultiCursor`。
 final class EditorTextView: NSTextView {
     var cursorShape: CursorShape = AppSettings.cursorShape
     var highlightCurrentLine: Bool = AppSettings.highlightCurrentLine
+    /// 不可視文字（タブ・改行・全角スペース・行末の半角スペース）を記号で見せるか。
+    var showInvisibles: Bool = AppSettings.showInvisibles
 
     private var caretWidth: CGFloat {
         EditorStyle.caretWidth(for: font ?? EditorFont.current())
@@ -14,6 +18,25 @@ final class EditorTextView: NSTextView {
 
     override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
+        drawCurrentLineHighlight(in: rect)
+    }
+
+    /// 記号は**本文とその選択ハイライトを描いた後**に重ねる。背景段階で描くと、
+    /// 選択した瞬間に選択の帯へ塗り潰されて記号が消える（実機で発覚）。
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        if showInvisibles { drawInvisibles(in: dirtyRect) }
+        drawExtraCarets()
+    }
+
+    deinit { caretBlinkTimer?.invalidate() }
+
+    // MARK: - テスト用フック（マルチカーソルは selectedRanges に載らないので専用の口が要る）
+
+    func _testSetCarets(_ ranges: [NSRange]) { applyCarets(ranges) }
+    var _testCarets: [NSRange] { carets.isEmpty ? [selectedRange()] : carets }
+
+    private func drawCurrentLineHighlight(in rect: NSRect) {
         guard highlightCurrentLine, selectedRange().length == 0,
               let lm = layoutManager, let tc = textContainer else { return }
         let len = (string as NSString).length
@@ -33,10 +56,277 @@ final class EditorTextView: NSTextView {
         frag.fill()
     }
 
+    // MARK: - 不可視文字
+
+    /// 可視範囲の行を走査し、タブ・全角スペース・行末スペース・改行の位置へ記号を重ねる。
+    /// **本文は書き換えない**（置換するとタブの桁揃えも選択位置も崩れるため）。
+    private func drawInvisibles(in rect: NSRect) {
+        guard let lm = layoutManager, let tc = textContainer else { return }
+        let text = string as NSString
+        guard text.length > 0 else { return }
+
+        let font = EditorFont.current()
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: EditorTheme.current().chromeSecondaryText.withAlphaComponent(0.7),
+        ]
+        let origin = textContainerOrigin
+        let glyphRange = lm.glyphRange(forBoundingRect: rect, in: tc)
+        let charRange = lm.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+
+        /// 文字位置 `index` のグリフ矩形（ビュー座標）。
+        func glyphRect(_ index: Int) -> NSRect {
+            let g = lm.glyphIndexForCharacter(at: index)
+            return lm.boundingRect(forGlyphRange: NSRange(location: g, length: 1), in: tc)
+                .offsetBy(dx: origin.x, dy: origin.y)
+        }
+
+        var lineStart = text.lineRange(for: NSRange(location: charRange.location, length: 0)).location
+        while lineStart < min(NSMaxRange(charRange) + 1, text.length) {
+            let lineRange = text.lineRange(for: NSRange(location: lineStart, length: 0))
+            // 改行を除いた本文部分（記号の算出は改行なしの1行に対して行う）。
+            let contentEnd = NSMaxRange(lineRange)
+            var end = contentEnd
+            while end > lineStart, isNewline(text.character(at: end - 1)) { end -= 1 }
+
+            let line = text.substring(with: NSRange(location: lineStart, length: end - lineStart))
+            for marker in InvisibleGlyphs.markers(in: line) {
+                let r = glyphRect(lineStart + marker.utf16Index)
+                NSAttributedString(string: marker.glyph, attributes: attrs)
+                    .draw(at: NSPoint(x: r.minX, y: r.minY))
+            }
+            // 改行記号（この行が改行で終わっているときだけ）。
+            if end < contentEnd {
+                let r = glyphRect(end)
+                NSAttributedString(string: InvisibleGlyphs.eol, attributes: attrs)
+                    .draw(at: NSPoint(x: r.minX, y: r.minY))
+            }
+            if NSMaxRange(lineRange) == lineStart { break }   // 進まない＝末尾
+            lineStart = NSMaxRange(lineRange)
+        }
+    }
+
+    private func isNewline(_ unit: unichar) -> Bool { unit == 0x000A || unit == 0x000D }
+
     /// 選択（キャレット）移動で現在行ハイライトを描き直す。
+    /// **AppKit 由来の選択変更はマルチカーソルの解除**（普通のクリック・矢印キーで元に戻る）。
+    /// 自分で複数キャレットを置くときは `applyCarets` から `super` を直接呼ぶのでここを通らない。
     override func setSelectedRanges(_ ranges: [NSValue], affinity: NSSelectionAffinity, stillSelecting: Bool) {
         super.setSelectedRanges(ranges, affinity: affinity, stillSelecting: stillSelecting)
+        if !carets.isEmpty { carets = []; needsDisplay = true }
         if highlightCurrentLine { needsDisplay = true }
+        syncCaretBlink()
+    }
+
+    // MARK: - マルチカーソル
+
+    /// 複数キャレット（UTF-16・昇順）。**空のとき＝単一キャレットの通常状態**。
+    ///
+    /// NSTextView の `selectedRanges` は**長さ 0 の範囲を複数持てない**（1 つに畳まれる）ので、
+    /// キャレットの列はここで自前に持つ。長さのある範囲（⌘D で集めた語）は AppKit にも渡して
+    /// 選択の帯を描かせ、長さ 0 のキャレットだけ `drawExtraCarets` で自分で描く。
+    private var carets: [NSRange] = []
+
+    /// マルチカーソル中か。
+    var hasMultipleCarets: Bool { carets.count > 1 }
+
+    /// 編集・追加操作の起点になる現在の範囲（マルチなら全キャレット、単一なら選択そのもの）。
+    private var activeRanges: [NSRange] { hasMultipleCarets ? carets : [selectedRange()] }
+
+    /// 副キャレットの点滅位相（AppKit が点滅させるのは主キャレット 1 つだけ）。
+    private var extraCaretsOn = true
+    private var caretBlinkTimer: Timer?
+
+    /// キャレット列を確定して表示へ反映する。1 個に畳まれたら通常の単一選択へ戻す。
+    private func applyCarets(_ new: [NSRange]) {
+        let normalized = MultiCursor.normalize(new)
+        guard let primary = normalized.last else { return }
+        carets = normalized.count > 1 ? normalized : []
+
+        // 長さのある範囲が複数あるときは AppKit の不連続選択に載せる（帯を描いてもらう）。
+        let selections = normalized.filter { $0.length > 0 }
+        let handOff = selections.count > 1 ? selections : [normalized.count > 1 ? (selections.first ?? primary) : primary]
+        super.setSelectedRanges(handOff.map { NSValue(range: $0) }, affinity: .downstream, stillSelecting: false)
+
+        needsDisplay = true
+        syncCaretBlink()
+    }
+
+    /// ⌘クリックでキャレットを足す／同じ位置をもう一度クリックで外す。
+    /// ⌥ドラッグの矩形選択（AppKit 標準）はそのまま残す＝そちらも複数範囲として編集できる。
+    override func mouseDown(with event: NSEvent) {
+        guard event.modifierFlags.contains(.command),
+              !event.modifierFlags.contains(.shift), isEditable else {
+            super.mouseDown(with: event); return
+        }
+        window?.makeFirstResponder(self)
+        let point = convert(event.locationInWindow, from: nil)
+        let index = characterIndexForInsertion(at: point)
+        applyCarets(MultiCursor.toggling(activeRanges, at: NSRange(location: index, length: 0)))
+    }
+
+    /// 上／下の行の同じ桁にキャレットを足す（⌥⌘↑ / ⌥⌘↓）。
+    func addCaret(above: Bool) {
+        applyCarets(MultiCursor.addingCaret(to: activeRanges, above: above, in: string as NSString))
+    }
+
+    /// 選択中の語と同じ次の語を選択に足す（⌘D）。選択が無ければキャレット位置の語を選ぶ。
+    func selectNextOccurrence() {
+        let text = string as NSString
+        let current = activeRanges
+        guard let last = current.max(by: { NSMaxRange($0) < NSMaxRange($1) }) else { return }
+        guard last.length > 0 else {
+            // まず語を掴む段階（VSCode の ⌘D 1 回目と同じ）。
+            guard let word = MultiCursor.wordRange(at: last.location, in: text) else { NSSound.beep(); return }
+            applyCarets([word])
+            return
+        }
+        let word = text.substring(with: last)
+        guard let found = MultiCursor.nextOccurrence(of: word, in: text, after: NSMaxRange(last),
+                                                     excluding: current) else { NSSound.beep(); return }
+        applyCarets(current + [found])
+        scrollRangeToVisible(found)
+    }
+
+    /// Esc でマルチカーソルを解除（主キャレット 1 つに畳む）。単一なら標準の動作へ。
+    override func cancelOperation(_ sender: Any?) {
+        guard hasMultipleCarets else { super.cancelOperation(sender); return }
+        applyCarets([carets.last ?? selectedRange()])
+    }
+
+    // MARK: - 複数キャレットへの編集（アンドゥは NSTextView の機構にそのまま載せる）
+
+    override func insertText(_ string: Any, replacementRange: NSRange) {
+        let text = (string as? NSAttributedString)?.string ?? (string as? String) ?? ""
+        // IME 変換中は主キャレットだけを相手にする（marked text は 1 か所にしか置けない）。
+        guard !hasMarkedText(), applyToAllCarets(replacing: nil, with: text) else {
+            super.insertText(string, replacementRange: replacementRange); return
+        }
+    }
+
+    override func insertNewline(_ sender: Any?) {
+        guard applyToAllCarets(replacing: nil, with: "\n") else { super.insertNewline(sender); return }
+    }
+
+    override func insertTab(_ sender: Any?) {
+        guard applyToAllCarets(replacing: nil, with: "\t") else { super.insertTab(sender); return }
+    }
+
+    override func deleteBackward(_ sender: Any?) {
+        guard applyToAllCarets(replacing: false, with: "") else { super.deleteBackward(sender); return }
+    }
+
+    override func deleteForward(_ sender: Any?) {
+        guard applyToAllCarets(replacing: true, with: "") else { super.deleteForward(sender); return }
+    }
+
+    /// 全キャレットに同じ編集を適用する。`forward` が nil なら選択（キャレットなら 0 文字）を
+    /// `text` で置換、非 nil なら削除方向。単一キャレットのときは false を返して標準処理に任せる。
+    private func applyToAllCarets(replacing forward: Bool?, with text: String) -> Bool {
+        guard hasMultipleCarets, isEditable, let storage = textStorage else { return false }
+        let targets: [NSRange] = {
+            guard let forward else { return MultiCursor.normalize(carets) }
+            return MultiCursor.deletionRanges(carets, forward: forward, in: string as NSString)
+        }()
+        guard !targets.isEmpty else { return true }   // 消すものが無い＝何もせず握り潰す
+
+        let replacements = Array(repeating: text, count: targets.count)
+        guard shouldChangeText(inRanges: targets.map { NSValue(range: $0) },
+                               replacementStrings: replacements) else { return true }
+        let inserted = NSAttributedString(string: text, attributes: typingAttributes)
+        storage.beginEditing()
+        // 後ろから適用すれば前方のオフセットが動かない。
+        for r in targets.reversed() { storage.replaceCharacters(in: r, with: inserted) }
+        storage.endEditing()
+        didChangeText()
+        applyCarets(MultiCursor.caretsAfterReplacing(targets, with: replacements))
+        return true
+    }
+
+    // MARK: - 副キャレットの描画（点滅も自前）
+
+    /// キャレットが 2 個以上のときだけ点滅タイマーを回す。
+    private func syncCaretBlink() {
+        let needed = hasMultipleCarets && carets.contains { $0.length == 0 }
+        if needed, caretBlinkTimer == nil {
+            extraCaretsOn = true
+            caretBlinkTimer = Timer.scheduledTimer(withTimeInterval: 0.56, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                self.extraCaretsOn.toggle()
+                self.setNeedsDisplay(self.extraCaretsBounds)
+            }
+        } else if !needed, caretBlinkTimer != nil {
+            caretBlinkTimer?.invalidate()
+            caretBlinkTimer = nil
+            extraCaretsOn = true
+        }
+    }
+
+    /// 副キャレットを含む再描画範囲（点滅で全面を描き直さないため）。
+    private var extraCaretsBounds: NSRect {
+        extraCaretRects().reduce(NSRect.zero) { $0.isEmpty ? $1 : $0.union($1) }
+    }
+
+    /// 自前で描くキャレット矩形。AppKit が描く主キャレット（空選択のとき）とは重ねない。
+    private func extraCaretRects() -> [NSRect] {
+        guard hasMultipleCarets else { return [] }
+        let primary = selectedRange()
+        let drawnByAppKit = primary.length == 0 ? primary.location : -1
+        return carets.filter { $0.length == 0 && $0.location != drawnByAppKit }
+                     .compactMap { caretRect(atCharIndex: $0.location) }
+    }
+
+    /// 文字位置 `ci` のキャレット矩形（ビュー座標）。末尾・空文書・行末の改行直後も扱う。
+    private func caretRect(atCharIndex ci: Int) -> NSRect? {
+        guard let lm = layoutManager, let tc = textContainer else { return nil }
+        let text = string as NSString
+        let len = text.length
+        let index = min(max(0, ci), len)
+        let origin = textContainerOrigin
+        let width = cursorShape == .bar ? 1.5 : caretWidth
+
+        func atEndOfText() -> NSRect {
+            if len == 0 || isNewline(text.character(at: len - 1)) {
+                var r = lm.extraLineFragmentRect
+                r.size.width = width
+                return r
+            }
+            let g = lm.glyphIndexForCharacter(at: len - 1)
+            let frag = lm.lineFragmentRect(forGlyphAt: g, effectiveRange: nil)
+            let box = lm.boundingRect(forGlyphRange: NSRange(location: g, length: 1), in: tc)
+            return NSRect(x: box.maxX, y: frag.minY, width: width, height: frag.height)
+        }
+
+        var rect: NSRect
+        if index >= len {
+            rect = atEndOfText()
+        } else {
+            let g = lm.glyphIndexForCharacter(at: index)
+            guard g < lm.numberOfGlyphs else { rect = atEndOfText(); return rect.offsetBy(dx: origin.x, dy: origin.y) }
+            let frag = lm.lineFragmentRect(forGlyphAt: g, effectiveRange: nil)
+            let p = lm.location(forGlyphAt: g)
+            rect = NSRect(x: frag.minX + p.x, y: frag.minY, width: width, height: frag.height)
+        }
+        return rect.offsetBy(dx: origin.x, dy: origin.y)
+    }
+
+    /// 副キャレットを描く（形状は主キャレットと同じ config 連動）。
+    private func drawExtraCarets() {
+        guard extraCaretsOn, hasMultipleCarets else { return }
+        let color = insertionPointColor ?? .textColor
+        for var r in extraCaretRects() {
+            switch cursorShape {
+            case .bar:
+                color.setFill()
+            case .block:
+                color.withAlphaComponent(0.4).setFill()
+            case .underline:
+                r.origin.y = r.maxY - 2
+                r.size.height = 2
+                color.setFill()
+            }
+            r.fill()
+        }
     }
 
     // MARK: - キャレット形状

--- a/Sources/MrEditor/Viewer/MultiCursor.swift
+++ b/Sources/MrEditor/Viewer/MultiCursor.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// マルチカーソルの範囲計算（UI 非依存の純ロジック）。
+///
+/// 保持しているのは `NSTextView.selectedRanges` そのもの（UTF-16 の範囲配列）で、
+/// このファイルには「どこにキャレットを足すか」「編集後にキャレットがどこへ動くか」
+/// だけを置く。実際の本文書き換えとアンドゥは `EditorTextView` が
+/// `shouldChangeTextInRanges` 経由で行う（NSTextView のアンドゥにそのまま載る）。
+enum MultiCursor {
+    // MARK: - 範囲の集合を保つ
+
+    /// 範囲を追加して正規化する。同じ位置のキャレットは足さずに**取り除く**
+    /// （⌘クリックで付けた点をもう一度クリックして消せる）。
+    static func toggling(_ ranges: [NSRange], at range: NSRange) -> [NSRange] {
+        if let hit = ranges.firstIndex(where: { $0 == range }), ranges.count > 1 {
+            var out = ranges
+            out.remove(at: hit)
+            return out
+        }
+        return normalize(ranges + [range])
+    }
+
+    /// 昇順に並べ、重なり合う範囲を 1 つに畳む。空（キャレット）が別の範囲に含まれる場合も畳む。
+    static func normalize(_ ranges: [NSRange]) -> [NSRange] {
+        let sorted = ranges.sorted { $0.location != $1.location ? $0.location < $1.location : $0.length < $1.length }
+        var out: [NSRange] = []
+        for r in sorted {
+            guard var last = out.last else { out.append(r); continue }
+            // 触れていない（間が空いている）なら別のキャレットとして残す。
+            guard r.location <= NSMaxRange(last) else { out.append(r); continue }
+            // 端で接するだけの空キャレットは、隣の選択に飲ませない限り重複扱いにする。
+            if r.length == 0 && last.length > 0 && r.location == NSMaxRange(last) { continue }
+            if r.length == 0 && last.length == 0 && r.location != last.location { out.append(r); continue }
+            last.length = max(NSMaxRange(last), NSMaxRange(r)) - last.location
+            out[out.count - 1] = last
+        }
+        return out
+    }
+
+    // MARK: - 上下にキャレットを足す（⌥⌘↑ / ⌥⌘↓）
+
+    /// `ranges` の最も上（`above` が true）／下のキャレットと同じ桁に、1 行ぶん隣のキャレットを足す。
+    /// 隣の行が無い（先頭行の上・末尾行の下）ときは `ranges` をそのまま返す。
+    static func addingCaret(to ranges: [NSRange], above: Bool, in text: NSString) -> [NSRange] {
+        guard let edge = above ? ranges.min(by: { $0.location < $1.location })
+                               : ranges.max(by: { $0.location < $1.location }) else { return ranges }
+        let anchor = above ? edge.location : NSMaxRange(edge)
+        let line = text.lineRange(for: NSRange(location: min(anchor, text.length), length: 0))
+        let column = min(anchor, text.length) - line.location
+
+        let neighbor: NSRange
+        if above {
+            guard line.location > 0 else { return ranges }
+            neighbor = text.lineRange(for: NSRange(location: line.location - 1, length: 0))
+        } else {
+            guard NSMaxRange(line) < text.length else { return ranges }
+            neighbor = text.lineRange(for: NSRange(location: NSMaxRange(line), length: 0))
+        }
+        // 短い行では行末に寄せる（改行を飛び越えて次の行に入らないよう content 長で止める）。
+        let target = neighbor.location + min(column, contentLength(of: neighbor, in: text))
+        return normalize(ranges + [NSRange(location: target, length: 0)])
+    }
+
+    /// 改行を除いた行の長さ（CRLF も 1 行として扱う）。
+    private static func contentLength(of line: NSRange, in text: NSString) -> Int {
+        var end = NSMaxRange(line)
+        while end > line.location, isNewline(text.character(at: end - 1)) { end -= 1 }
+        return end - line.location
+    }
+
+    private static func isNewline(_ unit: unichar) -> Bool { unit == 0x000A || unit == 0x000D }
+
+    // MARK: - 次の同じ語を選択に足す（⌘D）
+
+    /// `word` と同じ文字列を `after` 以降（末尾まで行ったら先頭へ回り込んで）探し、その範囲を返す。
+    /// 既に `ranges` に入っている一致は飛ばす。見つからなければ nil。
+    static func nextOccurrence(of word: String, in text: NSString, after: Int,
+                               excluding ranges: [NSRange]) -> NSRange? {
+        guard !word.isEmpty else { return nil }
+        let taken = Set(ranges.map { $0.location })
+        var from = min(max(0, after), text.length)
+        var wrapped = false
+        while true {
+            let searchRange = NSRange(location: from, length: text.length - from)
+            let found = text.range(of: word, options: [], range: searchRange)
+            if found.location == NSNotFound {
+                if wrapped { return nil }
+                wrapped = true; from = 0; continue
+            }
+            if !taken.contains(found.location) { return found }
+            from = found.location + 1
+            if from >= text.length {
+                if wrapped { return nil }
+                wrapped = true; from = 0
+            }
+        }
+    }
+
+    /// `index` を含む（または直前で終わる）語の範囲。語が無ければ nil。
+    static func wordRange(at index: Int, in text: NSString) -> NSRange? {
+        guard text.length > 0 else { return nil }
+        let isWord: (unichar) -> Bool = { u in
+            let c = Character(UnicodeScalar(u) ?? " ")
+            return c.isLetter || c.isNumber || c == "_"
+        }
+        var start = min(index, text.length)
+        // キャレットが語の直後にあるときも、その語を掴む。
+        if start == text.length || !isWord(text.character(at: start)) {
+            guard start > 0, isWord(text.character(at: start - 1)) else { return nil }
+            start -= 1
+        }
+        var end = start
+        while start > 0, isWord(text.character(at: start - 1)) { start -= 1 }
+        while end < text.length, isWord(text.character(at: end)) { end += 1 }
+        return end > start ? NSRange(location: start, length: end - start) : nil
+    }
+
+    // MARK: - 編集後のキャレット位置
+
+    /// 各範囲を `replacements[i]` で置き換えたあとのキャレット位置（挿入した文字列の直後）を返す。
+    /// 前の編集で生じた長さの差を積み上げてずらす（`ranges` は昇順であること）。
+    static func caretsAfterReplacing(_ ranges: [NSRange], with replacements: [String]) -> [NSRange] {
+        var delta = 0
+        var out: [NSRange] = []
+        out.reserveCapacity(ranges.count)
+        for (i, r) in ranges.enumerated() {
+            let inserted = (replacements[min(i, replacements.count - 1)] as NSString).length
+            out.append(NSRange(location: r.location + delta + inserted, length: 0))
+            delta += inserted - r.length
+        }
+        return out
+    }
+
+    /// 削除キーが消す範囲を各キャレットについて求める。
+    /// 選択があればその選択を、キャレットだけなら前（`forward` が false）／後ろの 1 文字を消す。
+    /// 消すものが無い（文頭で前を消す等）範囲は落とす。
+    static func deletionRanges(_ ranges: [NSRange], forward: Bool, in text: NSString) -> [NSRange] {
+        var out: [NSRange] = []
+        for r in ranges {
+            if r.length > 0 { out.append(r); continue }
+            if forward {
+                guard r.location < text.length else { continue }
+                // サロゲートペア・結合文字を 1 文字として消す。
+                out.append(text.rangeOfComposedCharacterSequence(at: r.location))
+            } else {
+                guard r.location > 0 else { continue }
+                out.append(text.rangeOfComposedCharacterSequence(at: r.location - 1))
+            }
+        }
+        return normalize(out)
+    }
+}

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -108,6 +108,8 @@ final class PieceTableViewer: NSView, DocumentPane {
     private var regexMode = false
     private var searchRegex: NSRegularExpression?
     private var caseSensitive = false
+    /// 置換で一致した語の大文字小文字を置換文字列へ引き継ぐか（`CasePreserving`）。
+    private var preserveCase = false
     private var filterMode = false
     private var matchHighlight = EditorTheme.current().searchMatch
     /// ANSI 着色用パレット（テーマ変更で更新）。
@@ -221,6 +223,8 @@ final class PieceTableViewer: NSView, DocumentPane {
     func applyDisplaySettings() {
         documentView.highlightCurrentLine = AppSettings.highlightCurrentLine
         documentView.cursorShape = AppSettings.cursorShape
+        documentView.showLineNumbers = AppSettings.showLineNumbers
+        documentView.showInvisibles = AppSettings.showInvisibles
         matchHighlight = EditorTheme.current().searchMatch
         ansiPalette = ANSIPalette.from(theme: EditorTheme.current())
         // タブ幅・行間・配色は configure(font:) が段落スタイル・行高・色へ織り込む。
@@ -359,6 +363,10 @@ final class PieceTableViewer: NSView, DocumentPane {
         } else {
             let ranges = lineRanges(from: topLine, count: needed)
             visibleRanges = ranges
+            // 最終行の後ろには改行が無い＝不可視文字の改行記号を出さない行。
+            documentView.rowWithoutEOL = ranges.indices.last.flatMap {
+                ranges[$0].upperBound >= docByteCount ? $0 : nil
+            }
             attributed.reserveCapacity(ranges.count)
             for r in ranges { attributed.append(decodeLine(r)) }
             documentView.lineNumbers = nil
@@ -483,15 +491,21 @@ final class PieceTableViewer: NSView, DocumentPane {
 
     /// 行内の (一致レンジ, 置換後文字列) を返す。literal は replacement そのまま、regex は $1 展開。
     private func matchReplacements(in text: String, with replacement: String) -> [(NSRange, String)] {
+        let ns = text as NSString
+        /// ケース維持がオンなら、一致した実際の綴りの書式を置換文字列へ移す。
+        func shaped(_ rep: String, _ range: NSRange) -> String {
+            guard preserveCase else { return rep }
+            return CasePreserving.apply(rep, matching: ns.substring(with: range))
+        }
         if let rx = searchRegex {
-            let ns = text as NSString
             var out: [(NSRange, String)] = []
             for m in rx.matches(in: text, range: NSRange(location: 0, length: ns.length)) where m.range.length > 0 {
-                out.append((m.range, rx.replacementString(for: m, in: text, offset: 0, template: replacement)))
+                let expanded = rx.replacementString(for: m, in: text, offset: 0, template: replacement)
+                out.append((m.range, shaped(expanded, m.range)))
             }
             return out
         }
-        return matchRanges(in: text).map { ($0, replacement) }
+        return matchRanges(in: text).map { ($0, shaped(replacement, $0)) }
     }
 
     /// 文書のバイト範囲を取り出す。クリーン時は mmap 直読み、編集後は piece table 経由。
@@ -1207,6 +1221,8 @@ final class PieceTableViewer: NSView, DocumentPane {
     func setSearchQuery(_ q: String) { guard readsFromOriginal, q != searchQuery else { return }; searchQuery = q; rebuildSearch() }
     func setRegexMode(_ on: Bool) { guard readsFromOriginal, on != regexMode else { return }; regexMode = on; rebuildSearch() }
     func setCaseSensitive(_ on: Bool) { guard readsFromOriginal, on != caseSensitive else { return }; caseSensitive = on; rebuildSearch() }
+    /// ケース維持は置換時にしか効かない（検索結果は変わらない）ので再検索しない。
+    func setPreserveCase(_ on: Bool) { preserveCase = on }
 
     private func rebuildSearch() {
         searchEpoch += 1
@@ -1405,13 +1421,17 @@ final class PieceTableViewer: NSView, DocumentPane {
     private func replacementForSelection(_ sel: Range<Int>, _ replacement: String) -> String? {
         let str = decodeString(rawBytes(in: sel))
         let ns = str as NSString
+        /// ケース維持がオンなら、選択（＝一致した実際の綴り）の書式を置換文字列へ移す。
+        func shaped(_ rep: String) -> String {
+            preserveCase ? CasePreserving.apply(rep, matching: str) : rep
+        }
         if let rx = searchRegex {
             guard let m = rx.firstMatch(in: str, range: NSRange(location: 0, length: ns.length)),
                   m.range.location == 0, m.range.length == ns.length else { return nil }
-            return rx.replacementString(for: m, in: str, offset: 0, template: replacement)
+            return shaped(rx.replacementString(for: m, in: str, offset: 0, template: replacement))
         }
         for term in searchTerms where !term.isEmpty {
-            if ns.compare(term, options: caseSensitive ? [] : .caseInsensitive) == .orderedSame { return replacement }
+            if ns.compare(term, options: caseSensitive ? [] : .caseInsensitive) == .orderedSame { return shaped(replacement) }
         }
         return nil
     }
@@ -1487,9 +1507,20 @@ final class PieceTableViewer: NSView, DocumentPane {
             lineCount: readsFromOriginal ? idx.displayLineCount : (pieceTable?.lineCount ?? idx.displayLineCount),
             lineCountIsExact: readsFromOriginal ? idx.isComplete : (pieceTable != nil),
             fileSize: readsFromOriginal ? buffer.count : (pieceTable?.byteCount ?? buffer.count),
-            indexProgress: idx.isComplete ? 1.0 : partialProgress
+            indexProgress: idx.isComplete ? 1.0 : partialProgress,
+            caret: caretPosition
         )
         onStateChange?(state)
+    }
+
+    /// キャレットの (行, 桁)（ともに 1 始まり）。キャレットを持たない表示では nil。
+    /// 桁は行頭からの文字数＋1（バイトではなく人が数える桁に合わせる）。
+    private var caretPosition: (line: Int, column: Int)? {
+        guard let pt = pieceTable, structuredFormatter == nil, !filterMode else { return nil }
+        let line = pt.line(ofByteOffset: caretByte)
+        let start = pt.byteOffset(ofLineStart: line)
+        let column = start < caretByte ? decodeString(rawBytes(in: start..<caretByte)).count : 0
+        return (line + 1, column + 1)
     }
 
     // MARK: - DocumentPane

--- a/Sources/MrEditor/Viewer/TextTransforms.swift
+++ b/Sources/MrEditor/Viewer/TextTransforms.swift
@@ -30,8 +30,9 @@ enum TextTransform: Int, CaseIterable {
     static let caseGroup: [TextTransform] = [.uppercase, .lowercase, .titlecase, .togglecase]
     /// エンコード／デコードグループ（第2グループ）。
     static let encodingGroup: [TextTransform] = [.urlEncode, .urlDecode, .base64Encode, .base64Decode, .htmlEncode, .htmlDecode]
-    /// 行操作グループ（第3グループ）。
-    static let lineGroup: [TextTransform] = [.sortAscending, .sortDescending, .uniqueLines, .reverseLines, .numberLines, .joinLines, .indent, .outdent]
+    /// 行操作グループ（第3グループ）。連番はパラメータを取るのでメニューでは
+    /// ダイアログ付きの別項目（`LineNumberer`）にしてあり、ここには並べない。
+    static let lineGroup: [TextTransform] = [.sortAscending, .sortDescending, .uniqueLines, .reverseLines, .joinLines, .indent, .outdent]
 
     /// 字下げ／字上げの単位（タブ1つ。字上げはこの単位ぶんの先頭タブ、または同幅の先頭スペースを1段はがす）。
     static let indentUnit = "\t"
@@ -186,11 +187,9 @@ enum TextTransform: Int, CaseIterable {
         return joinLines(transform(lines), trailingNewline: trailing)
     }
 
-    /// 各行の先頭に 1 始まりの連番＋タブを付ける。
+    /// 各行の先頭に 1 始まりの連番＋タブを付ける（既定パラメータの `LineNumberer` そのもの）。
     private static func numberLines(_ s: String) -> String {
-        let (lines, trailing) = splitLines(s)
-        let numbered = lines.enumerated().map { "\($0.offset + 1)\t\($0.element)" }
-        return joinLines(numbered, trailingNewline: trailing)
+        LineNumberer.number(s, options: .init())
     }
 
     /// 複数行を1行に連結する（改行を1つのスペースに畳み、各行の前後空白を除く）。
@@ -224,5 +223,124 @@ enum TextTransform: Int, CaseIterable {
                 return String(line[idx...])
             }
         }
+    }
+}
+
+/// 行の分割（`TextTransform` の連結の逆操作）。区切り文字というパラメータを取るため
+/// 引数なしの `TextTransform` には載せず、ダイアログで設定を受け取ってここを呼ぶ。
+enum LineSplitter {
+    /// 分割の設定（ダイアログの各項目に 1 対 1 で対応する）。
+    struct Options: Equatable {
+        /// 区切り文字（`\t` `\n` `\\` のエスケープを解いてから使う）。
+        var delimiter: String
+        /// 分割した各要素の前後の空白を取り除く。
+        var trimEach: Bool
+        /// 空になった要素を捨てる（`a,,b` → 2 行）。
+        var dropEmpty: Bool
+
+        init(delimiter: String, trimEach: Bool = false, dropEmpty: Bool = false) {
+            self.delimiter = delimiter
+            self.trimEach = trimEach
+            self.dropEmpty = dropEmpty
+        }
+    }
+
+    /// 選択テキストの各行を区切り文字で分割し、改行区切りにして返す。
+    /// 区切り文字が空（エスケープを解いた結果も空）なら nil＝変換不能。
+    static func split(_ s: String, options: Options) -> String? {
+        let delimiter = unescape(options.delimiter)
+        guard !delimiter.isEmpty else { return nil }
+
+        let hasTrailingNewline = s.hasSuffix("\n")
+        var lines = s.components(separatedBy: "\n")
+        if hasTrailingNewline { lines.removeLast() }
+
+        var out: [String] = []
+        for line in lines {
+            var parts = line.components(separatedBy: delimiter)
+            if options.trimEach { parts = parts.map { $0.trimmingCharacters(in: .whitespaces) } }
+            if options.dropEmpty { parts = parts.filter { !$0.isEmpty } }
+            out.append(contentsOf: parts)
+        }
+        return out.joined(separator: "\n") + (hasTrailingNewline ? "\n" : "")
+    }
+
+    /// 入力欄に打てない文字をエスケープで受け取る（`TextEscape` そのもの）。
+    static func unescape(_ s: String) -> String { TextEscape.unescape(s) }
+}
+
+/// ダイアログの入力欄で「打てない文字」をエスケープ表記で受け取るための共通ロジック。
+/// 行の分割の区切り文字・連番の区切り文字が同じ書き方（`\t` / `\n`）で通るように 1 箇所に置く。
+enum TextEscape {
+    /// エスケープの先導文字。日本語キーボードでは同じキーが `¥`（半角・全角）を打つので、
+    /// バックスラッシュと同じに扱う（`¥t` と打ってもタブとして通る）。
+    private static let leaders: Set<Character> = ["\\", "¥", "￥"]
+
+    /// `\t`＝タブ、`\n`＝改行、`\\`＝その文字自身。
+    /// 未知のエスケープは 2 文字そのまま残す（勝手に食べない）。
+    static func unescape(_ s: String) -> String {
+        var out = ""
+        var it = s.startIndex
+        while it < s.endIndex {
+            let ch = s[it]
+            let next = s.index(after: it)
+            guard leaders.contains(ch), next < s.endIndex else { out.append(ch); it = next; continue }
+            switch s[next] {
+            case "t":  out.append("\t"); it = s.index(after: next)
+            case "n":  out.append("\n"); it = s.index(after: next)
+            case let c where leaders.contains(c): out.append(c); it = s.index(after: next)
+            default:   out.append(ch);   it = next
+            }
+        }
+        return out
+    }
+}
+
+/// 選択行への連番付与。開始・増分・桁埋め・区切りをパラメータで受け取る
+/// （引数なしの `TextTransform.numberLines` は「開始 1・増分 1・桁埋めなし・タブ区切り」＝既定値）。
+enum LineNumberer {
+    /// 連番の設定（ダイアログの各項目に 1 対 1 で対応する）。
+    struct Options: Equatable {
+        /// 最初の行に振る番号。
+        var start: Int
+        /// 1 行進むごとの増分（負なら減る。0 なら全行が同じ番号）。
+        var step: Int
+        /// 0 埋めする桁数（0＝埋めない）。負数は符号の後ろを埋める（`-007`）。
+        var padWidth: Int
+        /// 番号と本文のあいだに置く文字列（`\t` `\n` のエスケープを解いてから使う）。
+        var separator: String
+
+        init(start: Int = 1, step: Int = 1, padWidth: Int = 0, separator: String = "\t") {
+            self.start = start
+            self.step = step
+            self.padWidth = padWidth
+            self.separator = separator
+        }
+    }
+
+    /// 選択テキストの各行の先頭に連番を付ける。末尾の改行は保つ。
+    static func number(_ s: String, options: Options) -> String {
+        let separator = TextEscape.unescape(options.separator)
+        let hasTrailingNewline = s.hasSuffix("\n")
+        var lines = s.components(separatedBy: "\n")
+        if hasTrailingNewline { lines.removeLast() }
+
+        var n = options.start
+        var out: [String] = []
+        out.reserveCapacity(lines.count)
+        for line in lines {
+            out.append(pad(n, width: options.padWidth) + separator + line)
+            // 桁あふれで落ちないよう飽和加算にする（極端な増分を入れられても壊れない）。
+            n = n.addingReportingOverflow(options.step).partialValue
+        }
+        return out.joined(separator: "\n") + (hasTrailingNewline ? "\n" : "")
+    }
+
+    /// 数値を `width` 桁へ 0 埋めする（負数は `-` の後ろを埋める）。
+    private static func pad(_ n: Int, width: Int) -> String {
+        let digits = String(n.magnitude)
+        let sign = n < 0 ? "-" : ""
+        guard width > digits.count else { return sign + digits }
+        return sign + String(repeating: "0", count: width - digits.count) + digits
     }
 }

--- a/Tests/MrEditorTests/LineDisplayTests.swift
+++ b/Tests/MrEditorTests/LineDisplayTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+import AppKit
+@testable import MrEditor
+
+/// 行表示まわり（行頭索引＝行番号ガター／キャレット位置、不可視文字の記号、行の分割）の検証。
+final class LineDisplayTests: XCTestCase {
+
+    // MARK: - 行頭索引（LineStartIndex）
+
+    func testEmptyTextHasOneLine() {
+        let index = LineStartIndex("")
+        XCTAssertEqual(index.lineCount, 1)
+        XCTAssertEqual(index.lineIndex(at: 0), 0)
+    }
+
+    func testLineIndexAtOffsets() {
+        //           0123 456789
+        let text = "abc\ndef\n\nxy"
+        let index = LineStartIndex(text)
+        XCTAssertEqual(index.lineCount, 4)         // "abc" / "def" / "" / "xy"
+        XCTAssertEqual(index.lineIndex(at: 0), 0)
+        XCTAssertEqual(index.lineIndex(at: 3), 0)  // 行末の改行はその行に属する
+        XCTAssertEqual(index.lineIndex(at: 4), 1)  // 次の行の先頭
+        XCTAssertEqual(index.lineIndex(at: 8), 2)  // 空行
+        XCTAssertEqual(index.lineIndex(at: 9), 3)
+        XCTAssertEqual(index.start(ofLine: 3), 9)
+    }
+
+    func testTrailingNewlineGivesAnEmptyLastLine() {
+        let index = LineStartIndex("a\nb\n")
+        XCTAssertEqual(index.lineCount, 3)          // 末尾の改行の後ろにもキャレットは置ける
+        XCTAssertEqual(index.lineIndex(at: 4), 2)
+    }
+
+    func testPositionIsOneBasedAndCountsCharactersNotUTF16() {
+        let text = "abc\nあ🚀z" as NSString
+        let index = LineStartIndex(text)
+        XCTAssertEqual(index.position(at: 0, in: text).line, 1)
+        XCTAssertEqual(index.position(at: 0, in: text).column, 1)
+        XCTAssertEqual(index.position(at: 2, in: text).column, 3)   // "ab" の後ろ＝3 桁目
+        // 2 行目: "あ"(UTF-16 1) + "🚀"(UTF-16 2) の後ろは 3 桁目（サロゲートペアを 1 文字と数える）
+        let afterRocket = 4 + 1 + 2
+        XCTAssertEqual(index.position(at: afterRocket, in: text).line, 2)
+        XCTAssertEqual(index.position(at: afterRocket, in: text).column, 3)
+    }
+
+    func testPositionClampsOutOfRange() {
+        let text = "ab" as NSString
+        let index = LineStartIndex(text)
+        XCTAssertEqual(index.position(at: 99, in: text).column, 3)
+        XCTAssertEqual(index.position(at: -5, in: text).column, 1)
+    }
+
+    // MARK: - 不可視文字の記号
+
+    func testTabAndIdeographicSpaceMarkers() {
+        let markers = InvisibleGlyphs.markers(in: "a\tb　c")
+        XCTAssertEqual(markers, [
+            .init(utf16Index: 1, glyph: InvisibleGlyphs.tab),
+            .init(utf16Index: 3, glyph: InvisibleGlyphs.ideographicSpace),
+        ])
+    }
+
+    /// 半角スペースは行末の連なりだけ出す（文中の空白まで点を打つと本文が読めない）。
+    func testOnlyTrailingHalfWidthSpacesAreMarked() {
+        let markers = InvisibleGlyphs.markers(in: "a b  ")
+        XCTAssertEqual(markers.map(\.utf16Index), [3, 4])
+        XCTAssertTrue(markers.allSatisfy { $0.glyph == InvisibleGlyphs.trailingSpace })
+    }
+
+    func testAllSpacesLineIsAllTrailing() {
+        XCTAssertEqual(InvisibleGlyphs.markers(in: "   ").count, 3)
+        XCTAssertTrue(InvisibleGlyphs.markers(in: "").isEmpty)
+        XCTAssertTrue(InvisibleGlyphs.markers(in: "abc").isEmpty)
+    }
+
+    // MARK: - 行の分割
+
+    func testSplitByComma() {
+        let out = LineSplitter.split("a,b,c", options: .init(delimiter: ","))
+        XCTAssertEqual(out, "a\nb\nc")
+    }
+
+    func testSplitKeepsTrailingNewlineAndHandlesEachLine() {
+        let out = LineSplitter.split("a,b\nc,d\n", options: .init(delimiter: ","))
+        XCTAssertEqual(out, "a\nb\nc\nd\n")
+    }
+
+    func testSplitByEscapedTab() {
+        let out = LineSplitter.split("a\tb", options: .init(delimiter: "\\t"))
+        XCTAssertEqual(out, "a\nb")
+    }
+
+    func testSplitTrimAndDropEmpty() {
+        let opts = LineSplitter.Options(delimiter: ",", trimEach: true, dropEmpty: true)
+        XCTAssertEqual(LineSplitter.split("a , ,b ", options: opts), "a\nb")
+        // 既定（trim/drop なし）は空要素もそのまま行にする。
+        XCTAssertEqual(LineSplitter.split("a,,b", options: .init(delimiter: ",")), "a\n\nb")
+    }
+
+    func testSplitWithEmptyDelimiterIsRefused() {
+        XCTAssertNil(LineSplitter.split("abc", options: .init(delimiter: "")))
+    }
+
+    /// 日本語キーボードは同じキーで `¥` を打つので、バックスラッシュと同じに扱う。
+    func testUnescapeAcceptsYenSignAsEscapeLeader() {
+        XCTAssertEqual(LineSplitter.unescape("¥t"), "\t")
+        XCTAssertEqual(LineSplitter.unescape("￥n"), "\n")
+        XCTAssertEqual(LineSplitter.unescape("¥¥"), "¥")
+        XCTAssertEqual(LineSplitter.split("a\tb", options: .init(delimiter: "¥t")), "a\nb")
+    }
+
+    func testUnescapeLeavesUnknownEscapesAlone() {
+        XCTAssertEqual(LineSplitter.unescape("\\t"), "\t")
+        XCTAssertEqual(LineSplitter.unescape("\\n"), "\n")
+        XCTAssertEqual(LineSplitter.unescape("\\\\"), "\\")
+        XCTAssertEqual(LineSplitter.unescape("\\q"), "\\q")
+        XCTAssertEqual(LineSplitter.unescape("a\\"), "a\\")
+    }
+
+    /// 連結の逆操作になっている（連結 → 分割で元の行数に戻る）。
+    func testJoinThenSplitRoundTrip() {
+        let source = "alpha\nbeta\ngamma"
+        let joined = try! XCTUnwrap(TextTransform.joinLines.apply(source))
+        XCTAssertEqual(joined, "alpha beta gamma")
+        XCTAssertEqual(LineSplitter.split(joined, options: .init(delimiter: " ")), source)
+    }
+
+    // MARK: - ステータスバーへ流れるキャレット位置（小ファイルペイン）
+
+    func testEditableViewerReportsCaretPosition() {
+        let v = EditableViewer()
+        var latest: ViewerState?
+        v.onStateChange = { latest = $0 }
+        v.newDocument()
+        v._testSetText("abc\nあいう\n")
+        v._testSelect(NSRange(location: 6, length: 0))   // 2 行目「あい」の後ろ
+        v.reEmitState()
+        XCTAssertEqual(latest?.caret?.line, 2)
+        XCTAssertEqual(latest?.caret?.column, 3)
+
+        v._testSelect(NSRange(location: 0, length: 0))
+        v.reEmitState()
+        XCTAssertEqual(latest?.caret?.line, 1)
+        XCTAssertEqual(latest?.caret?.column, 1)
+    }
+
+    /// 編集で行がずれても（索引キャッシュを捨てて）正しい行を返す。
+    func testCaretPositionFollowsEdits() {
+        let v = EditableViewer()
+        var latest: ViewerState?
+        v.onStateChange = { latest = $0 }
+        v.newDocument()
+        v._testSetText("one\ntwo")
+        v._testSelect(NSRange(location: 7, length: 0))
+        v.reEmitState()
+        XCTAssertEqual(latest?.caret?.line, 2)
+
+        v._testSetText("one\nmore\ntwo")
+        v._testSelect(NSRange(location: 12, length: 0))
+        v.reEmitState()
+        XCTAssertEqual(latest?.caret?.line, 3)
+        XCTAssertEqual(latest?.caret?.column, 4)
+    }
+}

--- a/Tests/MrEditorTests/MultiCursorTests.swift
+++ b/Tests/MrEditorTests/MultiCursorTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+import AppKit
+@testable import MrEditor
+
+/// マルチカーソル（範囲計算＋NSTextView 上の実挙動）、連番のパラメータ化、
+/// 置換のケース維持を検証する。
+final class MultiCursorTests: XCTestCase {
+
+    // MARK: - 範囲の集合（MultiCursor）
+
+    func testTogglingAddsThenRemovesSameCaret() {
+        let one = [NSRange(location: 3, length: 0)]
+        let two = MultiCursor.toggling(one, at: NSRange(location: 7, length: 0))
+        XCTAssertEqual(two, [NSRange(location: 3, length: 0), NSRange(location: 7, length: 0)])
+        // 同じ位置をもう一度 ⌘クリック＝そのキャレットを外す。
+        XCTAssertEqual(MultiCursor.toggling(two, at: NSRange(location: 7, length: 0)), one)
+    }
+
+    /// 最後の 1 個は外せない（キャレットが 0 個になる状態を作らない）。
+    func testTogglingKeepsLastCaret() {
+        let one = [NSRange(location: 3, length: 0)]
+        XCTAssertEqual(MultiCursor.toggling(one, at: NSRange(location: 3, length: 0)), one)
+    }
+
+    func testNormalizeSortsAndMergesOverlaps() {
+        let ranges = [NSRange(location: 10, length: 3), NSRange(location: 0, length: 2),
+                      NSRange(location: 11, length: 5)]
+        XCTAssertEqual(MultiCursor.normalize(ranges),
+                       [NSRange(location: 0, length: 2), NSRange(location: 10, length: 6)])
+    }
+
+    /// 選択の内側／端に落ちた空キャレットは選択に吸収する（重複キャレットを作らない）。
+    func testNormalizeAbsorbsCaretsInsideSelection() {
+        let ranges = [NSRange(location: 5, length: 3), NSRange(location: 6, length: 0),
+                      NSRange(location: 8, length: 0)]
+        XCTAssertEqual(MultiCursor.normalize(ranges), [NSRange(location: 5, length: 3)])
+    }
+
+    // MARK: - 上下にキャレットを足す
+
+    func testAddCaretBelowKeepsColumn() {
+        let text = "abcdef\nghijkl\n" as NSString
+        let ranges = [NSRange(location: 3, length: 0)]           // 1 行目・3 桁目
+        let out = MultiCursor.addingCaret(to: ranges, above: false, in: text)
+        XCTAssertEqual(out, [NSRange(location: 3, length: 0), NSRange(location: 10, length: 0)])
+    }
+
+    /// 隣の行が短いときは行末で止める（改行を飛び越えてさらに次の行へ入らない）。
+    func testAddCaretBelowClampsToShorterLine() {
+        let text = "abcdef\ngh\n" as NSString
+        let out = MultiCursor.addingCaret(to: [NSRange(location: 5, length: 0)], above: false, in: text)
+        XCTAssertEqual(out.last, NSRange(location: 9, length: 0))   // "gh" の行末
+    }
+
+    func testAddCaretAboveAtFirstLineDoesNothing() {
+        let text = "abc\ndef" as NSString
+        let ranges = [NSRange(location: 1, length: 0)]
+        XCTAssertEqual(MultiCursor.addingCaret(to: ranges, above: true, in: text), ranges)
+    }
+
+    func testAddCaretBelowAtLastLineDoesNothing() {
+        let text = "abc\ndef" as NSString
+        let ranges = [NSRange(location: 5, length: 0)]
+        XCTAssertEqual(MultiCursor.addingCaret(to: ranges, above: false, in: text), ranges)
+    }
+
+    // MARK: - 次の同じ語（⌘D）
+
+    func testWordRangeAtCaretInsideAndAfterWord() {
+        let text = "let total = 1" as NSString
+        XCTAssertEqual(MultiCursor.wordRange(at: 5, in: text), NSRange(location: 4, length: 5))
+        // 語の直後にキャレットがあるときも同じ語を掴む。
+        XCTAssertEqual(MultiCursor.wordRange(at: 9, in: text), NSRange(location: 4, length: 5))
+        XCTAssertNil(MultiCursor.wordRange(at: 11, in: text))  // "=" の後ろの空白＝掴む語が無い
+    }
+
+    func testNextOccurrenceSkipsAlreadySelectedAndWraps() {
+        let text = "foo bar foo baz foo" as NSString
+        let selected = [NSRange(location: 0, length: 3)]
+        let second = MultiCursor.nextOccurrence(of: "foo", in: text, after: 3, excluding: selected)
+        XCTAssertEqual(second, NSRange(location: 8, length: 3))
+
+        // 末尾まで採ったら先頭へ回り込み、すでに選択済みの一致は飛ばして nil。
+        let all = [NSRange(location: 0, length: 3), NSRange(location: 8, length: 3), NSRange(location: 16, length: 3)]
+        XCTAssertNil(MultiCursor.nextOccurrence(of: "foo", in: text, after: 19, excluding: all))
+    }
+
+    // MARK: - 編集後のキャレット位置
+
+    func testCaretsAfterReplacingAccumulateOffsets() {
+        let ranges = [NSRange(location: 0, length: 0), NSRange(location: 4, length: 0)]
+        XCTAssertEqual(MultiCursor.caretsAfterReplacing(ranges, with: ["X", "X"]),
+                       [NSRange(location: 1, length: 0), NSRange(location: 6, length: 0)])
+    }
+
+    func testCaretsAfterReplacingSelections() {
+        let ranges = [NSRange(location: 0, length: 3), NSRange(location: 10, length: 3)]
+        // 1 つ目で 1 文字縮んだぶん、2 つ目のキャレットは 10+2-1=11。
+        XCTAssertEqual(MultiCursor.caretsAfterReplacing(ranges, with: ["ab", "ab"]),
+                       [NSRange(location: 2, length: 0), NSRange(location: 11, length: 0)])
+    }
+
+    func testDeletionRangesBackwardDropsCaretAtDocumentStart() {
+        let text = "abc\ndef" as NSString
+        let ranges = [NSRange(location: 0, length: 0), NSRange(location: 6, length: 0)]
+        XCTAssertEqual(MultiCursor.deletionRanges(ranges, forward: false, in: text),
+                       [NSRange(location: 5, length: 1)])
+    }
+
+    func testDeletionRangesForwardKeepsSelections() {
+        let text = "abcdef" as NSString
+        let ranges = [NSRange(location: 1, length: 2), NSRange(location: 5, length: 0)]
+        XCTAssertEqual(MultiCursor.deletionRanges(ranges, forward: true, in: text),
+                       [NSRange(location: 1, length: 2), NSRange(location: 5, length: 1)])
+    }
+
+    // MARK: - NSTextView 上の実挙動（EditorTextView）
+
+    private func makeTextView(_ s: String) -> EditorTextView {
+        let tv = EditorTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        tv.string = s
+        return tv
+    }
+
+    /// NSTextView は長さ 0 の範囲を複数持てないので、キャレット列は専用の口から入れる。
+    private func setCarets(_ tv: EditorTextView, _ ranges: [NSRange]) {
+        tv._testSetCarets(ranges)
+    }
+
+    func testTypingInsertsAtEveryCaret() {
+        let tv = makeTextView("aaa\nbbb\nccc")
+        setCarets(tv, [NSRange(location: 0, length: 0), NSRange(location: 4, length: 0),
+                       NSRange(location: 8, length: 0)])
+        tv.insertText("- ", replacementRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertEqual(tv.string, "- aaa\n- bbb\n- ccc")
+        // 挿入した文字列の直後へキャレットが動く。
+        XCTAssertEqual(tv._testCarets,
+                       [NSRange(location: 2, length: 0), NSRange(location: 8, length: 0),
+                        NSRange(location: 14, length: 0)])
+    }
+
+    /// 選択が複数あるときは各選択が置き換わる（⌘D で語を集めてから打ち直す流れ）。
+    func testTypingReplacesEverySelection() {
+        let tv = makeTextView("foo bar foo")
+        setCarets(tv, [NSRange(location: 0, length: 3), NSRange(location: 8, length: 3)])
+        tv.insertText("qux", replacementRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertEqual(tv.string, "qux bar qux")
+    }
+
+    func testDeleteBackwardAtEveryCaret() {
+        let tv = makeTextView("a1b\na2b")
+        setCarets(tv, [NSRange(location: 2, length: 0), NSRange(location: 6, length: 0)])
+        tv.deleteBackward(nil)
+        XCTAssertEqual(tv.string, "ab\nab")
+    }
+
+    func testSingleCaretKeepsStandardBehaviour() {
+        let tv = makeTextView("abc")
+        setCarets(tv, [NSRange(location: 3, length: 0)])
+        tv.insertText("d", replacementRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertEqual(tv.string, "abcd")
+        XCTAssertFalse(tv.hasMultipleCarets)
+    }
+
+    func testSelectNextOccurrenceGrowsSelectionThenEscapeCollapses() {
+        let tv = makeTextView("foo bar foo baz foo")
+        setCarets(tv, [NSRange(location: 1, length: 0)])   // 1 つ目の foo の中
+        tv.selectNextOccurrence()                          // 語を掴む
+        XCTAssertEqual(tv._testCarets, [NSRange(location: 0, length: 3)])
+        tv.selectNextOccurrence()                          // 2 つ目
+        tv.selectNextOccurrence()                          // 3 つ目
+        XCTAssertEqual(tv._testCarets.count, 3)
+        XCTAssertTrue(tv.hasMultipleCarets)
+
+        tv.cancelOperation(nil)                            // Esc で単一へ
+        XCTAssertFalse(tv.hasMultipleCarets)
+    }
+
+    func testAddCaretBelowThenTypeHitsBothLines() {
+        let tv = makeTextView("abc\ndef")
+        setCarets(tv, [NSRange(location: 0, length: 0)])
+        tv.addCaret(above: false)
+        tv.insertText("#", replacementRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertEqual(tv.string, "#abc\n#def")
+    }
+
+    // MARK: - 連番のパラメータ化
+
+    func testNumberLinesDefaultsMatchPlainTransform() {
+        let source = "a\nb\nc\n"
+        XCTAssertEqual(LineNumberer.number(source, options: .init()), "1\ta\n2\tb\n3\tc\n")
+        XCTAssertEqual(TextTransform.numberLines.apply(source), LineNumberer.number(source, options: .init()))
+    }
+
+    func testNumberLinesStartStepAndPad() {
+        let opts = LineNumberer.Options(start: 10, step: 5, padWidth: 4, separator: ": ")
+        XCTAssertEqual(LineNumberer.number("a\nb\nc", options: opts), "0010: a\n0015: b\n0020: c")
+    }
+
+    func testNumberLinesNegativeStepAndSign() {
+        let opts = LineNumberer.Options(start: 1, step: -2, padWidth: 3, separator: " ")
+        XCTAssertEqual(LineNumberer.number("a\nb\nc", options: opts), "001 a\n-001 b\n-003 c")
+    }
+
+    /// 区切りは分割ダイアログと同じエスケープ（`\t` / 日本語キーボードの `¥t`）で書ける。
+    func testNumberLinesSeparatorEscapes() {
+        XCTAssertEqual(LineNumberer.number("a", options: .init(separator: "\\t")), "1\ta")
+        XCTAssertEqual(LineNumberer.number("a", options: .init(separator: "¥t")), "1\ta")
+    }
+
+    func testNumberLinesKeepsTrailingNewline() {
+        XCTAssertEqual(LineNumberer.number("a\nb", options: .init()), "1\ta\n2\tb")
+        XCTAssertEqual(LineNumberer.number("a\nb\n", options: .init()), "1\ta\n2\tb\n")
+    }
+
+    // MARK: - 置換のケース維持
+
+    func testPreserveCaseAppliesMatchedShape() {
+        XCTAssertEqual(CasePreserving.apply("timeout", matching: "DEADLINE"), "TIMEOUT")
+        XCTAssertEqual(CasePreserving.apply("timeout", matching: "deadline"), "timeout")
+        XCTAssertEqual(CasePreserving.apply("timeout", matching: "Deadline"), "Timeout")
+    }
+
+    /// 判定できない綴り（camelCase・記号のみ・日本語）は置換文字列をそのまま使う。
+    func testPreserveCaseLeavesMixedAlone() {
+        XCTAssertEqual(CasePreserving.apply("newValue", matching: "oldValue"), "newValue")
+        XCTAssertEqual(CasePreserving.apply("newValue", matching: "---"), "newValue")
+        XCTAssertEqual(CasePreserving.apply("newValue", matching: "見出し"), "newValue")
+    }
+
+    /// 先頭が英字でない置換文字列でも、最初の英字だけを大文字にする。
+    func testPreserveCaseCapitalizesFirstLetterOnly() {
+        XCTAssertEqual(CasePreserving.apply("_value", matching: "Old"), "_Value")
+        XCTAssertEqual(CasePreserving.apply("", matching: "Old"), "")
+    }
+
+    func testPreserveCaseStyleDetection() {
+        XCTAssertEqual(CasePreserving.style(of: "ABC"), .upper)
+        XCTAssertEqual(CasePreserving.style(of: "abc"), .lower)
+        XCTAssertEqual(CasePreserving.style(of: "Abc"), .capitalized)
+        XCTAssertEqual(CasePreserving.style(of: "aBc"), .mixed)
+        XCTAssertEqual(CasePreserving.style(of: "123"), .mixed)
+    }
+}
+
+extension CasePreserving.Style: Equatable {}


### PR DESCRIPTION
## 概要

編集ツールボックスの「残（別立て・重い）」4項目と、行まわりの表示設定をまとめて実装。マルチカーソルは小ファイルの編集ペイン限定（10GB 側は閲覧が仕事なので単一キャレットのまま）。

## 変更点

**行表示**
- 行番号ガター（大ファイルは自前描画、小ファイルは `NSRulerView`。設定は 1 つ）
- 不可視文字の表示（タブ・改行・全角スペース・行末スペース。本文は書き換えない）
- ステータスバーにキャレットの「行:桁」（キャレットの無い表示では出さない）

**編集ツールボックス**
- 行の分割…（区切り文字ダイアログ＋純関数 `LineSplitter`。行の連結の逆操作）
- 連番のパラメータ化（開始・増分・0 埋め桁数・区切りのダイアログ＋`LineNumberer`）
- 区切り文字のエスケープ処理を `TextEscape` に共通化（日本語キーボードの ¥t も通す）

**マルチカーソル**（⌘クリック / ⌥⌘↑↓ / ⌘D / Esc で解除）
- 範囲計算は純関数 `MultiCursor`、適用は `EditorTextView`（挿入・改行・タブ・前後削除）
- `NSTextView` は長さ 0 の範囲を複数持てないため、キャレット列は自前に持ち、空キャレットの描画と点滅も自前。長さのある範囲だけ AppKit の不連続選択に渡す
- 編集は `shouldChangeText(inRanges:)` 経由＝全キャレットの変更が 1 アンドゥに載る

**ケース維持置換**
- 検索バーの置換行に aA トグル。一致した実際の綴りの書式を置換文字列へ移す（純関数 `CasePreserving`。camelCase・記号・日本語は判定不能としてそのまま）

## テスト

321 green（+29）。実機 E2E は未了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
