### PR TITLE
Pro v1: 時刻マージのコア（TimestampDetector / LogMerger）

### DIFF
--- a/Sources/MrEditor/AppDelegate.swift
+++ b/Sources/MrEditor/AppDelegate.swift
@@ -133,6 +133,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         ensureController().openDocument(sender)
     }
 
+    @objc private func openMergedByTime(_ sender: Any?) {
+        ensureController().openMergedByTime(sender)
+    }
+
     @objc private func performFind(_ sender: Any?) {
         windowController?.showSearch()
     }
@@ -362,6 +366,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                                   action: #selector(openDocument(_:)), keyEquivalent: "o")
         openItem.target = self
         fileMenu.addItem(openItem)
+        // 複数のログを時刻で1本に束ねて開く
+        let mergeItem = NSMenuItem(title: L("menu.openMerged"),
+                                   action: #selector(openMergedByTime(_:)), keyEquivalent: "O")
+        mergeItem.keyEquivalentModifierMask = [.command, .shift]
+        mergeItem.target = self
+        fileMenu.addItem(mergeItem)
         // 最近使った項目（サブメニューは開くたびに menuNeedsUpdate で再構築）
         let recentItem = NSMenuItem(title: L("menu.openRecent"), action: nil, keyEquivalent: "")
         let recent = NSMenu(title: L("menu.openRecent"))

--- a/Sources/MrEditor/Core/LogMerger.swift
+++ b/Sources/MrEditor/Core/LogMerger.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// 複数のログを1本の時系列に束ねる純ロジック（UI 非依存・ファイル I/O 非依存）。
+///
+/// `sort -m` で済まない理由がこの型の存在理由なので、そこだけ書いておく。
+///
+/// - **時刻を持たない行がある。** スタックトレースの続きや SQL の複数行ダンプは
+///   時刻を持たない。素朴に行単位で並べ替えると、これらが親の行から引き剥がされて
+///   全体に散らばる。ここでは**直前の時刻を引き継ぐ**（`effectiveTimes`）ことで、
+///   継続行が必ず親の直後に残るようにしている。
+/// - **同時刻が大量に出る。** 秒までしか無い形式では同じ時刻の行が普通に何十行も
+///   並ぶ。並べ替えが不安定だと、開くたびに順番が変わる。ここでは
+///   （時刻 → ソース番号 → 行番号）で全順序を作り、**常に同じ結果**にしている。
+/// - **ホストごとに時計がずれている。** NTP がずれた1台があると因果が逆転して見える。
+///   `clockOffset` でソース単位に補正する。
+///
+/// 行本文は持たない。`Entry` はどのソースの何行目かだけを指し、本文の取得は呼び出し
+/// 側に任せる。巨大ファイルを丸ごとメモリに載せないための境界。
+struct LogMerger {
+    /// 束ねる対象1本ぶん。
+    struct Source {
+        /// 表示名（`web-1` など）。
+        let label: String
+        /// 行ごとの「その行自身が持っていた」時刻。持たない行は `nil`。
+        let times: [Date?]
+        /// この系の時計ずれ補正（秒）。`+1.5` なら記録時刻を 1.5 秒進める。
+        let clockOffset: TimeInterval
+
+        init(label: String, times: [Date?], clockOffset: TimeInterval = 0) {
+            self.label = label
+            self.times = times
+            self.clockOffset = clockOffset
+        }
+    }
+
+    /// 束ねた結果の1行。
+    struct Entry: Equatable {
+        /// `sources` の添字。
+        let source: Int
+        /// そのソース内の行番号（0 始まり）。
+        let line: Int
+        /// 並べ替えに使った実効時刻（補正済み）。全く時刻の無いソースでは `nil`。
+        let time: Date?
+        /// その行自身が時刻を持っていたか。`false` は継続行＝画面では時刻を出さない。
+        let hasOwnTimestamp: Bool
+    }
+
+    /// 行ごとの実効時刻を求める。**入力と同じ本数を必ず返す。**
+    ///
+    /// - 時刻を持つ行はその時刻（＋`clockOffset`）。
+    /// - 持たない行は**直前の時刻を引き継ぐ**（継続行を親から離さないため）。
+    /// - 先頭にある時刻を持たない行（見出し・バナー）は、**最初に現れる時刻**を借りる。
+    ///   これが無いとファイル冒頭の数行だけ行き場を失う。
+    /// - 1つも時刻が無いソースは全行 `nil`。
+    static func effectiveTimes(_ times: [Date?], clockOffset: TimeInterval = 0) -> [Date?] {
+        var out = [Date?](repeating: nil, count: times.count)
+        var carried: Date?
+        for i in times.indices {
+            if let t = times[i] { carried = t.addingTimeInterval(clockOffset) }
+            out[i] = carried
+        }
+        // 先頭の空白部分を、最初に見つかった時刻で埋める
+        if let firstIndex = out.firstIndex(where: { $0 != nil }), firstIndex > 0 {
+            let first = out[firstIndex]
+            for i in 0..<firstIndex { out[i] = first }
+        }
+        return out
+    }
+
+    /// 複数ソースを1本の時系列に束ねる。
+    ///
+    /// 各ソース内の行順は必ず保たれる（同時刻でも入れ替わらない）。時刻を持たない
+    /// ソースの行は、時刻を持つ行を全て出したあとに、ソース順・行順で並ぶ。
+    ///
+    /// ソース数 k は現実には数本なので、ヒープを使わず先頭 k 本を毎回見る素直な
+    /// k-way merge にしている（O(N·k)）。k が二桁に増えたらここを差し替える。
+    static func merge(_ sources: [Source]) -> [Entry] {
+        let effective = sources.map { effectiveTimes($0.times, clockOffset: $0.clockOffset) }
+        var cursor = [Int](repeating: 0, count: sources.count)
+        let total = effective.reduce(0) { $0 + $1.count }
+
+        var out: [Entry] = []
+        out.reserveCapacity(total)
+
+        for _ in 0..<total {
+            var pick = -1
+            var pickTime: Date?
+            for s in sources.indices where cursor[s] < effective[s].count {
+                let t = effective[s][cursor[s]]
+                if pick < 0 { pick = s; pickTime = t; continue }
+                // nil は「時刻不明」なので最後に回す。同時刻はソース番号の小さい方が先。
+                switch (t, pickTime) {
+                case let (a?, b?): if a < b { pick = s; pickTime = t }
+                case (_?, nil):    pick = s; pickTime = t
+                default:           break
+                }
+            }
+            guard pick >= 0 else { break }
+            let line = cursor[pick]
+            out.append(Entry(source: pick,
+                             line: line,
+                             time: effective[pick][line],
+                             hasOwnTimestamp: sources[pick].times[line] != nil))
+            cursor[pick] += 1
+        }
+        return out
+    }
+}

--- a/Sources/MrEditor/Core/MergedLogBuilder.swift
+++ b/Sources/MrEditor/Core/MergedLogBuilder.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// 複数のログファイルを読み、時刻で1本に束ねて1つのテキストにする。
+///
+/// `TimestampDetector` / `LogMerger`（どちらも純関数）に、ファイル読み込みと
+/// 見せ方だけを足す層。ここが唯一 I/O を持つ。
+///
+/// **結果は一時ファイルに書き出し、通常の「開く」経路に流す。** 専用のビューアを
+/// 作らないことで、検索・フィルタ・構造化表示・別名保存・行ジャンプが全部そのまま
+/// 効く。束ねた結果が大きければ既存の大ファイル経路（`PieceTableViewer`）に自動で
+/// 乗るので、表示側のメモリ設計にも手を入れずに済む。
+///
+/// **形式はファイルごとに判定する。** nginx（Apache 形式）とアプリログ（ISO）を
+/// 一緒に束ねるのが現実の使い方で、全体で1つの形式に決めつけると片方が丸ごと
+/// 継続行になって時系列が崩れる。
+struct MergedLogBuilder {
+
+    /// 束ねた1本ぶんの素性（見出しに出す）。
+    struct SourceInfo {
+        let label: String
+        let url: URL
+        let format: TimestampFormat?
+        let lineCount: Int
+        let timestampedCount: Int
+    }
+
+    struct Result {
+        /// 書き出した一時ファイル。
+        let url: URL
+        let sources: [SourceInfo]
+        let totalLines: Int
+        /// 読めなかった・時刻が無かったなど、利用者に伝えるべきこと。
+        let warnings: [String]
+    }
+
+    enum Failure: LocalizedError {
+        case needsTwoFiles
+        case tooLarge(bytes: Int, limit: Int)
+        case unreadable(URL)
+        case writeFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .needsTwoFiles:
+                return L("merge.error.needsTwoFiles")
+            case let .tooLarge(bytes, limit):
+                return String(format: L("merge.error.tooLarge"),
+                              ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file),
+                              ByteCountFormatter.string(fromByteCount: Int64(limit), countStyle: .file))
+            case let .unreadable(url):
+                return String(format: L("merge.error.unreadable"), url.lastPathComponent)
+            case let .writeFailed(e):
+                return e.localizedDescription
+            }
+        }
+    }
+
+    /// 入力の合計サイズの上限。
+    ///
+    /// 束ねるには**全行の時刻を先に知る必要がある**ので、10GB を素通しするわけには
+    /// いかない（並べ替えは全件を見るまで1行目が確定しない）。ここは正直に上限を
+    /// 設けて断る。上限を超えるものを黙って途中まで束ねるのが一番悪い。
+    static let inputSizeLimit = 512 * 1024 * 1024
+
+    /// 表示に使う UTC オフセット（秒）。既定はローカル。
+    let displayOffset: Int
+    /// 行に書かれていないときに仮定する UTC オフセット（秒）。
+    let assumedOffset: Int
+    /// 年を持たない形式（syslog）で仮定する年。
+    let assumedYear: Int
+
+    init(displayOffset: Int = TimeZone.current.secondsFromGMT(),
+         assumedOffset: Int = TimeZone.current.secondsFromGMT(),
+         assumedYear: Int = Calendar(identifier: .gregorian).component(.year, from: Date())) {
+        self.displayOffset = displayOffset
+        self.assumedOffset = assumedOffset
+        self.assumedYear = assumedYear
+    }
+
+    // MARK: - 本体
+
+    func build(urls: [URL], into directory: URL? = nil) throws -> Result {
+        guard urls.count >= 2 else { throw Failure.needsTwoFiles }
+
+        let total = urls.reduce(0) { sum, u in
+            sum + ((try? FileManager.default.attributesOfItem(atPath: u.path)[.size] as? Int) ?? 0 ?? 0)
+        }
+        guard total <= Self.inputSizeLimit else {
+            throw Failure.tooLarge(bytes: total, limit: Self.inputSizeLimit)
+        }
+
+        var warnings: [String] = []
+        var infos: [SourceInfo] = []
+        var texts: [[String]] = []
+        var sources: [LogMerger.Source] = []
+
+        for (i, url) in urls.enumerated() {
+            guard let data = try? Data(contentsOf: url) else { throw Failure.unreadable(url) }
+            let encoding = EncodingDetector.detect(data)
+            guard let text = String(data: data, encoding: encoding.stringEncoding) else {
+                throw Failure.unreadable(url)
+            }
+            // 改行は CRLF/CR も受ける。表示は LF に揃える。
+            var lines = text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map(String.init)
+            // 末尾の改行で生まれる幻の空行を1つだけ落とす。テキストファイルは改行で
+            // 終わるのが普通なので、これを残すと**ファイルの数だけ空行が混ざる**。
+            // 継続行として直前の時刻を引き継ぐぶん、ラベルだけの行として見えてしまう。
+            if lines.last == "" { lines.removeLast() }
+
+            let label = Self.label(for: url, index: i, among: urls)
+            let sample = Array(lines.prefix(500))
+            let detector = TimestampDetector.detect(sampleLines: sample,
+                                                    timeZoneOffset: assumedOffset,
+                                                    assumedYear: assumedYear)
+            let times = detector?.parseAll(lines) ?? [Date?](repeating: nil, count: lines.count)
+            let hits = times.reduce(0) { $0 + ($1 == nil ? 0 : 1) }
+
+            if detector == nil {
+                warnings.append(String(format: L("merge.warn.noTimestamp"), url.lastPathComponent))
+            }
+            infos.append(SourceInfo(label: label, url: url, format: detector?.format,
+                                    lineCount: lines.count, timestampedCount: hits))
+            texts.append(lines)
+            sources.append(LogMerger.Source(label: label, times: times))
+        }
+
+        let merged = LogMerger.merge(sources)
+        let labelWidth = infos.map { $0.label.count }.max() ?? 0
+
+        var out = header(infos: infos, totalLines: merged.count, warnings: warnings)
+        out.reserveCapacity(merged.count * 96)
+        var lastStamp = ""
+        for e in merged {
+            let stamp = e.hasOwnTimestamp ? Self.format(e.time, offset: displayOffset) : ""
+            // 継続行は時刻欄を空にする。親の時刻を引き継いでいるだけなので、
+            // そこに数字を出すと「その行自身が持っている時刻」に見えて嘘になる。
+            out += stamp.isEmpty ? String(repeating: " ", count: lastStamp.count) : stamp
+            if !stamp.isEmpty { lastStamp = stamp }
+            out += " │ "
+            out += infos[e.source].label.padding(toLength: labelWidth, withPad: " ", startingAt: 0)
+            out += " │ "
+            out += texts[e.source][e.line]
+            out += "\n"
+        }
+
+        let dir = directory ?? FileManager.default.temporaryDirectory
+        let name = "merged-\(urls.count)files-\(Self.stamp()).log"
+        let dest = dir.appendingPathComponent(name)
+        do {
+            try out.write(to: dest, atomically: true, encoding: .utf8)
+        } catch {
+            throw Failure.writeFailed(error)
+        }
+        return Result(url: dest, sources: infos, totalLines: merged.count, warnings: warnings)
+    }
+
+    // MARK: - 見出し
+
+    private func header(infos: [SourceInfo], totalLines: Int, warnings: [String]) -> String {
+        var s = "# " + String(format: L("merge.header.title"), infos.count, totalLines) + "\n"
+        for i in infos {
+            let fmt = i.format?.rawValue ?? L("merge.header.noFormat")
+            s += "#   \(i.label)  \(i.url.lastPathComponent)  (\(fmt), "
+            s += String(format: L("merge.header.lines"), i.lineCount, i.timestampedCount) + ")\n"
+        }
+        for w in warnings { s += "# ⚠️ \(w)\n" }
+        s += "#\n"
+        return s
+    }
+
+    // MARK: - 小道具
+
+    /// 表示名。同名ファイルが混ざるとき（`web-1/app.log` と `web-2/app.log`）は
+    /// 親ディレクトリまで足す。ホスト別に集めたログでこれが起きないと区別できない。
+    static func label(for url: URL, index: Int, among urls: [URL]) -> String {
+        let base = url.deletingPathExtension().lastPathComponent
+        let duplicated = urls.filter { $0.deletingPathExtension().lastPathComponent == base }.count > 1
+        guard duplicated else { return base }
+        let parent = url.deletingLastPathComponent().lastPathComponent
+        return parent.isEmpty ? "\(base)-\(index + 1)" : "\(parent)/\(base)"
+    }
+
+    /// `2026-07-30 12:34:56.789`。`DateFormatter` は使わない（行数ぶん呼ばれる）。
+    static func format(_ date: Date?, offset: Int) -> String {
+        guard let date else { return "" }
+        let total = date.timeIntervalSince1970 + Double(offset)
+        let whole = Int(floor(total))
+        let millis = Int(((total - floor(total)) * 1000).rounded())
+        let days = Int(floor(Double(whole) / 86_400))
+        let rem = whole - days * 86_400
+        let c = TimestampDetector.civilFromDays(days)
+        return "\(pad(c.year, 4))-\(pad(c.month, 2))-\(pad(c.day, 2)) "
+            + "\(pad(rem / 3600, 2)):\(pad((rem % 3600) / 60, 2)):\(pad(rem % 60, 2))"
+            + ".\(pad(millis, 3))"
+    }
+
+    private static func pad(_ v: Int, _ width: Int) -> String {
+        let s = String(v)
+        return s.count >= width ? s : String(repeating: "0", count: width - s.count) + s
+    }
+
+    private static func stamp() -> String {
+        let now = Date().timeIntervalSince1970 + Double(TimeZone.current.secondsFromGMT())
+        let rem = Int(now) % 86_400
+        return "\(pad(rem / 3600, 2))\(pad((rem % 3600) / 60, 2))\(pad(rem % 60, 2))"
+    }
+}

