### PR TITLE
検索: 上限で打ち切った件数を「N 件以上」と出す＋LP に編集ペインの ⌘F を追記

### DIFF
--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -880,9 +880,10 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             guard let self, self.activeViewer === v else { return }
             self.statusBar.update(state)
         }
-        v.onSearchState = { [weak self, weak v] cur, tot, searching, prog, invalid in
+        v.onSearchState = { [weak self, weak v] cur, tot, searching, prog, invalid, capped in
             guard let self, self.activeViewer === v else { return }
-            self.searchBar.setCount(current: cur, total: tot, searching: searching, progress: prog, invalid: invalid)
+            self.searchBar.setCount(current: cur, total: tot, searching: searching,
+                                    progress: prog, invalid: invalid, capped: capped)
         }
         v.onDropFiles = { [weak self] urls in urls.forEach { self?.open(url: $0) } }
         v.onDirtyChange = { [weak self, weak v] dirty in

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -215,6 +215,8 @@
 "search.invalid" = "Invalid pattern";
 "search.found" = "%@ matches";
 "search.count" = "%1$@ of %2$@";
+"search.foundCapped" = "%@+ matches";
+"search.countCapped" = "%1$@ of %2$@+";
 "search.searching" = "Searching… %d%%";
 "search.replacePlaceholder" = "Replace with";
 "search.replace" = "Replace";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -215,6 +215,8 @@
 "search.invalid" = "無効なパターン";
 "search.found" = "%@ 件";
 "search.count" = "%2$@ 件中 %1$@ 件目";
+"search.foundCapped" = "%@ 件以上";
+"search.countCapped" = "%2$@ 件以上の %1$@ 件目";
 "search.searching" = "検索中… %d%%";
 "search.replacePlaceholder" = "置換";
 "search.replace" = "置換";

--- a/Sources/MrEditor/UI/SearchBarView.swift
+++ b/Sources/MrEditor/UI/SearchBarView.swift
@@ -187,7 +187,10 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         field.selectText(nil)
     }
 
-    func setCount(current: Int, total: Int, searching: Bool, progress: Int, invalid: Bool) {
+    /// `capped` が真なら総数は上限で打ち切った下限＝「N 件以上」と出す。
+    /// 打ち切った数をそのまま「N 件」と言うと、実際より少ない数を断言してしまう。
+    func setCount(current: Int, total: Int, searching: Bool, progress: Int,
+                  invalid: Bool, capped: Bool = false) {
         let fmt = { (n: Int) in NumberFormatter.localizedString(from: NSNumber(value: n), number: .decimal) }
         if query.isEmpty {
             countLabel.stringValue = ""
@@ -197,9 +200,11 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
             countLabel.stringValue = searching ? L("search.searching", progress) : L("search.none")
         } else if current == 0 {
             // まだ移動していない: 件数のみ（検索中なら継続表示）
-            countLabel.stringValue = L("search.found", fmt(total))
+            countLabel.stringValue = capped ? L("search.foundCapped", fmt(total))
+                                            : L("search.found", fmt(total))
         } else {
-            countLabel.stringValue = L("search.count", fmt(current), fmt(total))
+            countLabel.stringValue = capped ? L("search.countCapped", fmt(current), fmt(total))
+                                            : L("search.count", fmt(current), fmt(total))
         }
     }
 

--- a/Sources/MrEditor/Viewer/DiffViewer.swift
+++ b/Sources/MrEditor/Viewer/DiffViewer.swift
@@ -14,7 +14,7 @@ final class DiffViewer: NSView, DocumentPane {
     /// diff は特定の 1 ファイルに属さない（左右 2 つある）。サイドバー名は `displayTitle` を使う。
     var fileURL: URL? { nil }
     var onStateChange: ((ViewerState) -> Void)?
-    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)?
+    var onSearchState: ((Int, Int, Bool, Int, Bool, Bool) -> Void)?
     var onDropFiles: (([URL]) -> Void)?
     var onDirtyChange: ((Bool) -> Void)?
 

--- a/Sources/MrEditor/Viewer/DocumentPane.swift
+++ b/Sources/MrEditor/Viewer/DocumentPane.swift
@@ -25,8 +25,10 @@ protocol DocumentPane: NSView {
 
     /// ステータスバー更新の通知。
     var onStateChange: ((ViewerState) -> Void)? { get set }
-    /// 検索状態の通知（検索バーの件数表示用）。編集ペインでは未使用。
-    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)? { get set }
+    /// 検索状態の通知（検索バーの件数表示用）。
+    /// 引数は (現在, 総数, 走査中, 進捗%, 正規表現が不正, **総数が上限で打ち切られたか**)。
+    /// 最後の印が真なら総数は下限＝検索バーは「N 件以上」と出す（丸めた数を言わない）。
+    var onSearchState: ((Int, Int, Bool, Int, Bool, Bool) -> Void)? { get set }
     /// ファイルがドロップされたとき（新規ドキュメントとして開くのはコントローラ側）。
     var onDropFiles: (([URL]) -> Void)? { get set }
 

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -49,7 +49,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     private static let draftDebounce: TimeInterval = 1.0
 
     var onStateChange: ((ViewerState) -> Void)?
-    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)?   // 編集ペインでは未使用
+    var onSearchState: ((Int, Int, Bool, Int, Bool, Bool) -> Void)?
     var onDropFiles: (([URL]) -> Void)?
 
     // 検索は素の編集状態でのみ（構造化／整形／クエリ中は読み取り専用の見た目で、
@@ -91,7 +91,10 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     /// 現在の一致（1 始まり。0＝まだ移動していない）。
     private var currentMatch = 0
     /// 数え切る上限。1 文字クエリで数百万一致になっても打鍵が止まらないように。
+    /// 打ち鍵ごとに同期で数えるので、ここを外すと 8MB×1 文字で目に見えて詰まる。
     private static let matchCap = 200_000
+    /// 上限で打ち切ったか（＝`matches.count` は総数でなく下限）。件数表示を「N 件以上」にする。
+    private var matchesCapped = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -515,6 +518,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     /// 本文全体の一致を数え直し、ハイライトと件数表示を更新する。
     private func recomputeMatches() {
         matches = matchRanges(in: textView.string)
+        matchesCapped = matches.count >= Self.matchCap
         currentMatch = 0
         applySearchHighlight()
         emitSearchState()
@@ -549,7 +553,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     }
 
     private func emitSearchState() {
-        onSearchState?(currentMatch, matches.count, false, 0, searchInvalid)
+        onSearchState?(currentMatch, matches.count, false, 0, searchInvalid, matchesCapped)
     }
 
     /// 一致を塗る。可視範囲だけ塗るのでヒットが数万でもスクロールが重くならない
@@ -961,6 +965,8 @@ extension EditableViewer {
     func _testSelect(_ range: NSRange) { textView.setSelectedRange(range) }
     var _testSelection: NSRange { textView.selectedRange() }
     var _testMatchCount: Int { matches.count }
+    var _testMatchesCapped: Bool { matchesCapped }
+    static var _testMatchCap: Int { matchCap }
     var _testCurrentMatch: Int { currentMatch }
     var _testSearchInvalid: Bool { searchInvalid }
     /// アンドゥ 1 回。自動グループ（groupsByEvent）はイベントループの一巡で閉じるので、

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -65,7 +65,7 @@ final class PieceTableViewer: NSView, DocumentPane {
     private let maxUndoBytes = 64 * 1024 * 1024
 
     var onStateChange: ((ViewerState) -> Void)?
-    var onSearchState: ((Int, Int, Bool, Int, Bool) -> Void)?   // B1 では未使用
+    var onSearchState: ((Int, Int, Bool, Int, Bool, Bool) -> Void)?
     var onDropFiles: (([URL]) -> Void)?
 
     // MARK: - 編集・保存状態（B3）
@@ -1302,7 +1302,8 @@ final class PieceTableViewer: NSView, DocumentPane {
         } else {
             current = currentMatchIdx >= 0 ? currentMatchIdx + 1 : 0
         }
-        onSearchState?(current, total, searching, progress, invalid)
+        // 総数は上限超過も数えているので正確（上限がかかるのは「移動できる一致行」だけ）。
+        onSearchState?(current, total, searching, progress, invalid, false)
     }
 
     private func firstMatchIndex(after line: Int) -> Int {
@@ -1385,7 +1386,7 @@ final class PieceTableViewer: NSView, DocumentPane {
         selectionAnchor = caretByte
         scrollCaretIntoView()
         refresh()
-        onSearchState?(count, count, false, 100, false)   // 「N 件置換」相当のフィードバック
+        onSearchState?(count, count, false, 100, false, false)   // 「N 件置換」相当のフィードバック
     }
 
     /// 現在の選択が一致ならそれを置換して次へ、一致でなければ次の一致を選択する（反復置換）。

--- a/Tests/MrEditorTests/EditableViewerSearchTests.swift
+++ b/Tests/MrEditorTests/EditableViewerSearchTests.swift
@@ -206,3 +206,38 @@ final class EditableViewerSearchTests: XCTestCase {
         XCTAssertEqual(v._testSelection.location, 8)
     }
 }
+
+// MARK: - 件数の上限（丸めた数を断言しない）
+
+extension EditableViewerSearchTests {
+
+    /// 上限に達していなければ「打ち切った」印は立たない＝件数はそのまま断言してよい。
+    func testMatchCountIsNotFlaggedCappedWhenUnderLimit() {
+        let v = EditableViewer()
+        v.newDocument()
+        v._testSetText("hit hit hit")
+        v.setSearchQuery("hit")
+        XCTAssertEqual(v._testMatchCount, 3)
+        XCTAssertFalse(v._testMatchesCapped)
+    }
+
+    /// 上限で打ち切ったら印を立てる（検索バーは「N 件以上」と出す）。
+    /// 上限ぶんの一致を作るので本文は大きめ。同期で数える設計なのでここも実測になる。
+    func testMatchCountFlagsCappedAtLimit() {
+        let cap = EditableViewer._testMatchCap
+        let v = EditableViewer()
+        v.newDocument()
+        v._testSetText(String(repeating: "a", count: cap + 100))
+        v.setSearchQuery("a")
+        XCTAssertEqual(v._testMatchCount, cap)      // 数え切らずに打ち切る
+        XCTAssertTrue(v._testMatchesCapped)         // ＝総数ではなく下限
+    }
+
+    /// 打ち切りの文言が両言語にあり、キー名がそのまま出ていない。
+    func testCappedCountStringsExist() {
+        for key in ["search.foundCapped", "search.countCapped"] {
+            XCTAssertNotEqual(L(key), key, key)
+            XCTAssertFalse(L(key).isEmpty, key)
+        }
+    }
+}

--- a/site/index.en.html
+++ b/site/index.en.html
@@ -210,7 +210,7 @@
       <li>AI error diagnosis (BYOK) <span>— select a stack trace, press ⌥⌘E, and the answer streams in as it is written. Your own key (Anthropic / OpenAI / Gemini), stored in the Keychain; pick a model — or type one that is not listed and let the connection test add it — in Settings</span></li>
       <li>Atomic save <span>— write to a temp file, then swap; the original is never left half-written</span></li>
       <li>Save encoding <span>— convert between UTF-8 / Shift-JIS / EUC-JP on save</span></li>
-      <li>Search <span>— streams over mmap; multi-term AND, regex &amp; case toggle</span></li>
+      <li>Search <span>— streams over mmap for huge files, and ⌘F works while you edit too (replace, case-preserving). Multi-term AND, regex &amp; case toggle</span></li>
       <li>Filtered view / live grep <span>— show only matching lines</span></li>
       <li>Multiple documents <span>— open many files, switch from a sidebar</span></li>
       <li>Session restore <span>— reopens your sidebar on launch, unsaved drafts included</span></li>

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -210,7 +210,7 @@
       <li>AI でエラーの原因推測（BYOK）<span>— スタックトレースを選んで ⌥⌘E。答えは書かれる端から流れてくる。鍵はあなたのもの（Anthropic / OpenAI / Gemini）で Keychain 保管。設定でモデルを選べる。一覧に無いものは打ち込め、接続テストに通れば次から一覧に出る</span></li>
       <li>atomic 保存 <span>— 一時ファイルに書いて入れ替え。元ファイルを壊さない</span></li>
       <li>保存エンコード指定 <span>— 保存時に UTF-8 / Shift-JIS / EUC-JP へ変換</span></li>
-      <li>検索 <span>— mmap をストリーム走査。複数語AND・正規表現・大小区別</span></li>
+      <li>検索 <span>— 巨大ファイルは mmap をストリーム走査。編集中のファイルでも ⌘F（置換・ケース維持まで）。複数語AND・正規表現・大小区別</span></li>
       <li>フィルタ表示 / live grep <span>— 一致行だけ表示</span></li>
       <li>複数ドキュメント <span>— 同時に開いてサイドバーで切替</span></li>
       <li>セッション復元 <span>— 起動時にサイドバーを復元。未保存の新規も本文ごと戻る</span></li>

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -234,7 +234,7 @@
       <li data-en="AI error diagnosis (BYOK) <span>— select a stack trace, press ⌥⌘E, and the answer streams in as it is written. Your own key (Anthropic / OpenAI / Gemini), stored in the Keychain; pick a model — or type one that is not listed and let the connection test add it — in Settings</span>" data-ja="AI でエラーの原因推測（BYOK）<span>— スタックトレースを選んで ⌥⌘E。答えは書かれる端から流れてくる。鍵はあなたのもの（Anthropic / OpenAI / Gemini）で Keychain 保管。設定でモデルを選べる。一覧に無いものは打ち込め、接続テストに通れば次から一覧に出る</span>"></li>
       <li data-en="Atomic save <span>— write to a temp file, then swap; the original is never left half-written</span>" data-ja="atomic 保存 <span>— 一時ファイルに書いて入れ替え。元ファイルを壊さない</span>"></li>
       <li data-en="Save encoding <span>— convert between UTF-8 / Shift-JIS / EUC-JP on save</span>" data-ja="保存エンコード指定 <span>— 保存時に UTF-8 / Shift-JIS / EUC-JP へ変換</span>"></li>
-      <li data-en="Search <span>— streams over mmap; multi-term AND, regex &amp; case toggle</span>" data-ja="検索 <span>— mmap をストリーム走査。複数語AND・正規表現・大小区別</span>"></li>
+      <li data-en="Search <span>— streams over mmap for huge files, and ⌘F works while you edit too (replace, case-preserving). Multi-term AND, regex &amp; case toggle</span>" data-ja="検索 <span>— 巨大ファイルは mmap をストリーム走査。編集中のファイルでも ⌘F（置換・ケース維持まで）。複数語AND・正規表現・大小区別</span>"></li>
       <li data-en="Filtered view / live grep <span>— show only matching lines</span>" data-ja="フィルタ表示 / live grep <span>— 一致行だけ表示</span>"></li>
       <li data-en="Multiple documents <span>— open many files, switch from a sidebar</span>" data-ja="複数ドキュメント <span>— 同時に開いてサイドバーで切替</span>"></li>
       <li data-en="Session restore <span>— reopens your sidebar on launch, unsaved drafts included</span>" data-ja="セッション復元 <span>— 起動時にサイドバーを復元。未保存の新規も本文ごと戻る</span>"></li>


### PR DESCRIPTION
## 直したもの

### 1. 打ち切った件数を断言しないようにした

編集ペインは打鍵ごとに**同期で**数えるので、上限 20 万で打ち切ります。そこで止めた数をそのまま「200,000 件」と表示していました ―― **実際より少ない数を断言していた**わけです。8MB のファイルで 1 文字を検索すれば普通に超えるので、絵空事ではありません。

- `matchesCapped` を立て、検索状態の通知に印を追加（`onSearchState` の第6引数）。検索バーは `search.foundCapped` / `search.countCapped` で「**N 件以上**」と出す
- **巨大ファイル側は件数は正確**（`SearchEngine.Result.lineCount` は上限超過も数える。上限 100 万がかかるのは「移動できる一致行」だけ）なので `false` を渡す。この非対称は読み違えやすいのでコメントで明示

### 2. LP の検索の説明が大ファイル前提のままだった

1.10.1 で編集ペインでも ⌘F が効くようになったのに、LP からは読み取れませんでした。日英そろえて追記（取りこぼしの回収）:

> 検索 — 巨大ファイルは mmap をストリーム走査。**編集中のファイルでも ⌘F（置換・ケース維持まで）**。複数語AND・正規表現・大小区別

## 検証

- 388 green（+3）
- **配布形式の .app で実測**: 25 万文字の `a` に対し `a` で「200,000 件以上の 1 件目」、`aaaa` で「62,500 件中 2 件目」（上限未満は従来表示）
- check_consistency 緑（i18n 264/264・site ドリフト無し・版数7箇所一致）

## 版数

**1.10.2 のまま上げていません。** コード側の変化は「一致が 20 万件を超えたときのラベル」だけで、そのために全利用者へ更新通知を出すのは釣り合わないため、次のリリースに同梱します。LP は main に入った時点で Pages が反映します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)