### PR TITLE
AI連携BYOK（無料）: 選択したエラーの原因をAIで推測

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -205,6 +205,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         windowController?.numberActiveSelectionLines()
     }
 
+    // AI（BYOK・単発解析）。選択したエラー / スタックトレースの原因を推測する。
+    @objc private func aiDiagnoseError(_ sender: Any?) { windowController?.diagnoseSelectionWithAI() }
+
     // マルチカーソル（キャレットを上下に足す／同じ語を次々に選ぶ）。
     @objc private func addCaretAbove(_ sender: Any?) { windowController?.addCaretToActive(above: true) }
     @objc private func addCaretBelow(_ sender: Any?) { windowController?.addCaretToActive(above: false) }
@@ -307,6 +310,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return c.canTransformText   // 編集可能なペインでのみ有効
         case #selector(addCaretAbove(_:)), #selector(addCaretBelow(_:)), #selector(selectNextOccurrence(_:)):
             return c.canMultiCursor     // マルチカーソルは小ファイルの編集ペインのみ
+        case #selector(aiDiagnoseError(_:)):
+            return c.canAIDiagnose      // ドキュメントが開いていれば（選択の有無はパネル内で案内）
 
         default:
             return true
@@ -616,6 +621,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let diffItem = NSMenuItem(title: L("menu.compare"), action: nil, keyEquivalent: "")
         diffItem.submenu = diffMenu
         viewMenu.addItem(diffItem)