--- a/Sources/MrEditor/Core/TimestampDetector.swift
+++ b/Sources/MrEditor/Core/TimestampDetector.swift
@@ -156,14 +156,29 @@ struct TimestampDetector {
 
     // MARK: - 形式ごとの走査
 
+    /// 1行を走査して要素を取り出す。
+    ///
+    /// `Array(line.utf8)` を作らず `withUTF8` で既存のバッファを直接見る。行ごとの
+    /// 確保は1行では些細でも、数百万行では支配的になる。
+    ///
+    /// 実測（2026-08-04・Mac mini M1・`swift test -Xswiftc -O`・`testdata/test_50mb_jp.log`
+    /// 429,337 行）: **3.74 → 13.9 M行/s**。
+    ///
+    /// ⚠️ **速いのは Swift ネイティブの文字列に限る。** NSString 由来（`String(format:)`
+    /// の戻り値など）は連続バッファを持たず、`withUTF8` がそのたびにコピーを作る。
+    /// ここに流す行は自前のファイル読み込みから来るネイティブ文字列であること。
     func parseComponents(_ line: String) -> Components? {
-        let b = Array(line.utf8.prefix(Self.scanLimit))
-        switch format {
-        case .iso8601:      return Self.scanISO8601(b)
-        case .syslog:       return Self.scanSyslog(b)
-        case .apache:       return Self.scanApache(b)
-        case .epochSeconds: return Self.scanEpoch(b, millis: false)
-        case .epochMillis:  return Self.scanEpoch(b, millis: true)
+        var s = line
+        return s.withUTF8 { raw -> Components? in
+            guard let base = raw.baseAddress, !raw.isEmpty else { return nil }
+            let b = UnsafeBufferPointer(start: base, count: min(raw.count, Self.scanLimit))
+            switch format {
+            case .iso8601:      return Self.scanISO8601(b)
+            case .syslog:       return Self.scanSyslog(b)
+            case .apache:       return Self.scanApache(b)
+            case .epochSeconds: return Self.scanEpoch(b, millis: false)
+            case .epochMillis:  return Self.scanEpoch(b, millis: true)
+            }
         }
     }
 
@@ -174,7 +189,7 @@ struct TimestampDetector {
     // MARK: - スキャナ（いずれも失敗したら nil を返すだけ。例外も副作用も無い）
 
     /// `2026-07-30T12:34:56.789+09:00` / `2026-07-30 12:34:56,789` / 末尾 `Z`。
-    static func scanISO8601(_ b: [UInt8]) -> Components? {
+    static func scanISO8601(_ b: UnsafeBufferPointer<UInt8>) -> Components? {
         // 「4桁数字 + '-'」で始まる位置を探す
         var start = -1
         var i = 0
@@ -216,7 +231,7 @@ struct TimestampDetector {
     }
 
     /// `Jul 30 12:34:56`。年もタイムゾーンも無い。日は1桁のとき空白詰め（`Jul  3`）。
-    static func scanSyslog(_ b: [UInt8]) -> Components? {
+    static func scanSyslog(_ b: UnsafeBufferPointer<UInt8>) -> Components? {
         var p = 0
         while p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
         guard let month = readMonthName(b, &p) else { return nil }
@@ -233,7 +248,7 @@ struct TimestampDetector {
     }
 
     /// `[30/Jul/2026:12:34:56 +0900]`。前に IP やユーザ名が付くので `[` を探す。
-    static func scanApache(_ b: [UInt8]) -> Components? {
+    static func scanApache(_ b: UnsafeBufferPointer<UInt8>) -> Components? {
         guard var p = b.firstIndex(of: UInt8(ascii: "[")) else { return nil }
         p += 1
         guard let day = readInt(b, &p, 2) else { return nil }
@@ -252,7 +267,7 @@ struct TimestampDetector {
     ///
     /// 秒とミリ秒は桁数で分ける（10桁 / 13桁）。ここを緩くすると、行頭に ID を持つ
     /// ログを全部エポックとして誤読する。
-    static func scanEpoch(_ b: [UInt8], millis: Bool) -> Components? {
+    static func scanEpoch(_ b: UnsafeBufferPointer<UInt8>, millis: Bool) -> Components? {
         var p = 0
         while p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
         let head = p
@@ -298,14 +313,14 @@ struct TimestampDetector {
         (c >= 65 && c <= 90) || (c >= 97 && c <= 122)
     }
 
-    private static func expect(_ b: [UInt8], _ p: inout Int, _ ch: Character) -> Bool {
+    private static func expect(_ b: UnsafeBufferPointer<UInt8>, _ p: inout Int, _ ch: Character) -> Bool {
         guard p < b.count, b[p] == ch.asciiValue else { return false }
         p += 1
         return true
     }
 
     /// ちょうど `count` 桁の数字を読む。足りなければ位置を戻して nil。
-    private static func readInt(_ b: [UInt8], _ p: inout Int, _ count: Int) -> Int? {
+    private static func readInt(_ b: UnsafeBufferPointer<UInt8>, _ p: inout Int, _ count: Int) -> Int? {
         guard p + count <= b.count else { return nil }
         var v = 0
         for k in 0..<count {
@@ -320,7 +335,7 @@ struct TimestampDetector {
                                                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
         .map { Array($0.utf8) }
 
-    private static func readMonthName(_ b: [UInt8], _ p: inout Int) -> Int? {
+    private static func readMonthName(_ b: UnsafeBufferPointer<UInt8>, _ p: inout Int) -> Int? {
         guard p + 3 <= b.count else { return nil }
         for (idx, name) in monthNames.enumerated() where b[p] == name[0] && b[p+1] == name[1] && b[p+2] == name[2] {
             p += 3
@@ -335,7 +350,7 @@ struct TimestampDetector {
     /// `/var/log/install.log` が実際にこの形（`2025-07-18 08:15:05-07 localhost …`）。
     /// ここを取りこぼすと offset が nil になって既定のタイムゾーンに落ち、**数時間ずれた
     /// 時刻を正しい顔で返す**——複数ホストを束ねたときに最も見つけにくい壊れ方になる。
-    private static func readOffset(_ b: [UInt8], _ p: inout Int) -> Int? {
+    private static func readOffset(_ b: UnsafeBufferPointer<UInt8>, _ p: inout Int) -> Int? {
         guard p < b.count else { return nil }
         if b[p] == UInt8(ascii: "Z") || b[p] == UInt8(ascii: "z") { p += 1; return 0 }
         guard b[p] == UInt8(ascii: "+") || b[p] == UInt8(ascii: "-") else { return nil }

--- a/Sources/MrEditor/Core/TimestampDetector.swift
+++ b/Sources/MrEditor/Core/TimestampDetector.swift
@@ -1,0 +1,385 @@
+import Foundation
+
+/// ログ1行から時刻を取り出す純ロジック（UI 非依存）。
+///
+/// 設計の要点は3つ。
+///
+/// 1. **形式は行ごとでなくソースごとに1回だけ決める**（`detect(sampleLines:)` →
+///    `parse`）。`TabularFormatter` の `build`/`format` と同じ型。行ごとに総当たり
+///    すると遅い上に、同じファイルの中で行によって解釈が変わって並びが壊れる。
+/// 2. **`DateFormatter` も `NSRegularExpression` も使わない**。数百万行を通すので
+///    手書きで UTF-8 を走査し、暦計算も自前（`daysFromCivil`）で秒に落とす。
+/// 3. **年やタイムゾーンが「無い」形式がある**ことを型で認めている。syslog には年が
+///    無く、ISO でもオフセット無しの行がある。無いものは `Components` で `nil` の
+///    まま持ち上げ、補い方（`assumedYear` / `timeZoneOffset`）は呼び出し側の設定に
+///    する。ここで勝手に「今年・ローカル時刻」と決め打つと、去年のログを開いた瞬間に
+///    静かに間違う。
+enum TimestampFormat: String, CaseIterable {
+    /// `2026-07-30T12:34:56.789Z` / `2026-07-30 12:34:56,789` / オフセット有無どちらも。
+    case iso8601
+    /// `Jul 30 12:34:56`（RFC3164）。**年が無い。**
+    case syslog
+    /// `[30/Jul/2026:12:34:56 +0900]`（Apache/nginx の common log）。
+    case apache
+    /// `1754000000` / `1754000000.123`（10桁＝秒）。
+    case epochSeconds
+    /// `1754000000123`（13桁＝ミリ秒）。
+    case epochMillis
+}
+
+struct TimestampDetector {
+    /// 行から読み取れた「生の」時刻要素。埋まっていない欄は `nil` のまま持ち上げる。
+    struct Components: Equatable {
+        var year: Int?              // syslog は年を持たない
+        var month: Int
+        var day: Int
+        var hour: Int
+        var minute: Int
+        var second: Int
+        var fraction: Double        // 秒未満（0.0〜1.0 未満）
+        var utcOffset: Int?         // 行に明示されていた場合のみ（秒）
+    }
+
+    let format: TimestampFormat
+    /// 行にオフセットが書かれていないときに使う UTC オフセット（秒）。既定はローカル。
+    let timeZoneOffset: Int
+    /// 年を持たない形式（syslog）で使う年。
+    let assumedYear: Int
+
+    init(format: TimestampFormat,
+         timeZoneOffset: Int = TimeZone.current.secondsFromGMT(),
+         assumedYear: Int = Calendar(identifier: .gregorian)
+            .component(.year, from: Date())) {
+        self.format = format
+        self.timeZoneOffset = timeZoneOffset
+        self.assumedYear = assumedYear
+    }
+
+    // MARK: - 形式の判定
+
+    /// サンプル行から形式を決める。どれも当たらなければ `nil`（＝時刻を持たない
+    /// ファイルとして扱う）。命中数が最大の形式を採る。
+    ///
+    /// **1行でも当たれば候補にする**（`minimumHits` の既定は 1）。スタックトレース
+    /// のように時刻を持たない行が大半を占めるログが現実にあり、割合でしきいを切ると
+    /// そういうファイルだけ時刻無しに落ちてしまうため。日付形の3形式（ISO/syslog/
+    /// Apache）はパターンが十分に具体的なので、偶然当たることはまず無い。
+    ///
+    /// 危ないのは**エポックだけ**。「13桁の数字＋区切り」で始まる行は世の中にいくらでも
+    /// ある（国税庁の法人番号 CSV `1000012010001,01,…` が実例）。そこで**エポック系
+    /// にだけ追加の条件**を課す: 命中が3件以上あり、かつ**時刻がほぼ単調に増えている**
+    /// こと。ログの時刻は増え続けるが、ID の列は増えたり減ったりする。ここが両者を
+    /// 分ける唯一の実用的な差。
+    static func detect(sampleLines: [String],
+                       timeZoneOffset: Int = TimeZone.current.secondsFromGMT(),
+                       assumedYear: Int = Calendar(identifier: .gregorian)
+                        .component(.year, from: Date()),
+                       minimumHits: Int = 1) -> TimestampDetector? {
+        let rows = sampleLines.filter { !$0.isEmpty }
+        guard !rows.isEmpty else { return nil }
+
+        var best: (format: TimestampFormat, hits: Int)?
+        for f in TimestampFormat.allCases {
+            let d = TimestampDetector(format: f, timeZoneOffset: timeZoneOffset, assumedYear: assumedYear)
+            let parsed = rows.compactMap { d.parse($0) }
+            guard parsed.count >= max(1, minimumHits) else { continue }
+
+            if f == .epochSeconds || f == .epochMillis {
+                guard parsed.count >= 3, monotonicRatio(parsed) >= 0.9 else { continue }
+            }
+            if parsed.count > (best?.hits ?? 0) {
+                best = (f, parsed.count)
+            }
+        }
+        guard let best else { return nil }
+        return TimestampDetector(format: best.format, timeZoneOffset: timeZoneOffset, assumedYear: assumedYear)
+    }
+
+    /// 隣り合う値が「減っていない」割合。1.0 に近いほど時系列らしい。
+    static func monotonicRatio(_ values: [Date]) -> Double {
+        guard values.count >= 2 else { return 1.0 }
+        var ok = 0
+        for i in 1..<values.count where values[i] >= values[i - 1] { ok += 1 }
+        return Double(ok) / Double(values.count - 1)
+    }
+
+    // MARK: - 1行を解釈する
+
+    /// 1行から時刻を取り出す。取れなければ `nil`（＝継続行・見出し行など）。
+    func parse(_ line: String) -> Date? {
+        guard let c = parseComponents(line) else { return nil }
+        return date(from: c, year: c.year ?? assumedYear)
+    }
+
+    /// 複数行をまとめて解釈する。行数は入力と必ず一致する。
+    ///
+    /// `parse` を単に `map` するのと違い、**年を持たない形式の年またぎを補正する**。
+    /// 12月31日の次に1月1日が来ると、年を固定したままでは約11か月巻き戻って見え、
+    /// 並べ替えた瞬間にログが裏返る。時刻が2日以上巻き戻ったら年が変わったとみなす
+    /// （同一ソース内の行は時系列に並んでいる、という前提に依存している）。
+    func parseAll(_ lines: [String]) -> [Date?] {
+        var out: [Date?] = []
+        out.reserveCapacity(lines.count)
+        var yearShift = 0
+        var previous: Date?
+
+        for line in lines {
+            guard let c = parseComponents(line) else {
+                out.append(nil)
+                continue
+            }
+            if c.year != nil {
+                let d = date(from: c, year: c.year!)
+                out.append(d)
+                previous = d
+                continue
+            }
+            var d = date(from: c, year: assumedYear + yearShift)
+            if let prev = previous, d < prev.addingTimeInterval(-2 * 86400) {
+                yearShift += 1
+                d = date(from: c, year: assumedYear + yearShift)
+            }
+            out.append(d)
+            previous = d
+        }
+        return out
+    }
+
+    /// `Components` と年から実際の時刻を作る。行にオフセットがあればそれを、
+    /// 無ければ `timeZoneOffset` を使う。
+    func date(from c: Components, year: Int) -> Date {
+        let days = Self.daysFromCivil(year, c.month, c.day)
+        let secs = days * 86_400 + c.hour * 3_600 + c.minute * 60 + c.second
+        let offset = c.utcOffset ?? timeZoneOffset
+        return Date(timeIntervalSince1970: Double(secs - offset) + c.fraction)
+    }
+
+    // MARK: - 形式ごとの走査
+
+    func parseComponents(_ line: String) -> Components? {
+        let b = Array(line.utf8.prefix(Self.scanLimit))
+        switch format {
+        case .iso8601:      return Self.scanISO8601(b)
+        case .syslog:       return Self.scanSyslog(b)
+        case .apache:       return Self.scanApache(b)
+        case .epochSeconds: return Self.scanEpoch(b, millis: false)
+        case .epochMillis:  return Self.scanEpoch(b, millis: true)
+        }
+    }
+
+    /// 行頭から何バイトまで時刻を探すか。ログの時刻は行頭付近にあるという前提で、
+    /// 長い行の全走査を避ける。Apache は IP やユーザ名が前に付くので少し余裕を持つ。
+    static let scanLimit = 128
+
+    // MARK: - スキャナ（いずれも失敗したら nil を返すだけ。例外も副作用も無い）
+
+    /// `2026-07-30T12:34:56.789+09:00` / `2026-07-30 12:34:56,789` / 末尾 `Z`。
+    static func scanISO8601(_ b: [UInt8]) -> Components? {
+        // 「4桁数字 + '-'」で始まる位置を探す
+        var start = -1
+        var i = 0
+        while i + 4 < b.count {
+            if isDigit(b[i]), isDigit(b[i+1]), isDigit(b[i+2]), isDigit(b[i+3]), b[i+4] == UInt8(ascii: "-") {
+                start = i
+                break
+            }
+            i += 1
+        }
+        guard start >= 0 else { return nil }
+
+        var p = start
+        guard let year = readInt(b, &p, 4) else { return nil }
+        guard expect(b, &p, "-"), let month = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, "-"), let day = readInt(b, &p, 2) else { return nil }
+        // 日付と時刻の区切りは 'T' でも ' ' でもよい
+        guard p < b.count, b[p] == UInt8(ascii: "T") || b[p] == UInt8(ascii: " ") else { return nil }
+        p += 1
+        guard let hour = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, ":"), let minute = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, ":"), let second = readInt(b, &p, 2) else { return nil }
+
+        // 秒未満は '.' でも ',' でもよい（Java 系のログは ','）
+        var fraction = 0.0
+        if p < b.count, b[p] == UInt8(ascii: ".") || b[p] == UInt8(ascii: ",") {
+            p += 1
+            var scale = 0.1
+            while p < b.count, isDigit(b[p]) {
+                fraction += Double(b[p] - 48) * scale
+                scale /= 10
+                p += 1
+            }
+        }
+
+        guard valid(month: month, day: day, hour: hour, minute: minute, second: second) else { return nil }
+        return Components(year: year, month: month, day: day, hour: hour, minute: minute,
+                          second: second, fraction: fraction, utcOffset: readOffset(b, &p))
+    }
+
+    /// `Jul 30 12:34:56`。年もタイムゾーンも無い。日は1桁のとき空白詰め（`Jul  3`）。
+    static func scanSyslog(_ b: [UInt8]) -> Components? {
+        var p = 0
+        while p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
+        guard let month = readMonthName(b, &p) else { return nil }
+        while p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
+        guard let day = readInt(b, &p, 2) ?? readInt(b, &p, 1) else { return nil }
+        guard expect(b, &p, " ") else { return nil }
+        while p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
+        guard let hour = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, ":"), let minute = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, ":"), let second = readInt(b, &p, 2) else { return nil }
+        guard valid(month: month, day: day, hour: hour, minute: minute, second: second) else { return nil }
+        return Components(year: nil, month: month, day: day, hour: hour, minute: minute,
+                          second: second, fraction: 0, utcOffset: nil)
+    }
+
+    /// `[30/Jul/2026:12:34:56 +0900]`。前に IP やユーザ名が付くので `[` を探す。
+    static func scanApache(_ b: [UInt8]) -> Components? {
+        guard var p = b.firstIndex(of: UInt8(ascii: "[")) else { return nil }
+        p += 1
+        guard let day = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, "/"), let month = readMonthName(b, &p) else { return nil }
+        guard expect(b, &p, "/"), let year = readInt(b, &p, 4) else { return nil }
+        guard expect(b, &p, ":"), let hour = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, ":"), let minute = readInt(b, &p, 2) else { return nil }
+        guard expect(b, &p, ":"), let second = readInt(b, &p, 2) else { return nil }
+        guard valid(month: month, day: day, hour: hour, minute: minute, second: second) else { return nil }
+        if p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
+        return Components(year: year, month: month, day: day, hour: hour, minute: minute,
+                          second: second, fraction: 0, utcOffset: readOffset(b, &p))
+    }
+
+    /// 行頭の `1754000000` / `1754000000.123` / `1754000000123`。
+    ///
+    /// 秒とミリ秒は桁数で分ける（10桁 / 13桁）。ここを緩くすると、行頭に ID を持つ
+    /// ログを全部エポックとして誤読する。
+    static func scanEpoch(_ b: [UInt8], millis: Bool) -> Components? {
+        var p = 0
+        while p < b.count, b[p] == UInt8(ascii: " ") { p += 1 }
+        let head = p
+        var value = 0
+        while p < b.count, isDigit(b[p]) {
+            value = value * 10 + Int(b[p] - 48)
+            p += 1
+        }
+        let digits = p - head
+        guard digits == (millis ? 13 : 10) else { return nil }
+
+        var seconds = value
+        var fraction = 0.0
+        if millis {
+            seconds = value / 1000
+            fraction = Double(value % 1000) / 1000
+        } else if p < b.count, b[p] == UInt8(ascii: ".") {
+            p += 1
+            var scale = 0.1
+            while p < b.count, isDigit(b[p]) {
+                fraction += Double(b[p] - 48) * scale
+                scale /= 10
+                p += 1
+            }
+        }
+        // 数字の直後が英数字なら時刻ではなく ID の一部とみなす
+        if p < b.count, isDigit(b[p]) || isLetter(b[p]) { return nil }
+
+        // エポックは定義上 UTC。暦へ戻して Components に載せる。
+        let days = Int(floor(Double(seconds) / 86_400))
+        let rem = seconds - days * 86_400
+        let (y, m, d) = civilFromDays(days)
+        return Components(year: y, month: m, day: d,
+                          hour: rem / 3600, minute: (rem % 3600) / 60, second: rem % 60,
+                          fraction: fraction, utcOffset: 0)
+    }
+
+    // MARK: - 細かい部品
+
+    private static func isDigit(_ c: UInt8) -> Bool { c >= 48 && c <= 57 }
+
+    private static func isLetter(_ c: UInt8) -> Bool {
+        (c >= 65 && c <= 90) || (c >= 97 && c <= 122)
+    }
+
+    private static func expect(_ b: [UInt8], _ p: inout Int, _ ch: Character) -> Bool {
+        guard p < b.count, b[p] == ch.asciiValue else { return false }
+        p += 1
+        return true
+    }
+
+    /// ちょうど `count` 桁の数字を読む。足りなければ位置を戻して nil。
+    private static func readInt(_ b: [UInt8], _ p: inout Int, _ count: Int) -> Int? {
+        guard p + count <= b.count else { return nil }
+        var v = 0
+        for k in 0..<count {
+            guard isDigit(b[p + k]) else { return nil }
+            v = v * 10 + Int(b[p + k] - 48)
+        }
+        p += count
+        return v
+    }
+
+    private static let monthNames: [[UInt8]] = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+        .map { Array($0.utf8) }
+
+    private static func readMonthName(_ b: [UInt8], _ p: inout Int) -> Int? {
+        guard p + 3 <= b.count else { return nil }
+        for (idx, name) in monthNames.enumerated() where b[p] == name[0] && b[p+1] == name[1] && b[p+2] == name[2] {
+            p += 3
+            return idx + 1
+        }
+        return nil
+    }
+
+    /// `Z` / `+09:00` / `-0500` / `-07` を秒で返す。無ければ nil（＝呼び出し側の既定を使う）。
+    ///
+    /// **分を省いた2桁だけの `-07` を必ず受けること。** macOS の
+    /// `/var/log/install.log` が実際にこの形（`2025-07-18 08:15:05-07 localhost …`）。
+    /// ここを取りこぼすと offset が nil になって既定のタイムゾーンに落ち、**数時間ずれた
+    /// 時刻を正しい顔で返す**——複数ホストを束ねたときに最も見つけにくい壊れ方になる。
+    private static func readOffset(_ b: [UInt8], _ p: inout Int) -> Int? {
+        guard p < b.count else { return nil }
+        if b[p] == UInt8(ascii: "Z") || b[p] == UInt8(ascii: "z") { p += 1; return 0 }
+        guard b[p] == UInt8(ascii: "+") || b[p] == UInt8(ascii: "-") else { return nil }
+        let sign = b[p] == UInt8(ascii: "-") ? -1 : 1
+        var q = p + 1
+        guard let hh = readInt(b, &q, 2) else { return nil }
+        var mm = 0
+        var r = q
+        if r < b.count, b[r] == UInt8(ascii: ":") { r += 1 }
+        if let m = readInt(b, &r, 2) { mm = m; q = r }   // 分が無ければ hh だけで確定
+        p = q
+        return sign * (hh * 3600 + mm * 60)
+    }
+
+    private static func valid(month: Int, day: Int, hour: Int, minute: Int, second: Int) -> Bool {
+        (1...12).contains(month) && (1...31).contains(day)
+            && (0...23).contains(hour) && (0...59).contains(minute) && (0...60).contains(second)
+    }
+
+    // MARK: - 暦（Howard Hinnant の days_from_civil / civil_from_days）
+    //
+    // Calendar/DateComponents は1行ごとに呼ぶには重すぎるので、グレゴリオ暦の
+    // 変換だけ整数演算で持つ。うるう年・世紀の例外はこの式に含まれている。
+
+    static func daysFromCivil(_ year: Int, _ month: Int, _ day: Int) -> Int {
+        var y = year
+        y -= month <= 2 ? 1 : 0
+        let era = (y >= 0 ? y : y - 399) / 400
+        let yoe = y - era * 400                                   // 0..399
+        let doy = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy
+        return era * 146_097 + doe - 719_468
+    }
+
+    static func civilFromDays(_ days: Int) -> (year: Int, month: Int, day: Int) {
+        let z = days + 719_468
+        let era = (z >= 0 ? z : z - 146_096) / 146_097
+        let doe = z - era * 146_097                               // 0..146096
+        let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365
+        let y = yoe + era * 400
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100)         // 0..365
+        let mp = (5 * doy + 2) / 153                              // 0..11
+        let d = doy - (153 * mp + 2) / 5 + 1
+        let m = mp + (mp < 10 ? 3 : -9)
+        return (y + (m <= 2 ? 1 : 0), m, d)
+    }
+}

--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -1291,4 +1291,44 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
             if response == .OK { panel.urls.forEach { self?.open(url: $0) } }
         }
     }
+
+    // MARK: - 時系列でまとめて開く
+
+    /// 複数のログを選び、時刻で1本に束ねて開く。
+    ///
+    /// 束ねた結果は一時ファイルに書いて**通常の「開く」経路**へ渡す。専用ビューアを
+    /// 作らないので、検索・フィルタ・構造化表示・別名保存が全部そのまま効く。
+    @objc func openMergedByTime(_ sender: Any?) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = true
+        panel.message = L("merge.open.message")
+        panel.prompt = L("merge.open.prompt")
+        panel.begin { [weak self] response in
+            guard response == .OK, let self else { return }
+            self.mergeByTime(urls: panel.urls)
+        }
+    }
+
+    /// 実際に束ねて開く。読み込みと並べ替えは背景で行い、UI は結果だけ受け取る。
+    func mergeByTime(urls: [URL]) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let builder = MergedLogBuilder()
+            do {
+                let result = try builder.build(urls: urls)
+                DispatchQueue.main.async { [weak self] in
+                    self?.open(url: result.url)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    let alert = NSAlert()
+                    alert.messageText = L("merge.failedTitle")
+                    alert.informativeText = error.localizedDescription
+                    alert.alertStyle = .warning
+                    alert.runModal()
+                }
+            }
+        }
+    }
 }

--- a/Sources/MrEditor/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,17 @@
 "menu.file" = "File";
 "menu.new" = "New";
 "menu.open" = "Open…";
+"menu.openMerged" = "Open Merged by Time…";
+"merge.open.message" = "Choose two or more logs to merge into one timeline.";
+"merge.open.prompt" = "Merge and Open";
+"merge.failedTitle" = "Could not merge by time";
+"merge.error.needsTwoFiles" = "Merging needs at least two files.";
+"merge.error.tooLarge" = "The selected files total %@, over the %@ limit. Merging has to read every timestamp before the first line is known, so there is a limit here.";
+"merge.error.unreadable" = "Could not read %@.";
+"merge.warn.noTimestamp" = "No timestamps found in %@. Its lines are placed at the end.";
+"merge.header.title" = "Merged timeline — %1$d files / %2$d lines";
+"merge.header.lines" = "%1$d lines, %2$d with a timestamp";
+"merge.header.noFormat" = "no timestamp";
 "menu.openRecent" = "Open Recent";
 "menu.recentEmpty" = "No Recent Files";
 "menu.clearRecent" = "Clear Menu";

--- a/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditor/Resources/ja.lproj/Localizable.strings
@@ -11,6 +11,17 @@
 "menu.file" = "ファイル";
 "menu.new" = "新規";
 "menu.open" = "開く…";
+"menu.openMerged" = "時系列でまとめて開く…";
+"merge.open.message" = "時刻で1本に束ねるログを 2 つ以上選んでください。";
+"merge.open.prompt" = "束ねて開く";
+"merge.failedTitle" = "時系列でまとめられませんでした";
+"merge.error.needsTwoFiles" = "束ねるにはファイルが 2 つ以上必要です。";
+"merge.error.tooLarge" = "選んだファイルの合計が %@ で、上限の %@ を超えています。束ねるには全行の時刻を先に読む必要があるため、ここは上限を設けています。";
+"merge.error.unreadable" = "%@ を読めませんでした。";
+"merge.warn.noTimestamp" = "%@ からは時刻を見つけられませんでした。この行は末尾にまとめて並びます。";
+"merge.header.title" = "時系列マージ — %1$d ファイル / %2$d 行";
+"merge.header.lines" = "%1$d 行・うち時刻あり %2$d 行";
+"merge.header.noFormat" = "時刻なし";
 "menu.openRecent" = "最近使った項目を開く";
 "menu.recentEmpty" = "最近使った項目はありません";
 "menu.clearRecent" = "メニューを消去";

--- a/Tests/MrEditorTests/LogMergeTests.swift
+++ b/Tests/MrEditorTests/LogMergeTests.swift
@@ -1,0 +1,331 @@
+import XCTest
+@testable import MrEditor
+
+/// 時刻の読み取り（`TimestampDetector`）と、複数ログの時系列統合（`LogMerger`）。
+///
+/// 時刻の期待値はすべてエポック秒の実数で書く。`DateFormatter` で期待値を作ると
+/// テスト自身が実装と同じ勘違いをしても気づけないため。
+/// 2026-07-30T12:34:56Z = 1785414896（`date -u -r 1785414896` で確認）。
+final class LogMergeTests: XCTestCase {
+
+    private let base = 1_785_414_896.0     // 2026-07-30 12:34:56 UTC
+    private let jst = 9 * 3600
+
+    private func epoch(_ d: Date?) -> Double? { d?.timeIntervalSince1970 }
+
+    // MARK: - ISO8601
+
+    func testISO8601WithZuluAndOffset() {
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: 0)
+        XCTAssertEqual(epoch(d.parse("2026-07-30T12:34:56Z hello")), base)
+        // +09:00 の 21:34:56 は UTC の 12:34:56 と同じ瞬間
+        XCTAssertEqual(epoch(d.parse("2026-07-30T21:34:56+09:00 hello")), base)
+        XCTAssertEqual(epoch(d.parse("2026-07-30T07:34:56-0500 hello")), base)
+    }
+
+    func testISO8601SpaceSeparatorAndCommaMillis() {
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: 0)
+        // Java 系ログの "," 区切りミリ秒
+        XCTAssertEqual(epoch(d.parse("2026-07-30 12:34:56,250 ERROR boom"))!, base + 0.25, accuracy: 1e-9)
+        XCTAssertEqual(epoch(d.parse("2026-07-30T12:34:56.500Z"))!, base + 0.5, accuracy: 1e-9)
+    }
+
+    /// オフセットが書かれていない行は、行ごとに勝手に決めず設定側の既定を使う。
+    func testISO8601WithoutOffsetUsesConfiguredZone() {
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: jst)
+        XCTAssertEqual(epoch(d.parse("2026-07-30 21:34:56 hello")), base)
+    }
+
+    func testISO8601RejectsNonTimestampLines() {
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: 0)
+        XCTAssertNil(d.parse("    at com.example.Foo.bar(Foo.java:42)"))
+        XCTAssertNil(d.parse(""))
+        XCTAssertNil(d.parse("2026-13-99T99:99:99Z"))   // 範囲外は撥ねる
+    }
+
+    // MARK: - syslog（年が無い）
+
+    func testSyslogUsesAssumedYearAndPadsSingleDigitDay() {
+        let d = TimestampDetector(format: .syslog, timeZoneOffset: 0, assumedYear: 2026)
+        XCTAssertEqual(epoch(d.parse("Jul 30 12:34:56 web-1 sshd[1]: ok")), base)
+        // 1桁の日は空白詰め（Jul  3）
+        let three = d.parse("Jul  3 00:00:00 web-1 sshd[1]: ok")
+        XCTAssertEqual(epoch(three), base - 27 * 86_400 - 45_296)
+    }
+
+    /// 12月31日 → 1月1日。年を固定したままだと約11か月巻き戻り、並べ替えでログが裏返る。
+    func testSyslogYearRollover() {
+        let d = TimestampDetector(format: .syslog, timeZoneOffset: 0, assumedYear: 2026)
+        let times = d.parseAll([
+            "Dec 31 23:59:58 web-1 last of the year",
+            "Dec 31 23:59:59 web-1 still 2026",
+            "Jan  1 00:00:00 web-1 happy new year",
+            "Jan  1 00:00:01 web-1 still 2027",
+        ])
+        let secs = times.map { $0!.timeIntervalSince1970 }
+        XCTAssertEqual(secs, secs.sorted(), "年またぎで時刻が巻き戻ってはいけない")
+        XCTAssertEqual(secs[2] - secs[1], 1.0, accuracy: 1e-9)
+    }
+
+    // MARK: - Apache
+
+    func testApacheCommonLog() {
+        let d = TimestampDetector(format: .apache, timeZoneOffset: 0)
+        let line = #"127.0.0.1 - alice [30/Jul/2026:21:34:56 +0900] "GET / HTTP/1.1" 200 42"#
+        XCTAssertEqual(epoch(d.parse(line)), base)
+    }
+
+    // MARK: - エポック
+
+    func testEpochSecondsAndMillis() {
+        let s = TimestampDetector(format: .epochSeconds, timeZoneOffset: jst)
+        XCTAssertEqual(epoch(s.parse("1754000000 started")), 1_754_000_000)
+        XCTAssertEqual(epoch(s.parse("1754000000.250 started"))!, 1_754_000_000.25, accuracy: 1e-9)
+
+        let m = TimestampDetector(format: .epochMillis, timeZoneOffset: jst)
+        XCTAssertEqual(epoch(m.parse("1754000000123 started"))!, 1_754_000_000.123, accuracy: 1e-6)
+    }
+
+    /// 行頭に ID を持つログをエポックとして誤読しないこと（桁数と直後の文字で弾く）。
+    func testEpochRejectsIdLikePrefix() {
+        let s = TimestampDetector(format: .epochSeconds, timeZoneOffset: 0)
+        XCTAssertNil(s.parse("12345 short id"))
+        XCTAssertNil(s.parse("1754000000123 これは13桁なので秒ではない"))
+        XCTAssertNil(s.parse("1754000000abc trailing letters"))
+    }
+
+    // MARK: - 形式の自動判定
+
+    func testDetectPicksTheRightFormat() {
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: [
+            "2026-07-30T12:34:56Z a", "2026-07-30T12:34:57Z b",
+        ])?.format, .iso8601)
+
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: [
+            "Jul 30 12:34:56 web-1 a", "Jul 30 12:34:57 web-1 b",
+        ])?.format, .syslog)
+
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: [
+            #"127.0.0.1 - - [30/Jul/2026:12:34:56 +0900] "GET / HTTP/1.1" 200 1"#,
+        ])?.format, .apache)
+
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: [
+            "1754000000 a", "1754000001 b", "1754000002 c",
+        ])?.format, .epochSeconds)
+    }
+
+    /// 国税庁の法人番号 CSV は先頭が13桁の数字＝そのままではエポックミリ秒に見える。
+    /// 実データで踏む誤判定なので、単調でないことを根拠に撥ねる。
+    func testDetectRejectsIdColumnThatLooksLikeEpochMillis() {
+        let corporateNumbers = [
+            "1000012010001,01,2018-04-02,内閣官房",
+            "5000012050002,01,2018-04-02,法務省",
+            "2000012060001,01,2018-04-02,財務省",
+            "9000012070001,01,2018-04-02,文部科学省",
+            "4000012090001,01,2018-04-02,厚生労働省",
+        ]
+        XCTAssertNil(TimestampDetector.detect(sampleLines: corporateNumbers),
+                     "ID の列を時刻と誤読してはいけない")
+    }
+
+    /// 逆に、本物のエポックミリ秒のログはちゃんと通る。
+    func testDetectAcceptsMonotonicEpochMillis() {
+        let lines = (0..<5).map { "175400000\($0)123 event" }
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: lines)?.format, .epochMillis)
+    }
+
+    func testMonotonicRatio() {
+        let t = { (s: Double) in Date(timeIntervalSince1970: s) }
+        XCTAssertEqual(TimestampDetector.monotonicRatio([t(1), t(2), t(3)]), 1.0)
+        XCTAssertEqual(TimestampDetector.monotonicRatio([t(3), t(2), t(1)]), 0.0)
+        XCTAssertEqual(TimestampDetector.monotonicRatio([t(1)]), 1.0, "1件では判断しない")
+    }
+
+    /// 時刻を持たないファイルは nil（＝時刻なしとして扱い、勝手に何かに当てはめない）。
+    func testDetectReturnsNilForTimestamplessInput() {
+        XCTAssertNil(TimestampDetector.detect(sampleLines: [
+            "hello world", "just some text", "no timestamps here",
+        ]))
+        XCTAssertNil(TimestampDetector.detect(sampleLines: []))
+    }
+
+    /// 時刻を持たない行が大半でも、少数でも当たれば形式は決まる（スタックトレース主体のログ）。
+    func testDetectSurvivesMostlyTimestamplessInput() {
+        var lines = ["2026-07-30T12:34:56Z ERROR boom"]
+        lines += (0..<30).map { "    at com.example.Foo.bar(Foo.java:\($0))" }
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: lines)?.format, .iso8601)
+    }
+
+    // MARK: - 実ログからの写し
+    //
+    // 以下の行は実際に macOS 上のログから採ったもの。作った入力だけでテストすると、
+    // 自分が想像した形式しか通らないことに気づけない（実際 2桁オフセットはここで出た）。
+
+    /// `/var/log/install.log`。オフセットが `-07` と**2桁**。分が無い。
+    func testRealInstallLogHasTwoDigitOffset() {
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: jst)   // 既定は JST にしておく
+        let line = "2025-07-18 08:15:05-07 localhost Installer Progress[56]: Progress UI App Starting"
+        // -07 を読めていれば 15:15:05Z。読み落として JST 既定に落ちると 23:15:05Z になる。
+        XCTAssertEqual(epoch(d.parse(line)), 1_752_851_705, "2桁オフセットを取りこぼすと数時間ずれる")
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: [line])?.format, .iso8601)
+    }
+
+    /// `/var/log/system.log`。素の syslog。
+    func testRealSystemLog() {
+        let lines = [
+            "Aug  4 00:04:03 Mac-mini-m1-2 syslogd[363]: ASL Sender Statistics",
+            "Aug  4 00:21:06 Mac-mini-m1-2 syslogd[363]: ASL Sender Statistics",
+        ]
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: lines)?.format, .syslog)
+        let d = TimestampDetector(format: .syslog, timeZoneOffset: 0, assumedYear: 2026)
+        XCTAssertNotNil(d.parse(lines[0]))
+    }
+
+    /// `/var/log/wifi.log` は syslog 行と `Tue Aug  4 …` 行が混ざっている。
+    /// 曜日つきの行は読めなくてよいが、**ファイル全体の判定は syslog に落ち着く**こと。
+    func testRealWifiLogWithMixedWeekdayPrefix() {
+        let lines = [
+            "Aug  4 00:39:29 Mac-mini-m1-2 newsyslog[17283]: logfile turned over",
+            "Tue Aug  4 00:39:29.475 [airport]/420 @[276161.593952] dq:'com.apple.main-thread'",
+        ]
+        XCTAssertEqual(TimestampDetector.detect(sampleLines: lines)?.format, .syslog)
+        let d = TimestampDetector(format: .syslog, timeZoneOffset: 0, assumedYear: 2026)
+        XCTAssertNotNil(d.parse(lines[0]))
+        XCTAssertNil(d.parse(lines[1]), "曜日つきは読めないが、継続行として扱えばよい")
+    }
+
+    // MARK: - 暦
+
+    func testCivilRoundTripAcrossLeapRules() {
+        for (y, m, d) in [(1970, 1, 1), (2000, 2, 29), (1900, 3, 1), (2024, 2, 29), (2026, 12, 31)] {
+            let days = TimestampDetector.daysFromCivil(y, m, d)
+            let back = TimestampDetector.civilFromDays(days)
+            XCTAssertEqual(back.year, y)
+            XCTAssertEqual(back.month, m)
+            XCTAssertEqual(back.day, d)
+        }
+        XCTAssertEqual(TimestampDetector.daysFromCivil(1970, 1, 1), 0)
+    }
+
+    // MARK: - 実効時刻（継続行の引き継ぎ）
+
+    func testEffectiveTimesCarriesForwardAndBackfillsHead() {
+        let t0 = Date(timeIntervalSince1970: 100)
+        let t1 = Date(timeIntervalSince1970: 200)
+        let got = LogMerger.effectiveTimes([nil, t0, nil, nil, t1, nil])
+        XCTAssertEqual(got.map { $0?.timeIntervalSince1970 },
+                       [100, 100, 100, 100, 200, 200],
+                       "継続行は直前の時刻を引き継ぎ、冒頭の見出し行は最初の時刻を借りる")
+    }
+
+    func testEffectiveTimesWithNoTimestampsAtAll() {
+        XCTAssertEqual(LogMerger.effectiveTimes([nil, nil, nil]).compactMap { $0 }.count, 0)
+    }
+
+    func testEffectiveTimesAppliesClockOffset() {
+        let t = Date(timeIntervalSince1970: 100)
+        let got = LogMerger.effectiveTimes([t], clockOffset: -1.5)
+        XCTAssertEqual(got[0]?.timeIntervalSince1970, 98.5)
+    }
+
+    // MARK: - 統合
+
+    private func at(_ s: Double) -> Date { Date(timeIntervalSince1970: s) }
+
+    func testMergeInterleavesByTime() {
+        let a = LogMerger.Source(label: "web-1", times: [at(10), at(30)])
+        let b = LogMerger.Source(label: "web-2", times: [at(20), at(40)])
+        let got = LogMerger.merge([a, b])
+        XCTAssertEqual(got.map { [$0.source, $0.line] }, [[0, 0], [1, 0], [0, 1], [1, 1]])
+        XCTAssertEqual(got.map { $0.time?.timeIntervalSince1970 }, [10, 20, 30, 40])
+    }
+
+    /// これが `sort -m` と決定的に違うところ。継続行が親から引き剥がされない。
+    func testMergeKeepsContinuationLinesWithTheirParent() {
+        let a = LogMerger.Source(label: "app", times: [at(10), nil, nil, at(30)])   // 10 の直後にスタックトレース2行
+        let b = LogMerger.Source(label: "db", times: [at(20)])
+        let got = LogMerger.merge([a, b])
+
+        XCTAssertEqual(got.map { [$0.source, $0.line] },
+                       [[0, 0], [0, 1], [0, 2], [1, 0], [0, 3]],
+                       "時刻を持たない継続行は親の直後に残ること")
+        XCTAssertEqual(got.map { $0.hasOwnTimestamp }, [true, false, false, true, true])
+    }
+
+    /// 同時刻が並んでも順序が揺れない（開くたびに並びが変わらない）。
+    func testMergeIsStableOnEqualTimestamps() {
+        let a = LogMerger.Source(label: "a", times: [at(10), at(10)])
+        let b = LogMerger.Source(label: "b", times: [at(10), at(10)])
+        let got = LogMerger.merge([a, b])
+        XCTAssertEqual(got.map { [$0.source, $0.line] }, [[0, 0], [0, 1], [1, 0], [1, 1]])
+        XCTAssertEqual(LogMerger.merge([a, b]), got, "同じ入力なら常に同じ結果")
+    }
+
+    /// NTP がずれた1台。補正しないと因果が逆に見える。
+    func testMergeAppliesClockOffset() {
+        let slow = LogMerger.Source(label: "slow", times: [at(25)], clockOffset: -10)  // 実際は 15
+        let other = LogMerger.Source(label: "other", times: [at(20)])
+        XCTAssertEqual(LogMerger.merge([slow, other]).map { $0.source }, [0, 1])
+
+        let uncorrected = LogMerger.Source(label: "slow", times: [at(25)])
+        XCTAssertEqual(LogMerger.merge([uncorrected, other]).map { $0.source }, [1, 0])
+    }
+
+    /// 時刻を1つも持たないソースは、時刻を持つ行を全部出したあとに続く。
+    func testMergePlacesTimestamplessSourceLast() {
+        let timed = LogMerger.Source(label: "timed", times: [at(10), at(20)])
+        let plain = LogMerger.Source(label: "plain", times: [nil, nil])
+        let got = LogMerger.merge([plain, timed])
+        XCTAssertEqual(got.map { [$0.source, $0.line] }, [[1, 0], [1, 1], [0, 0], [0, 1]])
+    }
+
+    /// 何があっても行を落とさない・増やさない。
+    func testMergePreservesEveryLine() {
+        let sources = [
+            LogMerger.Source(label: "a", times: [at(5), nil, at(50)]),
+            LogMerger.Source(label: "b", times: []),
+            LogMerger.Source(label: "c", times: [nil, at(1), nil, nil]),
+        ]
+        let got = LogMerger.merge(sources)
+        XCTAssertEqual(got.count, 7)
+        for (i, s) in sources.enumerated() {
+            let lines = got.filter { $0.source == i }.map { $0.line }
+            XCTAssertEqual(lines, Array(0..<s.times.count), "ソース内の行順は必ず保たれる")
+        }
+    }
+
+    func testMergeOfNothing() {
+        XCTAssertTrue(LogMerger.merge([]).isEmpty)
+        XCTAssertTrue(LogMerger.merge([LogMerger.Source(label: "empty", times: [])]).isEmpty)
+    }
+
+    // MARK: - 検出から統合まで通しで
+
+    func testEndToEndThreeHostsWithSkewAndStackTrace() {
+        let web1 = [
+            "2026-07-30T12:34:56Z GET /health 200",
+            "2026-07-30T12:34:58Z GET /buy 500",
+        ]
+        let app = [
+            "2026-07-30T12:34:57Z ERROR NullPointerException",
+            "    at com.example.Checkout.pay(Checkout.java:88)",
+            "    at com.example.Web.handle(Web.java:12)",
+        ]
+        let db = ["2026-07-30T12:34:59Z slow query 3200ms"]
+
+        let d = TimestampDetector.detect(sampleLines: web1 + app + db, timeZoneOffset: 0)
+        XCTAssertEqual(d?.format, .iso8601)
+        guard let d else { return XCTFail("形式を判定できなかった") }
+
+        let merged = LogMerger.merge([
+            LogMerger.Source(label: "web-1", times: d.parseAll(web1)),
+            LogMerger.Source(label: "app", times: d.parseAll(app)),
+            LogMerger.Source(label: "db", times: d.parseAll(db), clockOffset: -2),  // 2秒進んだ時計
+        ])
+
+        // db は記録上 12:34:59 だが 2 秒進んでいるので実際は 12:34:57 → app の直後
+        XCTAssertEqual(merged.map { [$0.source, $0.line] },
+                       [[0, 0], [1, 0], [1, 1], [1, 2], [2, 0], [0, 1]])
+        XCTAssertEqual(merged.count, web1.count + app.count + db.count)
+    }
+}

