### PR TITLE
検索バーが構造化バナーと重なっていた（1.11 の副作用）

### DIFF
--- a/Sources/MrEditor/MainWindowController.swift
+++ b/Sources/MrEditor/MainWindowController.swift
@@ -55,6 +55,8 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     private var sidebarWidthConstraint: NSLayoutConstraint?
     /// ツールバーの delegate。窓が持つのは weak なので、こちらで保持しておく。
     private var toolbarDelegate: MainToolbarDelegate?
+    /// 検索バーの上端。構造化バナーが出ている間は、その下へ下げる（重なり回避）。
+    private var searchBarTopConstraint: NSLayoutConstraint?
 
     convenience init() {
         let window = NSWindow(
@@ -148,8 +150,13 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         searchBar.isHidden = true
         content.addSubview(searchBar)
+        // 構造化バナーと同じ右上に浮くので、バナーが出ている間はその下へ逃がす。
+        // 1.11 で構造化中も検索できるようにした結果、両方が同時に出るようになった
+        // （それまでは構造化に切り替えると検索バーを閉じていたので重ならなかった）。
+        let searchTop = searchBar.topAnchor.constraint(equalTo: viewerContainer.topAnchor, constant: 10)
+        searchBarTopConstraint = searchTop
         NSLayoutConstraint.activate([
-            searchBar.topAnchor.constraint(equalTo: viewerContainer.topAnchor, constant: 10),
+            searchTop,
             searchBar.trailingAnchor.constraint(equalTo: viewerContainer.trailingAnchor, constant: -28),
             searchBar.widthAnchor.constraint(equalToConstant: 440),
             searchBar.heightAnchor.constraint(equalToConstant: SearchBarView.height),
@@ -880,6 +887,7 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     /// 構造化表示バナーの表示可否を更新する（構造化中だけ出す）。
+    /// バナーと検索バーは同じ右上に浮くので、出したぶんだけ検索バーを下げる。
     private func updateStructuredBanner() {
         if let mode = activeStructuredMode {
             structuredBanner.configure(mode: mode)
@@ -887,6 +895,8 @@ final class MainWindowController: NSWindowController, NSWindowDelegate {
         } else {
             structuredBanner.isHidden = true
         }
+        searchBarTopConstraint?.constant = structuredBanner.isHidden
+            ? 10 : 10 + StructuredBanner.height + 8
     }
 
     /// 各ビューアにステータス/検索/ドロップのハンドラを繋ぐ（アクティブな時だけ反映）。

--- a/Sources/MrEditor/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditor/Viewer/PieceTableViewer.swift
@@ -395,7 +395,11 @@ final class PieceTableViewer: NSView, DocumentPane {
                     h.addAttribute(.font, value: boldTextFont, range: NSRange(location: 0, length: h.length))
                     attributed[0] = h
                 }
-                documentView.activeRow = nil
+                // 行内のハイライトは出せない（整形後の文字位置が元のバイト位置と対応しない）が、
+                // **一致行の帯は出せる**。これが無いと、構造化中の検索は打っても何も起きないように見える。
+                let visMatch = currentMatchIdx >= 0 && currentMatchLine >= topLine
+                    && currentMatchLine < topLine + attributed.count
+                documentView.activeRow = visMatch ? currentMatchLine - topLine : nil
                 documentView.lines = attributed
                 documentView.caret = nil
                 documentView.selectionByRow = [:]


### PR DESCRIPTION
利用者報告。**構造化表示の帯が検索バーに被り、漏斗ボタンも件数も次/前も押せませんでした。**

1.11 で構造化中も検索できるようにしたのに、置き場所を直していなかったのが原因です。どちらも本文領域の右上（`top+10` / `trailing-28`）に浮くので、同時に出ると必ず重なります。1.11 以前は構造化に切り替えると検索バーを閉じていたため、重なりようがありませんでした。

報告の「検索できない」も、これで説明がつきます。検索自体は走っていて（再現時は「検索中… 69%」が出ていました）、**件数も漏斗も帯の下に隠れていただけ**でした。

## 直したもの

- 構造化バナーが出ている間は、検索バーをバナーの下へ下げる（`searchBarTopConstraint`）
- 構造化中も**一致行の帯**を出す。行内のハイライトは整形後の文字位置が元のバイト位置と対応しないので出せませんが、帯まで消していると「打っても何も起きない」ように見えます

## 検証

- 442 tests green
- 1.18GiB の法人番号 CSV で実機確認：⌘F で検索バーが被らずに出て、「岩見沢」**2,766 件**を桁揃えのまま絞り込める（行番号 39 / 71 / 113 / 243 / 328…）

## 残り

パネルをドラッグで動かせるようにする件は別途（位置の記憶やウィンドウ端の扱いが要るため、このリリースには入れません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)