### PR TITLE
LP: Cloudflare Web Analytics を入れて到達数を測る

### DIFF
--- a/site/index.en.html
+++ b/site/index.en.html
@@ -107,6 +107,9 @@
     nav .ghlink{display:none}
   }
 </style>
+<!-- Cloudflare Web Analytics — Cookie を置かず個人を追跡しないので同意バナー不要。
+     数える目的は「告知で何人が来て、何人が落ちたか」だけ。 -->
+<script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "cfc29640260e47389989d98e188b2b5b"}'></script>
 
 <link rel="alternate" hreflang="ja" href="index.ja.html">
 <link rel="alternate" hreflang="en" href="index.en.html">

--- a/site/index.ja.html
+++ b/site/index.ja.html
@@ -107,6 +107,9 @@
     nav .ghlink{display:none}
   }
 </style>
+<!-- Cloudflare Web Analytics — Cookie を置かず個人を追跡しないので同意バナー不要。
+     数える目的は「告知で何人が来て、何人が落ちたか」だけ。 -->
+<script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "cfc29640260e47389989d98e188b2b5b"}'></script>
 
 <link rel="alternate" hreflang="ja" href="index.ja.html">
 <link rel="alternate" hreflang="en" href="index.en.html">

--- a/web/lp.src.html
+++ b/web/lp.src.html
@@ -114,6 +114,9 @@
     nav .ghlink{display:none}
   }
 </style>
+<!-- Cloudflare Web Analytics — Cookie を置かず個人を追跡しないので同意バナー不要。
+     数える目的は「告知で何人が来て、何人が落ちたか」だけ。 -->
+<script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "cfc29640260e47389989d98e188b2b5b"}'></script>
 </head>
 <body>
 <div class="wrap">


### PR DESCRIPTION
## なぜ

Pro を出す前に「売れないのは**モノが刺さらない**からか、**知られていない**からか」を切り分けられる状態にしておきたい。DL 数は #52 で撮り始めたので、残りは LP に何人来て何人が落ちたか。

## なぜ Cloudflare か

- 無料で**商用可**・**Cookie を置かず個人を追跡しない**ので同意バナーが要らない
- GA4 は EU で同意バナーが必要な上に重い
- GoatCounter は無料枠が**非商用限定**で、Pro を売り始めると対象外になる

## 実装上の注意点

- ビーコンは `web/lp.src.html` の `<head>` に置いた。`site/` は生成物なので直接触らない。
- `data-cf-beacon` の値は JSON でシングルクォート属性。`build_site.py` は `data-{lang}` を持たないタグを `get_starttag_text()` でそのまま通すため、再エスケープで壊れない。**生成後に属性が原文のままであることを確認済み。**
- リダイレクタ `site/index.html` には入れていない。即座に ja/en へ飛ぶので、そこで数えると二重に数えることになる。

## 確認

- `python3 scripts/build_site.py` → ja/en 両方にビーコンが1つずつ、属性は原文のまま
- `python3 scripts/check_consistency.py` → 版数一致・site ドリフト無し・日英パリティ・i18n すべて ✅

ダッシュボード側はホスト名 `mr-tabata.github.io` で登録済み。パス `/MrEditor/` で絞って見る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)