--- a/Tests/MrEditorTests/MergedLogBuilderTests.swift
+++ b/Tests/MrEditorTests/MergedLogBuilderTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import MrEditor
+
+/// ファイルを読んで束ねるところまで（`MergedLogBuilder`）。
+///
+/// 形式が**ファイルごとに違う**のが現実の使い方なので、そこを主眼に置く。
+/// nginx（Apache 形式）とアプリログ（ISO）と DB（syslog）を一緒に束ねたとき、
+/// 全体で1つの形式に決めつけると片方が丸ごと継続行になって時系列が崩れる。
+final class MergedLogBuilderTests: XCTestCase {
+
+    private var dir: URL!
+
+    override func setUpWithError() throws {
+        dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("merge-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    @discardableResult
+    private func write(_ name: String, _ body: String) throws -> URL {
+        let u = dir.appendingPathComponent(name)
+        try body.write(to: u, atomically: true, encoding: .utf8)
+        return u
+    }
+
+    /// JST 固定で組み立てる（実行環境のタイムゾーンに結果を左右されないため）。
+    private var builder: MergedLogBuilder {
+        MergedLogBuilder(displayOffset: 9 * 3600, assumedOffset: 9 * 3600, assumedYear: 2026)
+    }
+
+    private let nginx = """
+    10.0.1.4 - - [30/Jul/2026:12:34:55 +0900] "GET /health HTTP/1.1" 200 2
+    10.0.1.9 - alice [30/Jul/2026:12:34:57 +0900] "POST /api/checkout HTTP/1.1" 500 512
+    """
+
+    private let app = """
+    2026-07-30T12:34:56.120+09:00 INFO  checkout start order=88213
+    2026-07-30T12:34:57.004+09:00 ERROR NullPointerException in Checkout.pay
+        at com.example.Checkout.pay(Checkout.java:88)
+    """
+
+    private let db = """
+    Jul 30 12:34:56 db-1 postgres[812]: LOG:  duration: 41.2 ms
+    Jul 30 12:34:58 db-1 postgres[812]: LOG:  duration: 3208.9 ms
+    """
+
+    /// 3つの形式が混ざっていても、ファイルごとに判定して1本の時系列になる。
+    func testMergesThreeDifferentFormats() throws {
+        let a = try write("nginx-access.log", nginx)
+        let b = try write("app.log", app)
+        let c = try write("db-syslog.log", db)
+
+        let r = try builder.build(urls: [a, b, c], into: dir)
+        XCTAssertEqual(r.sources.map { $0.format },
+                       [.apache, .iso8601, .syslog],
+                       "形式はファイルごとに決めること")
+        XCTAssertTrue(r.warnings.isEmpty)
+
+        let body = try String(contentsOf: r.url, encoding: .utf8)
+        let rows = body.split(separator: "\n").filter { !$0.hasPrefix("#") }.map(String.init)
+
+        // 12:34:55 nginx → 12:34:56.120 app → 12:34:56 db … の順に並ぶ
+        let labels = rows.map { row -> String in
+            let parts = row.split(separator: "│", maxSplits: 2).map { $0.trimmingCharacters(in: .whitespaces) }
+            return parts.count >= 2 ? parts[1] : ""
+        }
+        XCTAssertEqual(labels, ["nginx-access", "db-syslog", "app", "nginx-access", "app", "app", "db-syslog"])
+    }
+
+    /// 出力の時刻欄が単調に増えること（＝並べ替えが効いている、の最短の確認）。
+    func testOutputTimestampsAreMonotonic() throws {
+        let a = try write("nginx-access.log", nginx)
+        let b = try write("app.log", app)
+        let r = try builder.build(urls: [a, b], into: dir)
+
+        let stamps = try String(contentsOf: r.url, encoding: .utf8)
+            .split(separator: "\n")
+            .filter { !$0.hasPrefix("#") }
+            .map { String($0.prefix(23)) }
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        XCTAssertEqual(stamps, stamps.sorted(), "束ねた結果の時刻は増加していること")
+    }
+
+    /// 継続行は時刻欄を空にする。親の時刻を引き継いでいるだけなので、
+    /// そこに数字を出すと「その行自身の時刻」に見えて嘘になる。
+    func testContinuationLinesHaveBlankTimeColumn() throws {
+        let a = try write("app.log", app)
+        let b = try write("db-syslog.log", db)
+        let r = try builder.build(urls: [a, b], into: dir)
+
+        let stackLine = try String(contentsOf: r.url, encoding: .utf8)
+            .split(separator: "\n")
+            .first { $0.contains("Checkout.java:88") }
+        XCTAssertNotNil(stackLine)
+        XCTAssertTrue(String(stackLine!.prefix(23)).trimmingCharacters(in: .whitespaces).isEmpty,
+                      "継続行の時刻欄は空であること")
+    }
+
+    /// 全行が必ず出力される（見出し行を除く）。
+    func testEveryInputLineAppears() throws {
+        let a = try write("nginx-access.log", nginx)
+        let b = try write("app.log", app)
+        let c = try write("db-syslog.log", db)
+        let r = try builder.build(urls: [a, b, c], into: dir)
+
+        let expected = nginx.split(separator: "\n").count
+            + app.split(separator: "\n").count
+            + db.split(separator: "\n").count
+        XCTAssertEqual(r.totalLines, expected)
+    }
+
+    /// 同名ファイルはディレクトリ名で区別する。ホスト別に集めたログで必ず起きる。
+    func testDuplicateBaseNamesGetParentDirectoryInLabel() throws {
+        for host in ["web-1", "web-2"] {
+            let sub = dir.appendingPathComponent(host)
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            try app.write(to: sub.appendingPathComponent("app.log"), atomically: true, encoding: .utf8)
+        }
+        let urls = ["web-1", "web-2"].map { dir.appendingPathComponent($0).appendingPathComponent("app.log") }
+        let r = try builder.build(urls: urls, into: dir)
+        XCTAssertEqual(r.sources.map { $0.label }, ["web-1/app", "web-2/app"])
+    }
+
+    /// 時刻を持たないファイルは末尾に回り、その旨を警告に出す（黙って混ぜない）。
+    func testTimestamplessFileIsReportedAndPlacedLast() throws {
+        let a = try write("app.log", app)
+        let b = try write("notes.txt", "just some notes\nno timestamps at all\n")
+        let r = try builder.build(urls: [a, b], into: dir)
+
+        XCTAssertNil(r.sources[1].format)
+        XCTAssertEqual(r.warnings.count, 1)
+        XCTAssertTrue(r.warnings[0].contains("notes.txt"))
+
+        let rows = try String(contentsOf: r.url, encoding: .utf8)
+            .split(separator: "\n").filter { !$0.hasPrefix("#") }
+        XCTAssertTrue(rows.suffix(2).allSatisfy { $0.contains("notes") },
+                      "時刻を持たない行は末尾に並ぶ")
+    }
+
+    /// テキストファイルは改行で終わるのが普通。その末尾改行から生まれる空行を残すと
+    /// **ファイルの数だけラベルだけの空行が混ざる**（実機で見つけた）。
+    func testTrailingNewlineDoesNotAddPhantomLine() throws {
+        let a = try write("app.log", app + "\n")            // 改行で終わる
+        let b = try write("db-syslog.log", db + "\n")
+        let r = try builder.build(urls: [a, b], into: dir)
+
+        XCTAssertEqual(r.sources[0].lineCount, 3, "app.log は3行（幻の空行を数えない）")
+        XCTAssertEqual(r.sources[1].lineCount, 2)
+        XCTAssertEqual(r.totalLines, 5)
+
+        let rows = try String(contentsOf: r.url, encoding: .utf8)
+            .split(separator: "\n").filter { !$0.hasPrefix("#") }
+        // 「時刻 │ ラベル │ 空」の行が無いこと
+        for row in rows {
+            let parts = row.split(separator: "│", maxSplits: 2, omittingEmptySubsequences: false)
+            XCTAssertFalse(parts.count == 3 && parts[2].trimmingCharacters(in: .whitespaces).isEmpty,
+                           "本文が空の行が残っている: \(row)")
+        }
+    }
+
+    func testRefusesSingleFile() throws {
+        let a = try write("app.log", app)
+        XCTAssertThrowsError(try builder.build(urls: [a], into: dir))
+    }
+
+    /// Shift-JIS のログも読める（既存の文字コード判定を通す）。
+    func testReadsShiftJISInput() throws {
+        let u = dir.appendingPathComponent("sjis.log")
+        let text = "2026-07-30T12:34:56+09:00 エラー 在庫が足りません\n"
+        try text.data(using: .shiftJIS)!.write(to: u)
+        let b = try write("app.log", app)
+
+        let r = try builder.build(urls: [u, b], into: dir)
+        let body = try String(contentsOf: r.url, encoding: .utf8)
+        XCTAssertTrue(body.contains("在庫が足りません"), "Shift-JIS が文字化けせず読めること")
+    }
+}

--- a/Tests/MrEditorTests/TimestampBenchTests.swift
+++ b/Tests/MrEditorTests/TimestampBenchTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import MrEditor
+
+/// 時刻の読み取り速度を測る。普段は skip。
+/// `MREDITOR_BENCH=1 swift test --filter TimestampBench` で走る。
+///
+/// 時刻マージは「複数のログを全部読んで並べ直す」ので、1行あたりのコストが
+/// そのまま体感になる。索引 9 秒の隣に置いて恥ずかしくない速度かをここで見る。
+/// 公表値を勘で書かないための計測。
+final class TimestampBenchTests: XCTestCase {
+
+    /// 2桁・3桁のゼロ詰め。`String(format:)` を使わないための小道具。
+    private func pad(_ v: Int, _ width: Int) -> String {
+        let s = String(v)
+        return s.count >= width ? s : String(repeating: "0", count: width - s.count) + s
+    }
+
+    /// 実ログに近い分布（時刻あり8割・継続行2割）を組み立てる。
+    ///
+    /// ⚠️ **`String(format:)` を使ってはいけない。** 返ってくるのは NSString 由来の
+    /// 文字列で、Swift ネイティブの連続バッファを持たない。`withUTF8` がそのたびに
+    /// コピーを作るため、測っているのが自分のコードでなく**橋渡しの費用**になる
+    /// （実測 2026-08-04: **1.26 → 11.73 M行/s**。9倍の差が全部これだった）。
+    /// 実運用の行は自前のファイル読み込みから来るのでネイティブ。補間で組み立てる。
+    private func makeLines(_ count: Int) -> [String] {
+        var lines: [String] = []
+        lines.reserveCapacity(count)
+        for i in 0..<count {
+            if i % 5 == 4 {
+                lines.append("    at com.example.Service.handle(Service.java:\(i % 400))")
+            } else {
+                let s = 1_785_414_896 + i / 3
+                let t = TimestampDetector.civilFromDays(s / 86_400)
+                let rem = s % 86_400
+                lines.append("\(t.year)-\(pad(t.month, 2))-\(pad(t.day, 2))T"
+                             + "\(pad(rem / 3600, 2)):\(pad((rem % 3600) / 60, 2)):\(pad(rem % 60, 2))"
+                             + ".\(pad(i % 1000, 3))Z INFO request id=\(i) done in \(i % 900)ms")
+            }
+        }
+        return lines
+    }
+
+    func testParseAllThroughput() throws {
+        guard ProcessInfo.processInfo.environment["MREDITOR_BENCH"] == "1" else {
+            throw XCTSkip("MREDITOR_BENCH=1 で時刻読み取りのベンチを実行")
+        }
+        let n = 2_000_000
+        let lines = makeLines(n)
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: 0)
+
+        let t0 = Date()
+        let times = d.parseAll(lines)
+        let sec = Date().timeIntervalSince(t0)
+
+        let hits = times.compactMap { $0 }.count
+        print(String(format: "parseAll: %.3f 秒 / %d 行 (%.2f M行/s・命中 %d)",
+                     sec, n, Double(n) / sec / 1_000_000, hits))
+        XCTAssertEqual(times.count, n)
+    }
+
+    func testMergeThroughput() throws {
+        guard ProcessInfo.processInfo.environment["MREDITOR_BENCH"] == "1" else {
+            throw XCTSkip("MREDITOR_BENCH=1 で統合のベンチを実行")
+        }
+        let per = 500_000
+        let d = TimestampDetector(format: .iso8601, timeZoneOffset: 0)
+        let sources = (0..<4).map { k in
+            LogMerger.Source(label: "host-\(k)",
+                             times: d.parseAll(makeLines(per)),
+                             clockOffset: Double(k))
+        }
+
+        let t0 = Date()
+        let merged = LogMerger.merge(sources)
+        let sec = Date().timeIntervalSince(t0)
+
+        print(String(format: "merge: %.3f 秒 / %d 行 × %d 本 (%.2f M行/s)",
+                     sec, per, sources.count, Double(merged.count) / sec / 1_000_000))
+        XCTAssertEqual(merged.count, per * sources.count)
+    }
+
+    /// 実ファイルで測る。`testdata/test_50mb_jp.log` があれば使う。
+    func testRealFileThroughput() throws {
+        guard ProcessInfo.processInfo.environment["MREDITOR_BENCH"] == "1" else {
+            throw XCTSkip("MREDITOR_BENCH=1 で実ファイルのベンチを実行")
+        }
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("testdata/test_50mb_jp.log")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+            throw XCTSkip("testdata/test_50mb_jp.log がない")
+        }
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        let t0 = Date()
+        let detector = TimestampDetector.detect(sampleLines: Array(lines.prefix(200)))
+        let detectSec = Date().timeIntervalSince(t0)
+
+        guard let detector else {
+            print("実ファイル: 時刻形式を検出せず（\(lines.count) 行）")
+            return
+        }
+        let t1 = Date()
+        let times = detector.parseAll(lines)
+        let sec = Date().timeIntervalSince(t1)
+        let hits = times.compactMap { $0 }.count
+        print(String(format: "実ファイル(%@): 判定 %.4f 秒 / parseAll %.3f 秒 / %d 行 (%.2f M行/s・命中率 %.1f%%)",
+                     detector.format.rawValue, detectSec, sec, lines.count,
+                     Double(lines.count) / sec / 1_000_000,
+                     Double(hits) / Double(lines.count) * 100))
+    }
+}