+
+        // AI メニュー（BYOK・単発解析）。ログ／テキストの「今見ている箇所」に AI をぶつける。
+        let aiMenuItem = NSMenuItem()
+        mainMenu.addItem(aiMenuItem)
+        let aiMenu = NSMenu(title: L("ai.menu.title"))
+        aiMenuItem.submenu = aiMenu
+        let diagnose = NSMenuItem(title: L("ai.menu.errorCause"),
+                                  action: #selector(aiDiagnoseError(_:)), keyEquivalent: "e")
+        diagnose.keyEquivalentModifierMask = [.command, .option]
+        diagnose.target = self
+        aiMenu.addItem(diagnose)
 
         // ウインドウメニュー（Minimize / Zoom ＋ 開いているウィンドウ一覧を AppKit が自動追記）
         let windowMenuItem = NSMenuItem()

--- a/Sources/MrEditor/AppSettings.swift
+++ b/Sources/MrEditor/AppSettings.swift
@@ -148,6 +148,9 @@ enum AppSettings {
     private static let sessionKey = "MrEditor.session"
     private static let autoUpdateCheckKey = "MrEditor.automaticUpdateChecks"
     private static let lastUpdateCheckKey = "MrEditor.lastUpdateCheck"
+    private static let aiProviderKey = "MrEditor.ai.provider"
+    private static let aiModelKey = "MrEditor.ai.model"
+    private static let aiBaseURLKey = "MrEditor.ai.baseURL"
 
     static var saveProgressStyle: SaveProgressStyle {
         get { SaveProgressStyle(rawValue: defaults.string(forKey: saveProgressKey) ?? "") ?? .sheet }
@@ -223,6 +226,24 @@ enum AppSettings {
     static var lastUpdateCheck: Date? {
         get { defaults.object(forKey: lastUpdateCheckKey) as? Date }
         set { defaults.set(newValue, forKey: lastUpdateCheckKey) }
+    }
+
+    /// AI 連携（BYOK）の設定。**キー本体は含まない**（キーは [[Keychain]]）。
+    /// プロバイダ・モデル・ベース URL 上書きだけを UserDefaults に持つ。
+    static var aiConfig: AIConfig {
+        get {
+            let provider = AIProvider(rawValue: defaults.string(forKey: aiProviderKey) ?? "") ?? .anthropic
+            let model = defaults.string(forKey: aiModelKey) ?? ""
+            let base = defaults.string(forKey: aiBaseURLKey) ?? ""
+            return AIConfig(provider: provider,
+                            model: model.isEmpty ? provider.defaultModel : model,
+                            baseURLOverride: base)
+        }
+        set {
+            defaults.set(newValue.provider.rawValue, forKey: aiProviderKey)
+            defaults.set(newValue.model, forKey: aiModelKey)
+            defaults.set(newValue.baseURLOverride, forKey: aiBaseURLKey)
+        }
     }
 
     private static func postDisplayChanged() {

--- a/Sources/MrEditor/Core/AIClient.swift
+++ b/Sources/MrEditor/Core/AIClient.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// AI への単発問い合わせを実際に送る層（URLSession）。組立・解析は純粋な [[AIRequestBuilder]]、
+/// キーは [[Keychain]]、ここは送受信と失敗の言葉づかいだけを担う。
+/// 完了は必ずメインスレッドで呼ぶ（[[UpdateChecker]] と同じ流儀）。
+enum AIClient {
+
+    enum ClientError: LocalizedError {
+        case notConfigured          // キー未設定
+        case network(Error)
+        case http(Int)              // 2xx 以外（本文からメッセージが拾えなかったとき）
+        case api(String)            // プロバイダのエラーメッセージ
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured: return L("ai.error.notConfigured")
+            case .network(let e): return e.localizedDescription
+            case .http(let code): return L("ai.error.http", code)
+            case .api(let msg):   return msg
+            }
+        }
+    }
+
+    /// 現在の設定（AppSettings）＋ Keychain のキーで prompt を送る。
+    static func send(_ prompt: AIPrompt,
+                     completion: @escaping (Result<String, ClientError>) -> Void) {
+        let config = AppSettings.aiConfig
+        guard let key = Keychain.get(account: config.provider.keychainAccount), !key.isEmpty else {
+            DispatchQueue.main.async { completion(.failure(.notConfigured)) }
+            return
+        }
+        send(prompt, config: config, apiKey: key, completion: completion)
+    }
+
+    /// 設定・キーを明示して送る（テスト時に別プロバイダを差し込めるよう分離）。
+    static func send(_ prompt: AIPrompt,
+                     config: AIConfig,
+                     apiKey: String,
+                     completion: @escaping (Result<String, ClientError>) -> Void) {
+        let request: URLRequest
+        do {
+            var r = try AIRequestBuilder.makeRequest(prompt, config: config, apiKey: apiKey)
+            r.timeoutInterval = 60
+            request = r
+        } catch {
+            DispatchQueue.main.async { completion(.failure(.notConfigured)) }
+            return
+        }
+
+        let provider = config.provider
+        let finish: (Result<String, ClientError>) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        URLSession(configuration: .ephemeral).dataTask(with: request) { data, response, error in
+            if let error {
+                finish(.failure(.network(error)))
+                return
+            }
+            let data = data ?? Data()
+            // まず本文を解析。プロバイダのエラー形なら message を優先して見せる。
+            do {
+                let text = try AIRequestBuilder.parseResponse(data, provider: provider)
+                finish(.success(text))
+            } catch let e as AIRequestBuilder.AIError {
+                finish(.failure(.api(e.message)))
+            } catch {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+                finish(.failure(.http(code)))
+            }
+        }.resume()
+    }
+}

--- a/Sources/MrEditor/Core/AIConfig.swift
+++ b/Sources/MrEditor/Core/AIConfig.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// BYOK（ユーザー自前キー）で対応する AI プロバイダ。
+/// 原価はユーザーの鍵持ち＝アプリ側は無料機能として提供する（M3.5 の物語エンジン）。
+enum AIProvider: String, CaseIterable, Codable {
+    case anthropic
+    case openAI
+    case gemini
+
+    var displayName: String {
+        switch self {
+        case .anthropic: return "Anthropic (Claude)"
+        case .openAI:    return "OpenAI"
+        case .gemini:    return "Google (Gemini)"
+        }
+    }
+
+    /// 既定のエンドポイント。config の baseURLOverride で上書きでき、OpenAI 互換サーバへ向けられる。
+    var defaultBaseURL: URL {
+        switch self {
+        case .anthropic: return URL(string: "https://api.anthropic.com")!
+        case .openAI:    return URL(string: "https://api.openai.com")!
+        case .gemini:    return URL(string: "https://generativelanguage.googleapis.com")!
+        }
+    }
+
+    /// 既定モデル（環境設定で変更できる初期値）。
+    var defaultModel: String {
+        switch self {
+        case .anthropic: return "claude-opus-4-8"
+        case .openAI:    return "gpt-4o"
+        // エイリアス（常に現行の flash を指す）。Google はモデル ID を頻繁に改名・引退させるので、
+        // 固定版を既定にすると腐る。ユーザーは環境設定で具体的な版に変更できる。
+        case .gemini:    return "gemini-flash-latest"
+        }
+    }
+
+    /// API キーを収める Keychain のアカウント名（プロバイダごとに別々に持てる）。
+    var keychainAccount: String { "ai.\(rawValue).apiKey" }
+}
+
+/// AI 連携の設定（**キー本体は含まない**。キーは平文の UserDefaults ではなく [[Keychain]] に置く）。
+struct AIConfig: Equatable {
+    var provider: AIProvider
+    var model: String
+    /// OpenAI 互換サーバ等へ向けるためのベース URL 上書き（空＝既定）。**https 限定**
+    /// （配布 .app は ATS 例外なし＝平文 http は実機で -1022。[[ats-url-fetch-https-only]]）。
+    var baseURLOverride: String
+
+    static let `default` = AIConfig(provider: .anthropic,
+                                    model: AIProvider.anthropic.defaultModel,
+                                    baseURLOverride: "")
+
+    /// 実効ベース URL。上書きが有効な https URL ならそれ、無ければプロバイダ既定。
+    var baseURL: URL {
+        if let u = URL(string: baseURLOverride), u.scheme == "https", u.host != nil { return u }
+        return provider.defaultBaseURL
+    }
+}

--- a/Sources/MrEditor/Core/AIPrompts.swift
+++ b/Sources/MrEditor/Core/AIPrompts.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// ログ／テキストビューア特化の単発プロンプト群。**純関数＝テスト可能**。
+/// 汎用チャットではなく「今見ている箇所に AI をぶつける」用途に絞る。
+enum AIPrompts {
+
+    /// 選択したエラー / スタックトレース / 謎のログ行の原因推測。
+    /// - Parameter language: 回答に使う言語名（アプリの UI 言語。ログが英語でも利用者の言語で返す）。
+    static func errorCause(_ selection: String, language: String) -> AIPrompt {
+        let system = """
+        You are a debugging assistant embedded in a log/text viewer. \
+        Given a log excerpt, stack trace, or error message, explain concisely: \
+        (1) what went wrong, (2) the most likely root cause, (3) one concrete next step to fix or investigate. \
+        Reply in \(language), regardless of the language of the excerpt. \
+        Be brief and specific; do not repeat the input back. \
+        Use plain text only — no Markdown, no asterisks, no backticks, no headings.
+        """
+        // 2048: 推論系モデル（Gemini flash-latest 等）は思考にトークンを使い、1024 だと回答が途中で切れることがある。
+        return AIPrompt(system: system, user: selection, maxTokens: 2048)
+    }
+
+    /// 自然文 → 正規表現。検索／フィルタ窓へそのまま流し込むため、regex 本体だけを返させる。
+    static func naturalLanguageToRegex(_ description: String) -> AIPrompt {
+        let system = """
+        You convert a natural-language description into a single regular expression \
+        for searching and filtering log lines. Output ONLY the regular expression itself — \
+        no explanation, no code fences, no surrounding delimiters, no flags. \
+        Use ICU / NSRegularExpression syntax (the viewer supports lookahead and lookbehind).
+        """
+        // 出力の regex 自体は短いが、推論系モデル（Gemini flash-latest 等）は思考にトークンを使うため、
+        // 256 だと思考で使い切って出力が空になる。余裕を持たせる（regex 本体だけ抽出するので無駄は少ない）。
+        return AIPrompt(system: system, user: description, maxTokens: 1024)
+    }
+
+    /// モデル出力から regex 本体を取り出す（コードフェンス・囲みスラッシュ・前後空白・説明行を剥がす）。
+    /// モデルが指示を守らず ```regex ``` や `/pattern/` で包んでも検索窓に入れられる形へ整える。
+    static func extractRegex(from raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // ```...``` フェンスを剥がす。
+        if s.hasPrefix("```") {
+            if let nl = s.firstIndex(of: "\n") {
+                s = String(s[s.index(after: nl)...])            // ```regex 行を落とす
+            } else {
+                s = String(s.dropFirst(3))
+            }
+            if let close = s.range(of: "```", options: .backwards) {
+                s = String(s[..<close.lowerBound])
+            }
+            s = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // 複数行が残ったら最初の非空行を採る（説明が混ざった場合の保険）。
+        if let firstLine = s.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+            s = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // /pattern/ の囲みスラッシュを剥がす。
+        if s.count >= 2, s.hasPrefix("/"), let last = s.lastIndex(of: "/"), last != s.startIndex {
+            let inner = String(s[s.index(after: s.startIndex)..<last])
+            if !inner.isEmpty { s = inner }
+        }
+        return s
+    }
+}

--- a/Sources/MrEditor/Core/AIRequest.swift
+++ b/Sources/MrEditor/Core/AIRequest.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// AI への 1 回きりの問い合わせ（単発解析）。プロバイダ非依存の内部表現。
+/// 「収まる分だけ＝無料 / 収まらない規模＝Pro」の線は呼び出し側（選択範囲＝収まる分）で引く。
+struct AIPrompt: Equatable {
+    var system: String?
+    var user: String
+    var maxTokens: Int
+}
+
+/// プロンプトをプロバイダ固有の HTTP へ変換する純関数群＋レスポンス解析。**副作用なし＝テスト可能**。
+/// 実際の送信は GUI 層の AIClient（URLSession）が担う。
+enum AIRequestBuilder {
+    struct AIError: Error, Equatable { let message: String }
+
+    /// URLRequest を組み立てる。キーは呼び出し側が [[Keychain]] から取り出して渡す。
+    static func makeRequest(_ prompt: AIPrompt, config: AIConfig, apiKey: String) throws -> URLRequest {
+        guard !apiKey.isEmpty else { throw AIError(message: "missing API key") }
+        switch config.provider {
+        case .anthropic: return anthropic(prompt, config: config, apiKey: apiKey)
+        case .openAI:    return openAI(prompt, config: config, apiKey: apiKey)
+        case .gemini:    return try gemini(prompt, config: config, apiKey: apiKey)
+        }
+    }
+
+    private static func anthropic(_ p: AIPrompt, config: AIConfig, apiKey: String) -> URLRequest {
+        var req = URLRequest(url: config.baseURL.appendingPathComponent("v1/messages"))
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        req.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        var body: [String: Any] = [
+            "model": config.model,
+            "max_tokens": p.maxTokens,
+            "messages": [["role": "user", "content": p.user]],
+        ]
+        if let system = p.system { body["system"] = system }
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return req
+    }
+
+    private static func openAI(_ p: AIPrompt, config: AIConfig, apiKey: String) -> URLRequest {
+        var req = URLRequest(url: config.baseURL.appendingPathComponent("v1/chat/completions"))
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        var messages: [[String: String]] = []
+        if let system = p.system { messages.append(["role": "system", "content": system]) }
+        messages.append(["role": "user", "content": p.user])
+        let body: [String: Any] = [
+            "model": config.model,
+            "max_tokens": p.maxTokens,
+            "messages": messages,
+        ]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return req
+    }
+
+    /// Gemini（generativelanguage）。モデルは URL パスに入り（`models/<model>:generateContent`）、
+    /// キーは `x-goog-api-key` ヘッダ。system は `system_instruction`、本文は `contents`。
+    private static func gemini(_ p: AIPrompt, config: AIConfig, apiKey: String) throws -> URLRequest {
+        // モデルにコロンを含むパスなので appendingPathComponent（コロンを %3A 化する）を避け、文字列で組む。
+        let base = config.baseURL.absoluteString.hasSuffix("/")
+            ? String(config.baseURL.absoluteString.dropLast()) : config.baseURL.absoluteString
+        guard let url = URL(string: "\(base)/v1beta/models/\(config.model):generateContent") else {
+            throw AIError(message: "invalid Gemini URL")
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        var body: [String: Any] = [
+            "contents": [["role": "user", "parts": [["text": p.user]]]],
+            "generationConfig": ["maxOutputTokens": p.maxTokens],
+        ]
+        if let system = p.system {
+            body["system_instruction"] = ["parts": [["text": system]]]
+        }
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        return req
+    }
+
+    /// レスポンス JSON からテキストを取り出す。プロバイダのエラー形（`error.message`）も拾って投げる。
+    static func parseResponse(_ data: Data, provider: AIProvider) throws -> String {
+        guard let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw AIError(message: "invalid response")
+        }
+        // Anthropic / OpenAI とも共通のエラー形
+        if let err = obj["error"] as? [String: Any], let msg = err["message"] as? String {
+            throw AIError(message: msg)
+        }
+        switch provider {
+        case .anthropic:
+            guard let content = obj["content"] as? [[String: Any]] else {
+                throw AIError(message: "no content")
+            }
+            let text = content.compactMap { block -> String? in
+                (block["type"] as? String) == "text" ? block["text"] as? String : nil
+            }.joined()
+            guard !text.isEmpty else { throw AIError(message: "empty response") }
+            return text
+        case .openAI:
+            guard let choices = obj["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any],
+                  let text = message["content"] as? String, !text.isEmpty else {
+                throw AIError(message: "no content")
+            }
+            return text
+        case .gemini:
+            guard let candidates = obj["candidates"] as? [[String: Any]],
+                  let content = candidates.first?["content"] as? [String: Any],
+                  let parts = content["parts"] as? [[String: Any]] else {
+                throw AIError(message: "no content")
+            }
+            let text = parts.compactMap { $0["text"] as? String }.joined()
+            guard !text.isEmpty else { throw AIError(message: "empty response") }
+            return text
+        }
+    }
+}

--- a/Sources/MrEditor/Core/Keychain.swift
+++ b/Sources/MrEditor/Core/Keychain.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Security
+
+/// API キーなどの秘密を Keychain に保管する小さなラッパ。**平文の UserDefaults には置かない**。
+/// generic password を service `MrEditor.AI` / account 指定で読み書きする。
+enum Keychain {
+    private static let service = "MrEditor.AI"
+
+    /// キーを保存する。空文字 / nil は削除。
+    @discardableResult
+    static func set(_ value: String?, account: String) -> Bool {
+        guard let value, !value.isEmpty else { return delete(account: account) }
+        guard let data = value.data(using: .utf8) else { return false }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let update = SecItemUpdate(query as CFDictionary,
+                                   [kSecValueData as String: data] as CFDictionary)
+        if update == errSecSuccess { return true }
+        if update == errSecItemNotFound {
+            var add = query
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+        }
+        return false
+    }
+
+    /// 保存済みのキーを取り出す（無ければ nil）。
+    static func get(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var out: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &out) == errSecSuccess,
+              let data = out as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    @discardableResult
+    static func delete(account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -19,6 +19,9 @@ final class DropView: NSView {
 final class MainWindowController: NSWindowController, NSWindowDelegate {
     private let statusBar = StatusBarView()
     private let searchBar = SearchBarView()
+    private let aiResultPanel = AIResultPanel()
+    /// AI パネルを載せるフローティングウィンドウ（初回表示時に生成）。
+    private var aiPanelWindow: AIPanelWindow?
     private let readOnlyBanner = ReadOnlyBanner()
     private let structuredBanner = StructuredBanner()
 
@@ -91,6 +94,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         sidebar.applyTheme()
         statusBar.applyTheme()
         searchBar.applyTheme()
+        aiResultPanel.applyTheme()
     }
 
     /// 未保存変更でウィンドウを閉じる際の二重確認を抑止するフラグ。
@@ -150,6 +154,15 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         searchBar.onReplace = { [weak self] r in self?.activeViewer?.replaceCurrent(with: r) }
         searchBar.onReplaceAll = { [weak self] r in self?.activeViewer?.replaceAll(with: r) }
         searchBar.onPreserveCaseToggle = { [weak self] on in self?.activeViewer?.setPreserveCase(on) }
+
+        // AI パネルは独立したフローティングウィンドウ（アプリ外へも動かせる）。ここでは配線だけ。
+        aiResultPanel.onClose = { [weak self] in self?.hideAIResult() }
+        aiResultPanel.onAnalyze = { [weak self] in self?.diagnoseSelectionWithAI() }
+        aiResultPanel.onCopy = { [weak self] in
+            guard let self else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(self.aiResultPanel.bodyText, forType: .string)
+        }
 
         // 読み取り専用バナー（本文領域の左上に浮かべる。大ファイルを開いたときだけ表示）
         readOnlyBanner.translatesAutoresizingMaskIntoConstraints = false
@@ -542,6 +555,69 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         v.applyTextTransform(transform)
     }
 
+    // MARK: - AI（BYOK・単発解析。選択範囲＝コンテキストに収まる分だけを扱う）
+
+    /// AI パネルを開けるか（ドキュメントがあれば常に。選択の有無はパネル内で案内する）。
+    var canAIDiagnose: Bool { hasActiveDocument }
+
+    /// AI パネルを表示（常駐）し、いま選択している本文の原因を推測させて結果を出す。
+    /// パネルの「解析」ボタン・⌘⌥E・メニューの共通の入口。選択が無ければ淡いヒントを出す。
+    func diagnoseSelectionWithAI() {
+        showAIPanel()
+        guard let selection = activeViewer?.selectedText, !selection.isEmpty else {
+            aiResultPanel.showHint(L("ai.error.noSelection"))
+            return
+        }
+        aiResultPanel.showThinking()
+        AIClient.send(AIPrompts.errorCause(selection, language: L("ai.replyLanguage"))) { [weak self] result in
+            guard let self, self.aiPanelWindow?.isVisible == true else { return }
+            switch result {
+            case .success(let text): self.aiResultPanel.showResult(text)
+            case .failure(let err):  self.aiResultPanel.showError(err.errorDescription ?? "\(err)")
+            }
+        }
+    }
+
+    /// AI パネルのフローティングウィンドウを（無ければ作って）前面に出す。アプリに追従する子ウィンドウ。
+    private func showAIPanel() {
+        let panel: AIPanelWindow
+        if let existing = aiPanelWindow {
+            panel = existing
+        } else {
+            panel = AIPanelWindow(contentRect: NSRect(x: 0, y: 0, width: AIResultPanel.width, height: AIResultPanel.height),
+                                  styleMask: [.borderless, .resizable], backing: .buffered, defer: false)
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = true
+            panel.level = .floating
+            panel.hidesOnDeactivate = false
+            panel.isMovableByWindowBackground = false
+            panel.minSize = NSSize(width: 360, height: 200)
+            panel.contentView = aiResultPanel
+            aiPanelWindow = panel
+        }
+        guard !panel.isVisible else { return }
+        positionAIPanel(panel)
+        window?.addChildWindow(panel, ordered: .above)   // アプリに追従しつつ前面。外へも動かせる。
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    /// 初回表示位置＝メインウィンドウの右上あたり。
+    private func positionAIPanel(_ panel: NSWindow) {
+        guard let main = window else { return }
+        let f = main.frame
+        panel.setFrameOrigin(NSPoint(x: f.maxX - panel.frame.width - 24,
+                                     y: f.maxY - panel.frame.height - 24))
+    }
+
+    func hideAIResult() {
+        if let panel = aiPanelWindow {
+            window?.removeChildWindow(panel)
+            panel.orderOut(nil)
+        }
+        activeViewer?.focusContent()
+    }
+
     // MARK: - 行の分割（区切り文字はダイアログで受け取る）
 
     private static let lastSplitDelimiterKey = "toolbox.lastSplitDelimiter"
@@ -814,6 +890,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     private func activate(_ index: Int) {
         guard index >= 0, index < viewers.count else { return }
         if !searchBar.isHidden { hideSearch() }   // 切替時は検索を閉じる
+        // AI パネルは常駐（切替でも消さない）。別ドキュメントの選択をそのまま解析できる。
         for (i, v) in viewers.enumerated() { v.isHidden = (i != index) }
         activeIndex = index
         let v = viewers[index]

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -263,3 +263,22 @@
 "diff.adopted" = "%d taken";
 "diff.a11y.take" = "Push this difference to the right";
 "diff.a11y.undo" = "Undo push";
+
+/* AI integration (BYOK, M3.5) */
+"ai.menu.title" = "AI";
+"ai.menu.errorCause" = "Diagnose Error";
+"ai.panel.thinking" = "Asking…";
+"ai.panel.copy" = "Copy";
+"ai.panel.close" = "Close";
+"ai.error.noSelection" = "Select some text first";
+"ai.error.notConfigured" = "AI is not set up. Add a provider and API key in Settings → AI.";
+"ai.error.http" = "Server error (HTTP %d)";
+"prefs.ai.tab" = "AI";
+"prefs.ai.provider" = "Provider";
+"prefs.ai.model" = "Model";
+"prefs.ai.apiKey" = "API key";
+"prefs.ai.baseURL" = "Base URL (optional)";
+"prefs.ai.baseURLPlaceholder" = "OpenAI-compatible server (https only)";
+"prefs.ai.note" = "Your key is stored in the Keychain. You bring your own key (BYOK); it is used only for single-shot analysis of the current selection.";
+"ai.replyLanguage" = "English";
+"ai.panel.analyze" = "Analyze";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -263,3 +263,22 @@
 "diff.adopted" = "%d 箇所を取り込み";
 "diff.a11y.take" = "この差分を右へ取り込む";
 "diff.a11y.undo" = "取り込みを取り消す";
+
+/* AI 連携（BYOK・M3.5） */
+"ai.menu.title" = "AI";
+"ai.menu.errorCause" = "エラーの原因を推測";
+"ai.panel.thinking" = "問い合わせ中…";
+"ai.panel.copy" = "コピー";
+"ai.panel.close" = "閉じる";
+"ai.error.noSelection" = "本文を選択してから実行してください";
+"ai.error.notConfigured" = "AI が未設定です。環境設定の「AI」でプロバイダと API キーを入れてください";
+"ai.error.http" = "サーバエラー (HTTP %d)";
+"prefs.ai.tab" = "AI";
+"prefs.ai.provider" = "プロバイダ";
+"prefs.ai.model" = "モデル";
+"prefs.ai.apiKey" = "API キー";
+"prefs.ai.baseURL" = "ベース URL（任意）";
+"prefs.ai.baseURLPlaceholder" = "OpenAI 互換サーバ（https のみ）";
+"prefs.ai.note" = "キーは Keychain に保存されます。原価はあなたの鍵持ちです（BYOK）。選択範囲の単発解析にのみ使います。";
+"ai.replyLanguage" = "Japanese";
+"ai.panel.analyze" = "解析";

--- a/Sources/MrEditor/UI/AIResultPanel.swift
+++ b/Sources/MrEditor/UI/AIResultPanel.swift
@@ -1,0 +1,222 @@
+import AppKit
+
+/// Escape でキャンセル（＝パネルを閉じる）を拾うための読み取り専用テキストビュー。
+private final class AIResultTextView: NSTextView {
+    var onCancel: (() -> Void)?
+    override func cancelOperation(_ sender: Any?) { onCancel?() }
+}
+
+/// ヘッダをつかんでパネル（ウィンドウ）を動かすためのドラッグ領域。`performDrag` に委ねるので、
+/// 画面のどこへでも・アプリのウィンドウ外へも動かせる。ボタン上はボタンが先にイベントを取るので、
+/// ここが反応するのはヘッダの余白部分だけ＝本文の選択やボタン操作を邪魔しない。
+private final class DragHeaderView: NSView {
+    override func resetCursorRects() { addCursorRect(bounds, cursor: .openHand) }
+    override func mouseDown(with event: NSEvent) { window?.performDrag(with: event) }
+}
+
+/// 枠なしでもキーウィンドウになれるフローティングパネル（Escape をテキストビューに届けるため）。
+final class AIPanelWindow: NSPanel {
+    override var canBecomeKey: Bool { true }
+}
+
+/// AI の単発解析（エラー原因推測）を出す、ビューア上に浮かぶ**常駐・移動可能**なツールパネル。
+///
+/// 出したら出しっぱなし（✕ / Esc で閉じる）。ヘッダをドラッグで移動。ヘッダの「解析」ボタンで、
+/// そのとき選択している本文を都度解析する。本文（テーマ配色）から分離するため背景はすりガラス。
+/// custom draw() は持たない（合成不具合回避）。
+final class AIResultPanel: NSView {
+    static let width: CGFloat = 480
+    static let height: CGFloat = 300
+
+    private let effect = NSVisualEffectView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let spinner = NSProgressIndicator()
+    private let analyzeButton = NSButton()
+    private let copyButton = NSButton()
+    private let closeButton = NSButton()
+    private let divider = NSBox()
+    private let scroll = NSScrollView()
+    private let textView = AIResultTextView()
+
+    var onCopy: (() -> Void)?
+    var onClose: (() -> Void)?
+    var onAnalyze: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        // 影はウィンドウ（NSPanel.hasShadow）が落とすので、ここでは持たない。
+        // すりガラス背景（角丸クリップ）。
+        effect.material = .popover
+        effect.blendingMode = .withinWindow
+        effect.state = .active
+        effect.wantsLayer = true
+        effect.layer?.cornerRadius = 12
+        effect.layer?.masksToBounds = true
+        effect.layer?.borderWidth = 1
+        effect.layer?.borderColor = NSColor.separatorColor.cgColor
+        effect.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(effect)
+
+        // ヘッダ：✦ AI（アクセント）＋ 解析 ／ コピー ／ 閉じる。
+        let spark = NSImageView(image: NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil) ?? NSImage())
+        spark.contentTintColor = .controlAccentColor
+        spark.setContentHuggingPriority(.required, for: .horizontal)
+        titleLabel.stringValue = L("ai.menu.title")
+        titleLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        titleLabel.textColor = .secondaryLabelColor
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isDisplayedWhenStopped = false
+        spinner.setContentHuggingPriority(.required, for: .horizontal)
+
+        analyzeButton.title = L("ai.panel.analyze")
+        analyzeButton.bezelStyle = .rounded
+        analyzeButton.controlSize = .small
+        analyzeButton.font = .systemFont(ofSize: 11, weight: .medium)
+        analyzeButton.keyEquivalent = "\r"   // パネルにフォーカスがあれば Return で解析
+        analyzeButton.target = self
+        analyzeButton.action = #selector(analyzeTapped)
+        analyzeButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        copyButton.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: L("ai.panel.copy"))
+        copyButton.toolTip = L("ai.panel.copy")
+        styleIconButton(copyButton, action: #selector(copyTapped))
+        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: L("ai.panel.close"))
+        closeButton.toolTip = L("ai.panel.close")
+        styleIconButton(closeButton, action: #selector(closeTapped))
+
+        let headerRow = NSStackView(views: [spark, titleLabel, spinner, analyzeButton, copyButton, closeButton])
+        headerRow.orientation = .horizontal
+        headerRow.spacing = 7
+        headerRow.alignment = .centerY
+        headerRow.translatesAutoresizingMaskIntoConstraints = false
+
+        let header = DragHeaderView()
+        header.addSubview(headerRow)
+        NSLayoutConstraint.activate([
+            headerRow.leadingAnchor.constraint(equalTo: header.leadingAnchor),
+            headerRow.trailingAnchor.constraint(equalTo: header.trailingAnchor),
+            headerRow.topAnchor.constraint(equalTo: header.topAnchor),
+            headerRow.bottomAnchor.constraint(equalTo: header.bottomAnchor),
+        ])
+
+        divider.boxType = .separator
+
+        // 本文。
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 2, height: 2)
+        textView.onCancel = { [weak self] in self?.onClose?() }
+        scroll.documentView = textView
+        scroll.hasVerticalScroller = true
+        scroll.autohidesScrollers = true      // 必要なときだけ出す
+        scroll.scrollerStyle = .overlay       // かぶせ式（幅を食わない・常時表示しない）
+        scroll.drawsBackground = false
+        scroll.borderType = .noBorder
+        scroll.setContentHuggingPriority(.defaultLow, for: .vertical)
+
+        let stack = NSStackView(views: [header, divider, scroll])
+        stack.orientation = .vertical
+        stack.spacing = 9
+        stack.distribution = .fill
+        stack.alignment = .leading
+        stack.edgeInsets = NSEdgeInsets(top: 11, left: 15, bottom: 13, right: 12)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        effect.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            effect.leadingAnchor.constraint(equalTo: leadingAnchor),
+            effect.trailingAnchor.constraint(equalTo: trailingAnchor),
+            effect.topAnchor.constraint(equalTo: topAnchor),
+            effect.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: effect.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: effect.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: effect.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: effect.bottomAnchor),
+            header.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -27),
+            divider.widthAnchor.constraint(equalTo: header.widthAnchor),
+            scroll.widthAnchor.constraint(equalTo: header.widthAnchor),
+        ])
+    }
+
+    private func styleIconButton(_ b: NSButton, action: Selector) {
+        b.isBordered = false
+        b.bezelStyle = .smallSquare
+        b.imageScaling = .scaleProportionallyDown
+        b.contentTintColor = .secondaryLabelColor
+        b.target = self
+        b.action = action
+        b.setContentHuggingPriority(.required, for: .horizontal)
+    }
+
+    func applyTheme() {
+        effect.layer?.borderColor = NSColor.separatorColor.cgColor
+    }
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        effectiveAppearance.performAsCurrentDrawingAppearance { applyTheme() }
+    }
+
+    // MARK: - 状態
+
+    /// 問い合わせ中（スピナー＋「問い合わせ中…」）。コピーは伏せる。Escape 用にフォーカスを取る。
+    func showThinking() {
+        spinner.startAnimation(nil)
+        copyButton.isHidden = true
+        setBody(L("ai.panel.thinking"), color: .secondaryLabelColor)
+        window?.makeFirstResponder(textView)
+    }
+
+    func showResult(_ text: String) {
+        spinner.stopAnimation(nil)
+        copyButton.isHidden = false
+        setBody(text, color: .labelColor)
+        window?.makeFirstResponder(textView)
+    }
+
+    func showError(_ message: String) {
+        spinner.stopAnimation(nil)
+        copyButton.isHidden = true
+        setBody(message, color: .systemRed)
+        window?.makeFirstResponder(textView)
+    }
+
+    /// 選択が無いとき等の淡いヒント（赤ではない）。
+    func showHint(_ text: String) {
+        spinner.stopAnimation(nil)
+        copyButton.isHidden = true
+        setBody(text, color: .secondaryLabelColor)
+        window?.makeFirstResponder(textView)
+    }
+
+    /// 本文を、読みやすい行間・段落間で描く。
+    private func setBody(_ text: String, color: NSColor) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = 3
+        paragraph.paragraphSpacing = 8
+        let attributed = NSAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: 13),
+            .foregroundColor: color,
+            .paragraphStyle: paragraph,
+        ])
+        textView.textStorage?.setAttributedString(attributed)
+        textView.scrollToBeginningOfDocument(nil)
+    }
+
+    var bodyText: String { textView.string }
+
+    @objc private func analyzeTapped() { onAnalyze?() }
+    @objc private func copyTapped() { onCopy?() }
+    @objc private func closeTapped() { onClose?() }
+}

