### PR TITLE
メニューの日本語化と、構造化表示の列幅サンプル改善

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -422,7 +422,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // 編集メニュー（検索）
         let editMenuItem = NSMenuItem()
         mainMenu.addItem(editMenuItem)
-        let editMenu = NSMenu(title: "Edit")
+        let editMenu = NSMenu(title: L("menu.edit"))
         editMenuItem.submenu = editMenu
         // アンドゥ／リドゥ（⌘Z / ⌘⇧Z）: target nil でレスポンダチェーン（NSTextView）へ。
         let undoItem = NSMenuItem(title: L("menu.undo"),
@@ -518,7 +518,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // 表示メニュー（末尾追従）
         let viewMenuItem = NSMenuItem()
         mainMenu.addItem(viewMenuItem)
-        let viewMenu = NSMenu(title: "View")
+        let viewMenu = NSMenu(title: L("menu.view"))
         viewMenuItem.submenu = viewMenu
         let gotoItem = NSMenuItem(title: L("menu.gotoLine"),
                                   action: #selector(performGoToLine(_:)), keyEquivalent: "l")

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "menu.zoomReset" = "Actual Size";
 "menu.saveProgress.statusBar" = "Status bar (stay interactive)";
 "menu.saveProgress.sheet" = "Sheet (wait while saving)";
+"menu.view" = "View";
 "menu.gotoLine" = "Go to Line…";
 "menu.structured" = "Structured View";
 "menu.structured.off" = "Off";
@@ -186,6 +187,7 @@
 "common.ok" = "OK";
 
 /* Edit */
+"menu.edit" = "Edit";
 "menu.undo" = "Undo";
 "menu.redo" = "Redo";
 "menu.cut" = "Cut";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -60,6 +60,7 @@
 "menu.zoomReset" = "実際のサイズ";
 "menu.saveProgress.statusBar" = "ステータスバー（操作を止めない）";
 "menu.saveProgress.sheet" = "シート（保存中は待つ）";
+"menu.view" = "表示";
 "menu.gotoLine" = "行へ移動…";
 "menu.structured" = "構造化表示";
 "menu.structured.off" = "オフ";
@@ -186,6 +187,7 @@
 "common.ok" = "OK";
 
 /* 編集 */
+"menu.edit" = "編集";
 "menu.undo" = "取り消す";
 "menu.redo" = "やり直す";
 "menu.cut" = "カット";

--- a/Sources/MrEditor/Viewer/EditableViewer.swift
+++ b/Sources/MrEditor/Viewer/EditableViewer.swift
@@ -764,7 +764,12 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         jsonPrettyActive = false
         var lines = source.components(separatedBy: "\n")
         if lines.last == "" { lines.removeLast() }   // 末尾改行の余り
-        let fmt = TabularFormatter.build(mode: mode, sampleLines: Array(lines.prefix(1000)))
+        // 先頭だけでは後半で桁が伸びる列を取りこぼすため、両端をサンプルする
+        // （大ファイル側の `structuredSampleLines` と同じ方針）。
+        let sample = lines.count > 2000
+            ? Array(lines.prefix(1000)) + Array(lines.suffix(1000))
+            : lines
+        let fmt = TabularFormatter.build(mode: mode, sampleLines: sample)
         structuredFormatter = fmt
         textView.isEditable = false
         setWrapMode(wrapped: false)

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -214,9 +214,19 @@ final class PieceTableViewer: NSView, DocumentPane {
         refresh()
     }
 
-    /// 構造化の列幅算出用サンプル（先頭 n 行の生文字列）。
+    /// 構造化の列幅算出用サンプル（先頭 n 行＋末尾 n 行の生文字列）。
+    ///
+    /// 先頭だけを見ると、後半で桁が伸びる列（連番・ID など）が省略表示になる。
+    /// 581 万行の CSV で 1 列目が `581…` と切れたのが実例。全行走査はできないので、
+    /// 両端を見て列幅を決める。中間で更に伸びる列は依然として切れるが、
+    /// 単調増加する列はこれで拾える。
     private func structuredSampleLines(_ n: Int) -> [String] {
-        lineRanges(from: 0, count: n).map { decodeLineString($0) }
+        let head = lineRanges(from: 0, count: n).map { decodeLineString($0) }
+        let total = displayCount
+        guard total > n else { return head }
+        let tailStart = max(n, total - n)
+        let tail = lineRanges(from: tailStart, count: total - tailStart).map { decodeLineString($0) }
+        return head + tail
     }
 
     /// 表示設定（タブ幅・行間・現在行ハイライト・カーソル形状）を反映する。


### PR DESCRIPTION
581万行の CSV（国税庁 法人番号 全件データ・1.18GiB）で動画素材を検証していて見つかった2件。

## 1. メニュー「編集」「表示」だけ英語のまま

他のメニューは `L(...)` を通っているのに、この2つだけ `NSMenu(title: "Edit")` /
`NSMenu(title: "View")` とハードコードされていた。日本語環境のメニューバーが
「ファイル・Edit・書式・View・AI・ウインドウ・ヘルプ」と混ざって出ていた。

修正後: ファイル・**編集**・書式・**表示**・AI・ウインドウ・ヘルプ

## 2. 構造化表示の列幅が先頭 1000 行だけで決まっていた

後半で桁が伸びる列が省略される。実例として 581 万行の CSV で 1 列目の連番が
`581…` と切れた。全行走査はできないので両端をサンプルするようにした。
中間で更に伸びる列は依然として切れる（列幅ドラッグができるグリッド表示が本来の解）。

修正後: 最終行付近でも `5816493` と 7 桁フル表示。

## 検証

- 388 tests green
- 配布形式の .app バンドルに包んで、1.18GiB の実ファイルで両方とも実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)