### PR DESCRIPTION
Pro v1「束ねる」の心臓部。**画面もファイル読み込みも無い純関数だけ**を先に置く。ここが崩れると画面をどう作っても直らないし、逆にここが正しければ画面は後からどうとでもなる。`TextTransform` / `LineSplitter` と同じ型。

## TimestampDetector

- **形式は行ごとでなくソースごとに1回だけ決める**（`detect` → `parse`）。`TabularFormatter` の `build`/`format` と同じ。行ごとに総当たりすると遅い上に、同じファイル内で行によって解釈が変わって並びが壊れる。
- `DateFormatter` も `NSRegularExpression` も使わず UTF-8 を手で走査。暦も Howard Hinnant の式で整数演算に落とす。数百万行を通すため。
- **年やタイムゾーンが「無い」形式があることを型で認めた。** syslog に年は無く、ISO でもオフセット無しの行がある。無いものは `Components` で `nil` のまま持ち上げ、補い方（`assumedYear` / `timeZoneOffset`）は呼び出し側の設定にした。ここで「今年・ローカル時刻」と決め打つと、去年のログを開いた瞬間に静かに間違う。
- `parseAll` は**年またぎ（12/31 → 1/1）を補正**する。年を固定したままだと約11か月巻き戻り、並べ替えでログが裏返る。