--- a/Sources/MrEditor/UI/PreferencesWindowController.swift
+++ b/Sources/MrEditor/UI/PreferencesWindowController.swift
@@ -28,6 +28,12 @@ final class PreferencesWindowController: NSWindowController {
         colorsItem.image = NSImage(systemSymbolName: "paintpalette", accessibilityDescription: nil)
         tabs.addTabViewItem(colorsItem)
 
+        let ai = AIPaneViewController()
+        ai.title = L("prefs.ai.tab")
+        let aiItem = NSTabViewItem(viewController: ai)
+        aiItem.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: nil)
+        tabs.addTabViewItem(aiItem)
+
         let window = NSWindow(contentViewController: tabs)
         window.styleMask = [.titled, .closable]
         window.title = L("prefs.title")
@@ -481,5 +487,106 @@ private final class ColorsPaneViewController: NSViewController {
     private func applied() {
         sync()
         shareStatus.stringValue = L("prefs.share.imported")
+    }
+}
+
+// MARK: - AI ペイン（BYOK：プロバイダ・モデル・キー・ベース URL）
+
+private final class AIPaneViewController: NSViewController, NSTextFieldDelegate {
+    private var providerPopup: NSPopUpButton!
+    private var modelField: NSTextField!
+    private var keyField: NSSecureTextField!
+    private var baseURLField: NSTextField!
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 480, height: 320))
+
+        providerPopup = NSPopUpButton(frame: .zero, pullsDown: false)
+        for (i, p) in AIProvider.allCases.enumerated() {
+            providerPopup.addItem(withTitle: p.displayName)
+            providerPopup.lastItem?.tag = i
+        }
+        providerPopup.target = self
+        providerPopup.action = #selector(providerPicked(_:))
+
+        modelField = NSTextField(string: "")
+        modelField.delegate = self
+        keyField = NSSecureTextField(string: "")
+        keyField.delegate = self
+        baseURLField = NSTextField(string: "")
+        baseURLField.placeholderString = L("prefs.ai.baseURLPlaceholder")
+        baseURLField.delegate = self
+
+        let note = NSTextField(wrappingLabelWithString: L("prefs.ai.note"))
+        note.font = .systemFont(ofSize: 11)
+        note.textColor = .secondaryLabelColor
+        note.widthAnchor.constraint(lessThanOrEqualToConstant: 420).isActive = true
+
+        for f in [modelField, keyField, baseURLField] as [NSTextField] {
+            f.widthAnchor.constraint(equalToConstant: 320).isActive = true
+        }
+
+        let stack = makeStack([heading("prefs.ai.tab"),
+                               row("prefs.ai.provider", providerPopup),
+                               row("prefs.ai.model", modelField),
+                               row("prefs.ai.apiKey", keyField),
+                               row("prefs.ai.baseURL", baseURLField),
+                               note])
+        pin(stack, in: root)
+        self.view = root
+        sync()
+    }
+
+    private func row(_ key: String, _ control: NSView) -> NSStackView {
+        let label = NSTextField(labelWithString: L(key))
+        label.setContentHuggingPriority(.required, for: .horizontal)
+        label.widthAnchor.constraint(equalToConstant: 90).isActive = true
+        label.alignment = .right
+        let r = NSStackView(views: [label, control])
+        r.orientation = .horizontal
+        r.spacing = 10
+        r.alignment = .firstBaseline
+        return r
+    }
+
+    private func sync() {
+        let config = AppSettings.aiConfig
+        providerPopup.selectItem(withTag: AIProvider.allCases.firstIndex(of: config.provider) ?? 0)
+        modelField.stringValue = config.model
+        baseURLField.stringValue = config.baseURLOverride
+        keyField.stringValue = Keychain.get(account: config.provider.keychainAccount) ?? ""
+    }
+
+    private var currentProvider: AIProvider {
+        AIProvider.allCases[providerPopup.selectedTag()]
+    }
+
+    @objc private func providerPicked(_ sender: NSPopUpButton) {
+        // プロバイダを切り替え、モデルは既定へ・キー欄はそのプロバイダの保存キーへ。
+        var config = AppSettings.aiConfig
+        config.provider = currentProvider
+        config.model = currentProvider.defaultModel
+        AppSettings.aiConfig = config
+        sync()
+    }
+
+    /// モデル・ベース URL は**入力のたびに**その場保存する。
+    /// （編集確定＝フォーカスが外れる、を待つと「入力して即メニュー実行」で保存を取りこぼす。）
+    func controlTextDidChange(_ obj: Notification) {
+        persistTextFields()
+    }
+
+    /// 編集確定時は本文欄に加えてキーも Keychain へ（キーは毎打鍵で書かず確定時にまとめる）。
+    func controlTextDidEndEditing(_ obj: Notification) {
+        persistTextFields()
+        Keychain.set(keyField.stringValue, account: currentProvider.keychainAccount)
+    }
+
+    private func persistTextFields() {
+        var config = AppSettings.aiConfig
+        config.provider = currentProvider
+        config.model = modelField.stringValue.isEmpty ? currentProvider.defaultModel : modelField.stringValue
+        config.baseURLOverride = baseURLField.stringValue.trimmingCharacters(in: .whitespaces)
+        AppSettings.aiConfig = config
     }
 }