対応形式: ISO8601 / syslog / Apache common log / エポック秒 / エポックミリ秒。

## LogMerger

`sort -m` で済まない理由が3つあり、それがこの型の存在理由:

1. **時刻を持たない継続行**（スタックトレース）を親から引き剥がさない。直前の時刻を引き継ぐ。
2. **同時刻が大量に出る**（秒までしか無い形式）。（時刻 → ソース → 行）で全順序を作り、**開くたびに並びが変わらない**ようにした。
3. **NTP がずれたホスト**を `clockOffset` で補正する。補正しないと因果が逆に見える。

行本文は持たず「どのソースの何行目か」だけを返す。巨大ファイルを丸ごとメモリに載せないための境界。

## 実データで潰した2件

作った入力だけでテストすると、自分が想像した形式しか通らないことに気づけない。実際どちらもそれで出た。

- **国税庁の法人番号 CSV**（`1000012010001,01,…`）は先頭13桁が**エポックミリ秒に見える**。→ 単調性で切る。ログの時刻は増え続けるが、ID の列は増減する。
- **`/var/log/install.log` のオフセットは `-07` と2桁**で分が無い。取りこぼすと offset が `nil` になって既定のタイムゾーンに落ち、**数時間ずれた時刻を正しい顔で返す**。複数ホストを束ねたとき最も見つけにくい壊れ方。

`/var/log/system.log`（素の syslog）、`/var/log/wifi.log`（`Tue Aug  4 …` が混在）からも行を写してテストにした。

## テスト

30件追加（実ログからの写し3件を含む）。**全 418 green**（3 skip は既存の gated な巨大ファイルテスト）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)