--- a/Tests/MrEditorTests/AITests.swift
+++ b/Tests/MrEditorTests/AITests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import MrEditor
+
+/// AI 連携（BYOK）の純粋コアを検証する。ネットワーク送信・GUI は対象外。
+/// `AIConfig`（既定/上書き/https 限定）・`AIRequestBuilder`（組立/解析/エラー）・
+/// `AIPrompts.extractRegex`（フェンス/囲み/説明剥がし）を突く。
+final class AITests: XCTestCase {
+
+    // MARK: - AIConfig
+
+    func testDefaultConfig() {
+        let c = AIConfig.default
+        XCTAssertEqual(c.provider, .anthropic)
+        XCTAssertEqual(c.model, "claude-opus-4-8")
+        XCTAssertEqual(c.baseURL, URL(string: "https://api.anthropic.com"))
+    }
+
+    func testBaseURLOverrideHTTPSOnly() {
+        // 有効な https 上書きは採用。
+        var c = AIConfig(provider: .openAI, model: "m", baseURLOverride: "https://proxy.example.com")
+        XCTAssertEqual(c.baseURL, URL(string: "https://proxy.example.com"))
+        // 平文 http は拒否＝既定へフォールバック（配布 .app の ATS 例外なし）。
+        c.baseURLOverride = "http://insecure.example.com"
+        XCTAssertEqual(c.baseURL, AIProvider.openAI.defaultBaseURL)
+        // 空も既定。
+        c.baseURLOverride = ""
+        XCTAssertEqual(c.baseURL, AIProvider.openAI.defaultBaseURL)
+    }
+
+    // MARK: - AIRequestBuilder（組立）
+
+    private func body(_ req: URLRequest) -> [String: Any] {
+        (try? JSONSerialization.jsonObject(with: req.httpBody ?? Data())) as? [String: Any] ?? [:]
+    }
+
+    func testMakeAnthropicRequest() throws {
+        let cfg = AIConfig(provider: .anthropic, model: "claude-opus-4-8", baseURLOverride: "")
+        let req = try AIRequestBuilder.makeRequest(
+            AIPrompt(system: "SYS", user: "hello", maxTokens: 512), config: cfg, apiKey: "sk-ant-XXX")
+        XCTAssertEqual(req.url?.absoluteString, "https://api.anthropic.com/v1/messages")
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "x-api-key"), "sk-ant-XXX")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+        XCTAssertNil(req.value(forHTTPHeaderField: "Authorization"))
+        let b = body(req)
+        XCTAssertEqual(b["model"] as? String, "claude-opus-4-8")
+        XCTAssertEqual(b["max_tokens"] as? Int, 512)
+        XCTAssertEqual(b["system"] as? String, "SYS")
+        let msgs = b["messages"] as? [[String: Any]]
+        XCTAssertEqual(msgs?.first?["role"] as? String, "user")
+        XCTAssertEqual(msgs?.first?["content"] as? String, "hello")
+    }
+
+    func testMakeOpenAIRequest() throws {
+        let cfg = AIConfig(provider: .openAI, model: "gpt-4o", baseURLOverride: "")
+        let req = try AIRequestBuilder.makeRequest(
+            AIPrompt(system: "SYS", user: "hi", maxTokens: 256), config: cfg, apiKey: "sk-XXX")
+        XCTAssertEqual(req.url?.absoluteString, "https://api.openai.com/v1/chat/completions")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "Bearer sk-XXX")
+        XCTAssertNil(req.value(forHTTPHeaderField: "x-api-key"))
+        let msgs = body(req)["messages"] as? [[String: String]]
+        XCTAssertEqual(msgs?.count, 2)
+        XCTAssertEqual(msgs?[0]["role"], "system")
+        XCTAssertEqual(msgs?[1]["role"], "user")
+        XCTAssertEqual(msgs?[1]["content"], "hi")
+    }
+
+    func testMakeGeminiRequest() throws {
+        let cfg = AIConfig(provider: .gemini, model: "gemini-2.5-flash", baseURLOverride: "")
+        let req = try AIRequestBuilder.makeRequest(
+            AIPrompt(system: "SYS", user: "hi", maxTokens: 256), config: cfg, apiKey: "AIza-XXX")
+        // モデルはパスに入る（コロンは %3A 化しない）／キーは x-goog-api-key。
+        XCTAssertEqual(req.url?.absoluteString,
+                       "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "x-goog-api-key"), "AIza-XXX")
+        XCTAssertNil(req.value(forHTTPHeaderField: "Authorization"))
+        let b = body(req)
+        XCTAssertNotNil(b["system_instruction"])
+        let contents = b["contents"] as? [[String: Any]]
+        let parts = contents?.first?["parts"] as? [[String: Any]]
+        XCTAssertEqual(parts?.first?["text"] as? String, "hi")
+        let gen = b["generationConfig"] as? [String: Any]
+        XCTAssertEqual(gen?["maxOutputTokens"] as? Int, 256)
+    }
+
+    func testParseGeminiResponse() throws {
+        let json = #"{"candidates":[{"content":{"parts":[{"text":"likely OOM"}],"role":"model"}}]}"#
+        let text = try AIRequestBuilder.parseResponse(json.data(using: .utf8)!, provider: .gemini)
+        XCTAssertEqual(text, "likely OOM")
+    }
+
+    func testParseGeminiErrorResponse() {
+        let json = #"{"error":{"code":400,"message":"API key not valid","status":"INVALID_ARGUMENT"}}"#
+        XCTAssertThrowsError(try AIRequestBuilder.parseResponse(json.data(using: .utf8)!, provider: .gemini)) { err in
+            XCTAssertEqual((err as? AIRequestBuilder.AIError)?.message, "API key not valid")
+        }
+    }
+
+    func testMissingKeyThrows() {
+        XCTAssertThrowsError(try AIRequestBuilder.makeRequest(
+            AIPrompt(system: nil, user: "x", maxTokens: 10), config: .default, apiKey: ""))
+    }
+
+    // MARK: - AIRequestBuilder（解析）
+
+    func testParseAnthropicResponse() throws {
+        let json = #"{"content":[{"type":"text","text":"root cause: OOM"}],"stop_reason":"end_turn"}"#
+        let text = try AIRequestBuilder.parseResponse(json.data(using: .utf8)!, provider: .anthropic)
+        XCTAssertEqual(text, "root cause: OOM")
+    }
+
+    func testParseOpenAIResponse() throws {
+        let json = #"{"choices":[{"message":{"role":"assistant","content":"try -Xmx"}}]}"#
+        let text = try AIRequestBuilder.parseResponse(json.data(using: .utf8)!, provider: .openAI)
+        XCTAssertEqual(text, "try -Xmx")
+    }
+
+    func testParseErrorResponse() {
+        let json = #"{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}"#
+        XCTAssertThrowsError(try AIRequestBuilder.parseResponse(json.data(using: .utf8)!, provider: .anthropic)) { err in
+            XCTAssertEqual((err as? AIRequestBuilder.AIError)?.message, "invalid x-api-key")
+        }
+    }
+
+    // MARK: - AIPrompts.extractRegex
+
+    func testExtractRegexPlain() {
+        XCTAssertEqual(AIPrompts.extractRegex(from: #"ERROR|FATAL"#), "ERROR|FATAL")
+    }
+
+    func testExtractRegexTrimsWhitespace() {
+        XCTAssertEqual(AIPrompts.extractRegex(from: "  \n\\d{3}\n  "), #"\d{3}"#)
+    }
+
+    func testExtractRegexStripsCodeFence() {
+        let raw = "```regex\n^(?!.*200 ).*POST.*$\n```"
+        XCTAssertEqual(AIPrompts.extractRegex(from: raw), "^(?!.*200 ).*POST.*$")
+    }
+
+    func testExtractRegexStripsBareFence() {
+        XCTAssertEqual(AIPrompts.extractRegex(from: "```\nfoo.*bar\n```"), "foo.*bar")
+    }
+
+    func testExtractRegexStripsSlashes() {
+        XCTAssertEqual(AIPrompts.extractRegex(from: "/^abc$/"), "^abc$")
+    }
+
+    func testExtractRegexTakesFirstNonEmptyLine() {
+        // 説明が混ざったときは最初の非空行を採る。
+        XCTAssertEqual(AIPrompts.extractRegex(from: "\n\n\\bwarn\\b\nthis matches warnings"), #"\bwarn\b"#)
+    }
+
+    // MARK: - AIPrompts（テンプレの中身）
+
+    func testErrorCausePromptCarriesSelection() {
+        let p = AIPrompts.errorCause("NullPointerException at Foo.bar", language: "Japanese")
+        XCTAssertEqual(p.user, "NullPointerException at Foo.bar")
+        XCTAssertNotNil(p.system)
+        XCTAssertTrue(p.system?.contains("Japanese") ?? false)   // UI 言語で返すよう指示している
+        XCTAssertGreaterThan(p.maxTokens, 0)
+    }
+
+    func testRegexPromptBudget() {
+        let p = AIPrompts.naturalLanguageToRegex("4xx 以外の POST")
+        XCTAssertEqual(p.user, "4xx 以外の POST")
+        // regex 本体は短いが推論トークンぶんの余裕は要る。エラー診断より小さく、0 より大きい。
+        XCTAssertGreaterThan(p.maxTokens, 0)
+        XCTAssertLessThanOrEqual(p.maxTokens, AIPrompts.errorCause("x", language: "English").maxTokens)
+    }
+}


### PR DESCRIPTION
## 概要
ログ/テキストビューアに「今見ている箇所にAIをぶつける」単発解析を追加（M3.5 無料コア）。

## 機能
- **エラーの原因を推測**（⌘⌥E / AIメニュー / パネルの「解析」ボタン）
  選択したエラー・スタックトレース・謎のログ行 → 移動可能なフローティングパネルに **UI言語で** 回答（何が起きた／原因／次の一手）。Escで閉じ、都度解析、コピー可。大ファイルの閲覧ペインでも選択があれば効く。
- **BYOK**（ユーザー自前キー＝原価ゼロ）: Anthropic / OpenAI / **Gemini**。
  キーは **Keychain**、モデル既定は腐らないエイリアス、baseURL上書きは **https限定**（配布.appのATS例外なし対策）。
- 環境設定に「AI」タブ（プロバイダ・モデル・キー・ベースURL）。

## 設計
- 純粋コア（`AIConfig` / `AIRequest` / `AIPrompts` / `Keychain`）はテスト付き（`AITests`）。送信は `AIClient`（URLSession・`UpdateChecker`と同じ流儀）。
- 「選択範囲＝収まる分だけ＝無料 / 収まらない規模＝Pro」の線をコアに内包。
- 自然文→正規表現はコアのみ温存しGUIは出さない（機能は少なく鋭く）。

## テスト
- 全 **340 緑**（AI関連19件・回帰なし）。
- 実機E2E: Geminiキーでエラー診断を完動確認（認証・ATS通過・日本語回答・フローティングパネル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)