### PR TITLE
他のアプリでの変更を検知して読み込み直す（未保存はバナーで確認）

### DIFF
--- a/Sources/MrEditorCore/AppSettings.swift
+++ b/Sources/MrEditorCore/AppSettings.swift
@@ -146,6 +146,7 @@ enum AppSettings {
     private static let showInvisiblesKey = "MrEditor.showInvisibles"
     private static let cursorShapeKey = "MrEditor.cursorShape"
     private static let sessionKey = "MrEditor.session"
+    private static let autoReloadKey = "MrEditor.autoReloadExternalChanges"
     private static let autoUpdateCheckKey = "MrEditor.automaticUpdateChecks"
     private static let lastUpdateCheckKey = "MrEditor.lastUpdateCheck"
     private static let aiProviderKey = "MrEditor.ai.provider"
@@ -217,6 +218,14 @@ enum AppSettings {
                 defaults.removeObject(forKey: sessionKey)
             }
         }
+    }
+
+    /// 他のアプリでファイルが書き換わったとき、自動で読み込み直すか。既定 true。
+    /// **オフでも変更は知らせる**（本文下端のバナー）。黙って古い内容を見せ続けることはしない。
+    /// 未保存の変更があるときは、オンでも自動では取り込まない（潰してしまうため）。
+    static var autoReloadExternalChanges: Bool {
+        get { defaults.object(forKey: autoReloadKey) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: autoReloadKey) }
     }
 
     /// 起動時に新しい版が出ていないか自動で調べるか。既定 true。

--- a/Sources/MrEditorCore/Core/ExternalChangeWatcher.swift
+++ b/Sources/MrEditorCore/Core/ExternalChangeWatcher.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// ディスク上のファイルの「版」。外部変更を見分けるための最小の指紋。
+///
+/// **内容は読まない。** 10GB のファイルを 1 秒ごとに読み直すわけにはいかないので、
+/// `stat(2)` が返すサイズ・更新時刻・inode だけで「変わった」を判定する。
+/// inode を含めるのは、多くのエディタが**別ファイルへ書いて置き換える**（atomic save）ため。
+/// 置き換えではサイズも更新時刻も同じことがありうるが、inode は必ず変わる。
+struct FileStamp: Equatable {
+    var size: Int64
+    /// 更新時刻（1970 起点の秒。ナノ秒まで見る＝1 秒以内の連続変更も取りこぼさない）。
+    var modified: TimeInterval
+    var inode: UInt64
+
+    /// いまのディスクの状態を読む。ファイルが無ければ nil。
+    static func read(_ url: URL) -> FileStamp? {
+        var st = stat()
+        guard stat(url.path, &st) == 0 else { return nil }
+        let mtime = TimeInterval(st.st_mtimespec.tv_sec)
+            + TimeInterval(st.st_mtimespec.tv_nsec) / 1_000_000_000
+        return FileStamp(size: Int64(st.st_size), modified: mtime, inode: UInt64(st.st_ino))
+    }
+}
+
+/// 監視 1 件の状態。
+struct FileWatchEntry: Equatable {
+    var url: URL
+    /// このアプリが取り込み済みの版（＝いま表示しているはずの内容）。
+    var known: FileStamp?
+    /// 変化を見つけたが、まだ落ち着いていない版。
+    var pending: FileStamp?
+    /// `pending` が続いた回数。
+    var pendingTicks: Int = 0
+}
+
+/// 開いているファイルが**アプリの外**で書き換わったかを見張る。
+///
+/// 1 ファイルにつき 1 tick で `stat` 1 回。内容を読まないので、10GB を開いていても
+/// コストは無視できる。**取り込みの判断はしない**（誰に何をさせるかは呼び出し側の仕事）。
+final class ExternalChangeWatcher {
+    /// 変化を見つけたとき。メインスレッドで呼ばれる。
+    var onChange: ((ObjectIdentifier) -> Void)?
+    /// 見に行く間隔。安定判定に 2 tick 使うので、体感は 1 秒前後。
+    var interval: TimeInterval = 0.5
+
+    /// 書き込み途中を掴まないため、**同じ版を 2 回続けて見るまで待つ**。
+    /// ただしログのように書かれ続けるファイルは落ち着かないので、この回数で観念して通す。
+    static let forceAfterTicks = 4
+
+    private(set) var entries: [ObjectIdentifier: FileWatchEntry] = [:]
+    private var timer: Timer?
+
+    deinit { stop() }
+
+    func start() {
+        guard timer == nil else { return }
+        let t = Timer(timeInterval: interval, repeats: true) { [weak self] _ in self?.tick() }
+        RunLoop.main.add(t, forMode: .common)   // スクロール中・メニュー表示中も止めない
+        timer = t
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// 監視対象を「いまのディスクの状態は取り込み済み」として登録／更新する。
+    /// ファイルを開いた直後・保存した直後・読み込み直した直後に呼ぶ
+    /// （**自分の書き込みを外部変更と誤認しない**ための唯一の仕掛け）。
+    func note(key: ObjectIdentifier, url: URL) {
+        entries[key] = FileWatchEntry(url: url, known: FileStamp.read(url))
+    }
+
+    func forget(key: ObjectIdentifier) {
+        entries.removeValue(forKey: key)
+    }
+
+    /// 監視リストを開いているファイルの一覧に合わせる。
+    /// **すでに見ているものの版は触らない**（ここで版を取り直すと、取り込み前の変更を
+    /// 「知っている版」に格上げしてしまい、変更を握り潰す）。
+    func sync(_ items: [(key: ObjectIdentifier, url: URL)]) {
+        let live = Set(items.map(\.key))
+        for key in entries.keys where !live.contains(key) { entries.removeValue(forKey: key) }
+        for item in items {
+            if entries[item.key]?.url != item.url { note(key: item.key, url: item.url) }
+        }
+    }
+
+    /// 1 回分の見回り。テストからは直接呼ぶ（タイマーを待たない）。
+    func tick() {
+        for (key, var entry) in entries {
+            let changed = Self.decide(&entry, current: FileStamp.read(entry.url))
+            entries[key] = entry
+            if changed { onChange?(key) }
+        }
+    }
+
+    /// 1 件・1 tick 分の判定（純関数。時計もファイルも触らない）。取り込むべきなら true。
+    ///
+    /// - ファイルが消えている（`current == nil`）間は**何もしない**。非 atomic な書き手は
+    ///   書いている最中に一瞬消えるので、ここで騒ぐと空の内容を読み込みかねない。
+    ///   `known` を残しておくので、書き終わって現れた時点で差分として拾える。
+    static func decide(_ entry: inout FileWatchEntry,
+                       current: FileStamp?,
+                       forceAfter: Int = ExternalChangeWatcher.forceAfterTicks) -> Bool {
+        guard let current else {
+            entry.pending = nil
+            entry.pendingTicks = 0
+            return false
+        }
+        if current == entry.known {
+            entry.pending = nil
+            entry.pendingTicks = 0
+            return false
+        }
+        entry.pendingTicks += 1
+        // 同じ版を 2 回見た（＝書き終わった）か、待ちが長引いた（＝書かれ続けている）。
+        if current == entry.pending || entry.pendingTicks >= forceAfter {
+            entry.known = current
+            entry.pending = nil
+            entry.pendingTicks = 0
+            return true
+        }
+        entry.pending = current
+        return false
+    }
+}

--- a/Sources/MrEditorCore/MainWindowController.swift
+++ b/Sources/MrEditorCore/MainWindowController.swift
@@ -26,6 +26,19 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
     private var aiStream: AIStreamHandle?
     private let readOnlyBanner = ReadOnlyBanner()
     private let structuredBanner = StructuredBanner()
+    private let externalBanner = ExternalChangeBanner()
+
+    // MARK: - 外部変更の取り込み
+    //
+    // 開いているファイルが他のアプリで書き換わったら、未保存でなければ黙って読み込み直す。
+    // 潰せない状態（未保存・整形/絞り込み中）と、自動読み込みをオフにしている場合は
+    // バナーで知らせるだけにする。**古い内容を黙って見せ続けることはしない**のが約束。
+
+    private let externalWatcher = ExternalChangeWatcher()
+    /// 外部で変わったが、まだ取り込んでいないペイン（バナーを出す対象）。
+    private var externallyChangedPanes = Set<ObjectIdentifier>()
+    /// 「読み込みました」の一時メッセージを消すタイマー。
+    private var externalMessageTimer: Timer?
 
     private let sidebar = SidebarView()
     private let viewerContainer = DropView()
@@ -220,6 +233,21 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
             structuredBanner.heightAnchor.constraint(equalToConstant: StructuredBanner.height),
         ])
 
+        // 外部変更バナー（本文領域の**下端**。上端は検索バー・読み取り専用・構造化で埋まっている）
+        externalBanner.translatesAutoresizingMaskIntoConstraints = false
+        externalBanner.isHidden = true
+        externalBanner.onReload = { [weak self] in self?.reloadActiveFromDisk() }
+        externalBanner.onClose = { [weak self] in self?.dismissExternalBanner() }
+        content.addSubview(externalBanner)
+        NSLayoutConstraint.activate([
+            externalBanner.bottomAnchor.constraint(equalTo: viewerContainer.bottomAnchor, constant: -10),
+            externalBanner.leadingAnchor.constraint(equalTo: viewerContainer.leadingAnchor, constant: 14),
+            externalBanner.heightAnchor.constraint(equalToConstant: ExternalChangeBanner.height),
+        ])
+
+        externalWatcher.onChange = { [weak self] key in self?.externalChangeDetected(key) }
+        externalWatcher.start()
+
         applyChrome()   // 永続化されたテーマを起動時に反映する。
     }
 
@@ -286,6 +314,83 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
         sidebar.reload(names: viewers.map { displayName(of: $0) },
                        dirty: viewers.map { $0.isDirty },
                        active: activeIndex)
+        syncExternalWatch()   // 開いているファイルの増減・保存先の変更に監視を合わせる
+    }
+
+    // MARK: - 外部変更の取り込み
+
+    /// 監視リストを、いま開いているファイルに合わせる。
+    private func syncExternalWatch() {
+        externalWatcher.sync(viewers.compactMap { pane in
+            pane.fileURL.map { (key: ObjectIdentifier(pane), url: $0) }
+        })
+    }
+
+    /// ディスクの内容が変わったと分かったとき（監視タイマーから）。
+    ///
+    /// 黙って取り込むのは**未保存の変更が無く、本文をそのまま見せているペインだけ**。
+    /// 整形・絞り込み・クエリ表示中は本文が差し替わっており（`canEdit == false`）、
+    /// 読み込み直すとユーザーの作った見え方を勝手に壊すので、バナーで知らせて選ばせる。
+    private func externalChangeDetected(_ key: ObjectIdentifier) {
+        guard let pane = viewers.first(where: { ObjectIdentifier($0) == key }) else { return }
+        guard AppSettings.autoReloadExternalChanges, !pane.isDirty, pane.canEdit else {
+            externallyChangedPanes.insert(key)
+            updateExternalBanner()
+            return
+        }
+        applyDiskReload(to: pane)
+    }
+
+    /// ペインをディスクの内容へ更新し、周辺 UI を合わせる。
+    private func applyDiskReload(to pane: DocumentPane) {
+        guard let url = pane.fileURL, pane.reloadFromDisk() else { return }
+        externallyChangedPanes.remove(ObjectIdentifier(pane))
+        // いま取り込んだ版を「知っている版」にする（これをしないと同じ変更で鳴り続ける）。
+        externalWatcher.note(key: ObjectIdentifier(pane), url: url)
+        reloadSidebar()
+        updateExternalBanner()
+        updateEditedState()
+        if pane === activeViewer { showExternalReloadMessage() }
+    }
+
+    /// バナーの「読み込む」。未保存の変更を潰すときだけ確認する。
+    private func reloadActiveFromDisk() {
+        guard let pane = activeViewer, pane.fileURL != nil else { return }
+        guard pane.isDirty, let win = window else { applyDiskReload(to: pane); return }
+        let alert = NSAlert()
+        alert.messageText = L("external.confirmTitle", displayName(of: pane))
+        alert.informativeText = L("external.confirmMessage")
+        alert.addButton(withTitle: L("external.reload"))   // .alertFirstButtonReturn
+        alert.addButton(withTitle: L("common.cancel"))     // .alertSecondButtonReturn
+        alert.beginSheetModal(for: win) { [weak self] resp in
+            guard let self, resp == .alertFirstButtonReturn else { return }
+            self.applyDiskReload(to: pane)
+        }
+    }
+
+    /// バナーの ×。取り込まないと決めたので、いまのディスクの版を「知っている版」にして黙る
+    /// （次に変わったらまた知らせる）。
+    private func dismissExternalBanner() {
+        guard let pane = activeViewer, let url = pane.fileURL else { return }
+        externallyChangedPanes.remove(ObjectIdentifier(pane))
+        externalWatcher.note(key: ObjectIdentifier(pane), url: url)
+        updateExternalBanner()
+    }
+
+    /// バナーはアクティブなペインのものだけを出す（ドキュメントごとの状態）。
+    private func updateExternalBanner() {
+        guard let pane = activeViewer else { externalBanner.isHidden = true; return }
+        externalBanner.isHidden = !externallyChangedPanes.contains(ObjectIdentifier(pane))
+    }
+
+    /// 黙って差し替えると「勝手に変わった」と見えるので、数秒だけステータスバーで断る。
+    private func showExternalReloadMessage() {
+        statusBar.showMessage(L("external.reloaded"))
+        externalMessageTimer?.invalidate()
+        externalMessageTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { [weak self] _ in
+            self?.statusBar.clearMessage()
+            self?.activeViewer?.reEmitState()
+        }
     }
 
     /// 開いているドキュメント一覧を永続化する（次回起動時に復元）。
@@ -952,6 +1057,7 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
         updateEditedState()
         updateStructuredBanner()
         updateReadOnlyBanner()
+        updateExternalBanner()
         v.focusContent()
         persistSession()
     }
@@ -1011,6 +1117,8 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
         // ドキュメントを閉じるのはユーザーの明示的な操作。ここが draft を消してよい 2 経路の
         // もう 1 つ（保存に成功したときはペイン側で消える）。閉じずに終了した draft は残る。
         pane.discardDraft()
+        externallyChangedPanes.remove(ObjectIdentifier(pane))
+        externalWatcher.forget(key: ObjectIdentifier(pane))
         let v = viewers.remove(at: idx)
         v.removeFromSuperview()
         if viewers.isEmpty {
@@ -1020,6 +1128,7 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
             statusBar.setPlaceholder()
             updateEditedState()
             updateReadOnlyBanner()
+            updateExternalBanner()
             persistSession()
         } else {
             activeIndex = min(idx, viewers.count - 1)
@@ -1042,6 +1151,8 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
             guard let self, resp == .alertFirstButtonReturn else { return }
             guard let idx = self.viewers.firstIndex(where: { $0 === pane }) else { return }
             _ = pane.open(url: url)          // 再読込（dirty=false・状態リセット）
+            self.externalWatcher.note(key: ObjectIdentifier(pane), url: url)
+            self.externallyChangedPanes.remove(ObjectIdentifier(pane))
             self.reloadSidebar()
             self.activate(idx)               // タイトル／ステータス／編集ドットを更新
         }
@@ -1064,6 +1175,10 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
         let apply: () -> Void = { [weak self] in
             guard let self, let idx = self.viewers.firstIndex(where: { $0 === pane }) else { return }
             _ = pane.reopen(withEncoding: enc)
+            if let url = pane.fileURL {
+                self.externalWatcher.note(key: ObjectIdentifier(pane), url: url)
+                self.externallyChangedPanes.remove(ObjectIdentifier(pane))
+            }
             self.reloadSidebar()
             self.activate(idx)
         }
@@ -1194,7 +1309,14 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
 
     /// 保存後の UI 更新（保存先変更でファイル名が変わりうる）。
     private func afterSave(_ v: DocumentPane) {
-        if let url = v.fileURL { NSDocumentController.shared.noteNewRecentDocumentURL(url) }
+        if let url = v.fileURL {
+            NSDocumentController.shared.noteNewRecentDocumentURL(url)
+            // 自分で書いた版を「知っている版」にする。これを忘れると、保存するたびに
+            // 監視が「外部で変わった」と誤認して読み込み直す（＝アンドゥ履歴が飛ぶ）。
+            externalWatcher.note(key: ObjectIdentifier(v), url: url)
+            externallyChangedPanes.remove(ObjectIdentifier(v))
+            updateExternalBanner()
+        }
         reloadSidebar()
         if activeViewer === v {
             window?.title = displayName(of: v) + " — " + AppInfo.name
@@ -1204,6 +1326,12 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     // MARK: - NSWindowDelegate
+
+    /// 他のアプリで直してから戻ってきた、が一番多い動線なので、切り替わった瞬間に見に行く
+    /// （タイマー待ちの 1 秒を挟まない）。
+    public func windowDidBecomeKey(_ notification: Notification) {
+        externalWatcher.tick()
+    }
 
     /// ウィンドウを閉じる前に未保存のドキュメントを確認する。
     /// 未保存の新規（URL 未確定）はセッション復元で残るため確認せず、保存済みファイルの

--- a/Sources/MrEditorCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditorCore/Resources/en.lproj/Localizable.strings
@@ -45,6 +45,11 @@
 "reopen.confirmTitle" = "Reopen “%@” with a different encoding?";
 "reopen.confirmMessage" = "Your current changes will be lost.";
 "reopen.confirm" = "Reopen";
+"external.banner" = "This file was changed by another app";
+"external.reload" = "Reload";
+"external.reloaded" = "Reloaded changes made by another app";
+"external.confirmTitle" = "Load the changes another app made to “%@”?";
+"external.confirmMessage" = "Your unsaved changes will be lost.";
 "common.save" = "Save";
 "common.saveAll" = "Save All";
 "common.dontSave" = "Don’t Save";
@@ -246,6 +251,9 @@
 "update.failedTitle" = "Couldn’t check for updates";
 "update.failedMessage" = "The network was unreachable, or the release information could not be read. Please try again later.";
 "prefs.autoUpdateCheck" = "Check for updates on launch";
+"prefs.externalChanges" = "External Changes";
+"prefs.autoReload" = "Reload automatically";
+"prefs.autoReload.hint" = "Reloads a file when another app changes it. If you have unsaved changes it asks first instead of reloading, and even when this is off you still get told the file changed.";
 "prefs.updates" = "Updates";
 
 /* 比較（diff） */

--- a/Sources/MrEditorCore/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditorCore/Resources/ja.lproj/Localizable.strings
@@ -45,6 +45,11 @@
 "reopen.confirmTitle" = "“%@” を別のエンコーディングで開き直しますか？";
 "reopen.confirmMessage" = "現在の変更内容は失われます。";
 "reopen.confirm" = "開き直す";
+"external.banner" = "このファイルは他のアプリで変更されました";
+"external.reload" = "読み込む";
+"external.reloaded" = "他のアプリでの変更を読み込みました";
+"external.confirmTitle" = "“%@” に他のアプリでの変更を読み込みますか？";
+"external.confirmMessage" = "未保存の変更は失われます。";
 "common.save" = "保存";
 "common.saveAll" = "すべて保存";
 "common.dontSave" = "保存しない";
@@ -246,6 +251,9 @@
 "update.failedTitle" = "アップデートを確認できませんでした";
 "update.failedMessage" = "ネットワークに接続できないか、リリース情報を取得できませんでした。時間をおいて試してください。";
 "prefs.autoUpdateCheck" = "起動時にアップデートを確認する";
+"prefs.externalChanges" = "他のアプリでの変更";
+"prefs.autoReload" = "自動で読み込み直す";
+"prefs.autoReload.hint" = "他のアプリでファイルが変わったら読み込み直します。未保存の変更があるときは自動では取り込まず、確認します。オフでも変更があったことは知らせます。";
 "prefs.updates" = "アップデート";
 
 /* 比較（diff） */

--- a/Sources/MrEditorCore/UI/ExternalChangeBanner.swift
+++ b/Sources/MrEditorCore/UI/ExternalChangeBanner.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+/// 「このファイルは他で変更されました」を知らせる小さな帯。
+///
+/// 自動で読み込めなかったとき（未保存の変更がある／整形・絞り込みで本文を差し替えている／
+/// 自動読み込みをオフにしている）にだけ出す。**本文領域の下端**に浮かべる：
+/// 上端は検索バー・読み取り専用バナー・構造化バナーが既に取り合っているため。
+final class ExternalChangeBanner: NSView {
+    /// 「読み込む」を押したとき。
+    var onReload: (() -> Void)?
+    /// × を押したとき。
+    var onClose: (() -> Void)?
+
+    static let height: CGFloat = 26
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        applyBackground()
+        layer?.cornerRadius = 7
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.systemOrange.withAlphaComponent(0.30).cgColor
+
+        let icon = NSImageView()
+        icon.image = NSImage(systemSymbolName: "exclamationmark.arrow.circlepath", accessibilityDescription: nil)
+        icon.contentTintColor = .secondaryLabelColor
+        icon.translatesAutoresizingMaskIntoConstraints = false
+
+        let label = NSTextField(labelWithString: L("external.banner"))
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .secondaryLabelColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let reload = NSButton(title: L("external.reload"), target: self, action: #selector(reloadTapped))
+        reload.bezelStyle = .rounded
+        reload.controlSize = .small
+        reload.font = .systemFont(ofSize: 11)
+        reload.translatesAutoresizingMaskIntoConstraints = false
+        reload.setContentHuggingPriority(.required, for: .horizontal)
+
+        let close = NSButton()
+        close.translatesAutoresizingMaskIntoConstraints = false
+        close.isBordered = false
+        close.bezelStyle = .inline
+        close.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: L("common.cancel"))
+        close.imageScaling = .scaleProportionallyDown
+        close.contentTintColor = .secondaryLabelColor
+        close.target = self
+        close.action = #selector(closeTapped)
+
+        addSubview(icon)
+        addSubview(label)
+        addSubview(reload)
+        addSubview(close)
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            icon.centerYAnchor.constraint(equalTo: centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 12),
+            icon.heightAnchor.constraint(equalToConstant: 12),
+
+            label.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            reload.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 10),
+            reload.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            close.leadingAnchor.constraint(equalTo: reload.trailingAnchor, constant: 8),
+            close.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            close.centerYAnchor.constraint(equalTo: centerYAnchor),
+            close.widthAnchor.constraint(equalToConstant: 14),
+            close.heightAnchor.constraint(equalToConstant: 14),
+        ])
+    }
+
+    /// 本文の上に浮かぶ帯なので背景は**不透明**にする（半透明だと下の行が透けて読めない）。
+    private func applyBackground() {
+        let base = EditorTheme.current().background
+        let tinted = base.blended(withFraction: 0.16, of: .systemOrange) ?? base
+        layer?.backgroundColor = tinted.withAlphaComponent(1).cgColor
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        effectiveAppearance.performAsCurrentDrawingAppearance { applyBackground() }
+    }
+
+    @objc private func reloadTapped() { onReload?() }
+    @objc private func closeTapped() { onClose?() }
+}

--- a/Sources/MrEditorCore/UI/PreferencesWindowController.swift
+++ b/Sources/MrEditorCore/UI/PreferencesWindowController.swift
@@ -84,9 +84,10 @@ private final class GeneralPaneViewController: NSViewController {
     private var statusBarRadio: NSButton!
     private var sheetRadio: NSButton!
     private var autoUpdateCheck: NSButton!
+    private var autoReloadCheck: NSButton!
 
     override func loadView() {
-        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 260))
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 340))
 
         statusBarRadio = NSButton(radioButtonWithTitle: L("menu.saveProgress.statusBar"),
                                   target: self, action: #selector(radioChanged(_:)))
@@ -100,21 +101,37 @@ private final class GeneralPaneViewController: NSViewController {
         autoUpdateCheck = NSButton(checkboxWithTitle: L("prefs.autoUpdateCheck"),
                                    target: self, action: #selector(autoUpdateChanged(_:)))
 
+        autoReloadCheck = NSButton(checkboxWithTitle: L("prefs.autoReload"),
+                                   target: self, action: #selector(autoReloadChanged(_:)))
+        let reloadHint = NSTextField(wrappingLabelWithString: L("prefs.autoReload.hint"))
+        reloadHint.font = .systemFont(ofSize: 11)
+        reloadHint.textColor = .secondaryLabelColor
+
         let sep = NSBox(); sep.boxType = .separator
+        let sep2 = NSBox(); sep2.boxType = .separator
 
         let stack = makeStack([heading("prefs.saveProgress"), statusBarRadio, sheetRadio, hint,
                                sep,
+                               heading("prefs.externalChanges"), autoReloadCheck, reloadHint,
+                               sep2,
                                heading("prefs.updates"), autoUpdateCheck])
         hint.widthAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
+        reloadHint.widthAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
         sep.widthAnchor.constraint(equalToConstant: 400).isActive = true
+        sep2.widthAnchor.constraint(equalToConstant: 400).isActive = true
         pin(stack, in: root)
         self.view = root
         syncRadios()
         autoUpdateCheck.state = AppSettings.automaticUpdateChecks ? .on : .off
+        autoReloadCheck.state = AppSettings.autoReloadExternalChanges ? .on : .off
     }
 
     @objc private func autoUpdateChanged(_ sender: NSButton) {
         AppSettings.automaticUpdateChecks = (sender.state == .on)
+    }
+
+    @objc private func autoReloadChanged(_ sender: NSButton) {
+        AppSettings.autoReloadExternalChanges = (sender.state == .on)
     }
 
     private func syncRadios() {

--- a/Sources/MrEditorCore/Viewer/DocumentPane.swift
+++ b/Sources/MrEditorCore/Viewer/DocumentPane.swift
@@ -35,6 +35,10 @@ protocol DocumentPane: NSView {
     /// ファイルを開く。失敗時は false。
     @discardableResult func open(url: URL) -> Bool
 
+    /// ディスク上の内容を取り込み直す（他のアプリで書き換えられたときの読み込み直し）。
+    /// **見ている場所は保つ**（自動で走るので、毎回先頭へ飛ぶと追っている箇所を見失う）。
+    @discardableResult func reloadFromDisk() -> Bool
+
     /// バッファ（表示）の文字コード（「開き直す」メニューのチェック表示用）。
     var currentEncoding: DetectedEncoding { get }
     /// 保存時に書き出す文字コード（「テキストエンコーディング」メニューのチェック表示・ステータス用）。
@@ -173,6 +177,12 @@ extension DocumentPane {
     var supportsJsonQuery: Bool { false }
     var jsonQueryIsActive: Bool { false }
     func toggleJsonQuery() {}
+
+    /// 既定は単純に開き直す（位置を保つ必要のあるペインが上書きする）。
+    @discardableResult func reloadFromDisk() -> Bool {
+        guard let url = fileURL else { return false }
+        return open(url: url)
+    }
 
     var currentEncoding: DetectedEncoding { .utf8 }
     var currentSaveEncoding: DetectedEncoding { .utf8 }

--- a/Sources/MrEditorCore/Viewer/EditableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/EditableViewer.swift
@@ -25,6 +25,8 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
 
     private(set) var fileURL: URL?
     private var encoding: DetectedEncoding = .utf8
+    /// ユーザーが「開き直す」で明示したエンコード（自動判定に戻さないため、読み込み直しで引き継ぐ）。
+    private var userChosenEncoding: DetectedEncoding?
     /// ファイルの改行コード。保存時に全文をこれへ揃える（NSTextView は改行を LF で挿入するため）。
     private var lineEnding: LineEnding = .lf
     private var byteSize = 0
@@ -260,6 +262,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         }
         self.fileURL = url
         self.draftID = nil          // 実ファイルを開いたペインは draft を持たない
+        self.userChosenEncoding = forcedEncoding
         self.encoding = detected
         self.lineEnding = LineEnding.detect(Data(prefix), encoding: detected)
         self.byteSize = data.count
@@ -271,6 +274,26 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.setSelectedRange(NSRange(location: 0, length: 0))
         setDirty(false)
         emitState()
+        return true
+    }
+
+    /// 他のアプリで書き換えられたファイルを取り込み直す。
+    /// キャレットとスクロール位置は保つ（自動で走るので、毎回先頭へ飛ばされると使い物にならない）。
+    /// エンコードは、ユーザーが「開き直す」で指定していればそれを引き継ぐ（自動判定に戻さない）。
+    @discardableResult
+    func reloadFromDisk() -> Bool {
+        guard let url = fileURL else { return false }
+        let selection = textView.selectedRange()
+        let scrollOrigin = scrollView.contentView.bounds.origin
+        guard open(url: url, forcedEncoding: userChosenEncoding) else { return false }
+
+        // 短くなっていることがあるので、選択は新しい本文の長さへ丸める。
+        let length = (textView.string as NSString).length
+        let location = min(selection.location, length)
+        textView.setSelectedRange(NSRange(location: location,
+                                          length: min(selection.length, length - location)))
+        scrollView.contentView.scroll(to: scrollOrigin)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
         return true
     }
 

--- a/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
@@ -18,6 +18,8 @@ final class PieceTableViewer: NSView, DocumentPane {
     private var pieceTable: PieceTable?
     /// バッファ（piece table のバイト列）のエンコード。表示・挿入・検索に使う。
     private var encoding: DetectedEncoding = .utf8
+    /// ユーザーが「開き直す」で明示したエンコード（自動判定に戻さないため、読み込み直しで引き継ぐ）。
+    private var userChosenEncoding: DetectedEncoding?
     /// 保存時に書き出すエンコード。既定はバッファと同じ。ユーザーが変えると `encoding` と乖離し、
     /// 次回保存で S(=encoding)→T(=saveEncoding) 変換書き出し＋そのエンコードで開き直して再一致させる。
     private var saveEncoding: DetectedEncoding = .utf8
@@ -302,6 +304,22 @@ final class PieceTableViewer: NSView, DocumentPane {
         return open(url: url, forcedEncoding: enc)
     }
 
+    /// 他のアプリで書き換えられたファイルを取り込み直す。
+    ///
+    /// **追記されただけなら索引を伸ばすだけで済ませる。** 10GB を張り直せば 8 秒級で、
+    /// ログが 1 行増えるたびにそれをやるのは論外（tail -f と同じ経路に乗せる）。
+    /// 丸ごと書き換わったときだけ開き直し、見ていた行へ戻す。
+    @discardableResult
+    func reloadFromDisk() -> Bool {
+        guard let url = fileURL else { return false }
+        if followMode { return true }        // 追従中は追従タイマーが同じ仕事をしている
+        if !isDirty, extendForGrowth() { refresh(); return true }
+        let keepTop = topLine
+        guard open(url: url, forcedEncoding: userChosenEncoding) else { return false }
+        setTopLine(keepTop)                  // 短くなっていれば setTopLine 側でクランプされる
+        return true
+    }
+
     /// `forcedEncoding` を渡すと自動判定を上書きしてそのエンコードで開く（エンコード指定再オープン）。
     @discardableResult
     func open(url: URL, forcedEncoding: DetectedEncoding?) -> Bool {
@@ -311,6 +329,7 @@ final class PieceTableViewer: NSView, DocumentPane {
         self.pieceTable = nil
 
         let prefix = buffer.data(in: 0..<min(buffer.count, 64 * 1024))
+        self.userChosenEncoding = forcedEncoding
         self.encoding = forcedEncoding ?? EncodingDetector.detect(prefix)
         self.saveEncoding = encoding        // 開いた直後は保存先＝バッファのエンコード
         self.lineEnding = LineEnding.detect(prefix, encoding: encoding)
@@ -1543,12 +1562,30 @@ final class PieceTableViewer: NSView, DocumentPane {
     }
 
     private func followTick() {
-        guard followMode, let buffer = fileBuffer, let idx = lineIndex else { return }
+        guard followMode else { return }
         let wasAtBottom = (topLine >= maxTopLine)
-        guard let newSize = buffer.remapIfGrownTry() else { return }
-        idx.extend(toByte: newSize)
+        guard extendForGrowth() else { return }
         if wasAtBottom { topLine = maxTopLine }
         refresh()
+    }
+
+    /// 追記された分だけを取り込む（末尾追従と外部変更の読み込み直しの共通経路）。
+    /// 伸びていなければ false（＝書き換え。呼び出し側が開き直す）。
+    ///
+    /// piece table は**生成時の原本の長さ**をピースに焼き込んでいるので、索引だけ伸ばすと
+    /// 編集を始めた瞬間に追記分が消える。索引が完成していれば作り直しは走査なしで済むため、
+    /// ここで一緒に張り直しておく。
+    @discardableResult
+    private func extendForGrowth() -> Bool {
+        guard let buffer = fileBuffer, let idx = lineIndex,
+              let newSize = buffer.remapIfGrownTry() else { return false }
+        idx.extend(toByte: newSize)
+        if pieceTable != nil, idx.isComplete {
+            pieceTable = PieceTable(original: FileBufferSource(buffer),
+                                    originalNewlines: idx.originalNewlines,
+                                    locator: idx)
+        }
+        return true
     }
 
     // MARK: - ステータス

--- a/Tests/MrEditorTests/ExternalChangeWatcherTests.swift
+++ b/Tests/MrEditorTests/ExternalChangeWatcherTests.swift
@@ -1,0 +1,258 @@
+import XCTest
+import AppKit
+@testable import MrEditorCore
+
+/// 他のアプリでファイルが書き換わったときの検知（版の指紋・落ち着き待ち・取り込み）を検証する。
+final class ExternalChangeWatcherTests: XCTestCase {
+    private func tempURL(_ ext: String = "txt") -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mreditor-watch-\(UUID().uuidString).\(ext)")
+    }
+
+    private func stamp(size: Int64 = 1, modified: TimeInterval = 1, inode: UInt64 = 7) -> FileStamp {
+        FileStamp(size: size, modified: modified, inode: inode)
+    }
+
+    private func entry() -> FileWatchEntry {
+        FileWatchEntry(url: URL(fileURLWithPath: "/tmp/x"), known: stamp())
+    }
+
+    // MARK: 指紋（FileStamp）
+
+    func testStampReflectsWrites() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "one\n".write(to: url, atomically: true, encoding: .utf8)
+        let first = try XCTUnwrap(FileStamp.read(url))
+
+        try "one\ntwo\n".write(to: url, atomically: true, encoding: .utf8)
+        let second = try XCTUnwrap(FileStamp.read(url))
+        XCTAssertNotEqual(first, second)
+        XCTAssertEqual(second.size, 8)
+    }
+
+    /// atomic save（別ファイルへ書いて置き換え）はサイズも更新時刻も同じことがありうる。
+    /// inode を見ているので、それでも「変わった」と分かる。
+    func testStampCatchesAtomicReplaceOfIdenticalContent() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "same\n".write(to: url, atomically: true, encoding: .utf8)
+        let before = try XCTUnwrap(FileStamp.read(url))
+
+        let tmp = tempURL()
+        try "same\n".write(to: tmp, atomically: true, encoding: .utf8)
+        // 更新時刻まで揃えて置き換える（サイズも内容も同じ＝inode だけが違う状況を作る）。
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: before.modified)],
+                                              ofItemAtPath: tmp.path)
+        _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+
+        let after = try XCTUnwrap(FileStamp.read(url))
+        XCTAssertEqual(after.size, before.size)
+        XCTAssertNotEqual(after.inode, before.inode)
+        XCTAssertNotEqual(after, before)
+    }
+
+    func testStampIsNilForMissingFile() {
+        XCTAssertNil(FileStamp.read(tempURL()))
+    }
+
+    // MARK: 落ち着き待ち（decide）
+
+    func testUnchangedNeverFires() {
+        var e = entry()
+        XCTAssertFalse(ExternalChangeWatcher.decide(&e, current: stamp()))
+        XCTAssertFalse(ExternalChangeWatcher.decide(&e, current: stamp()))
+        XCTAssertNil(e.pending)
+    }
+
+    /// 書き込み途中を掴まないため、同じ版を 2 回見てから取り込む。
+    func testFiresOnlyAfterStamperSettles() {
+        var e = entry()
+        let changed = stamp(size: 99, modified: 2)
+        XCTAssertFalse(ExternalChangeWatcher.decide(&e, current: changed))   // 1 回目は様子見
+        XCTAssertTrue(ExternalChangeWatcher.decide(&e, current: changed))    // 落ち着いた
+        XCTAssertEqual(e.known, changed)
+        XCTAssertFalse(ExternalChangeWatcher.decide(&e, current: changed))   // 同じ版では鳴らない
+    }
+
+    /// 書かれ続けるログ（毎回サイズが違う）でも、待ちが長引けば観念して取り込む。
+    func testFiresEventuallyWhileFileKeepsGrowing() {
+        var e = entry()
+        var fired = false
+        for i in 1...ExternalChangeWatcher.forceAfterTicks {
+            fired = ExternalChangeWatcher.decide(&e, current: stamp(size: Int64(100 + i), modified: Double(i)))
+        }
+        XCTAssertTrue(fired)
+        XCTAssertEqual(e.pendingTicks, 0)
+    }
+
+    /// 消えている間は何もしない（非 atomic な書き手は書いている最中に一瞬消える）。
+    /// 知っている版は残るので、書き終わって現れた時点で差分として拾える。
+    func testVanishedFileIsIgnoredButRemembered() {
+        var e = entry()
+        XCTAssertFalse(ExternalChangeWatcher.decide(&e, current: nil))
+        XCTAssertEqual(e.known, stamp())
+
+        let rewritten = stamp(size: 42, modified: 9, inode: 8)
+        XCTAssertFalse(ExternalChangeWatcher.decide(&e, current: rewritten))
+        XCTAssertTrue(ExternalChangeWatcher.decide(&e, current: rewritten))
+    }
+
+    // MARK: 監視（実ファイル・tick を手で回す）
+
+    func testWatcherReportsExternalWriteOnce() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "before\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let watcher = ExternalChangeWatcher()
+        let key = ObjectIdentifier(self)
+        var hits = 0
+        watcher.onChange = { _ in hits += 1 }
+        watcher.note(key: key, url: url)
+
+        watcher.tick()
+        XCTAssertEqual(hits, 0)                     // 何も起きていない
+
+        try "after\n".write(to: url, atomically: true, encoding: .utf8)
+        watcher.tick()                              // 1 回目は様子見
+        watcher.tick()                              // 落ち着いたので通知
+        XCTAssertEqual(hits, 1)
+
+        watcher.tick()
+        watcher.tick()
+        XCTAssertEqual(hits, 1)                     // 同じ版では鳴り続けない
+    }
+
+    /// 保存した直後に `note` すれば、自分の書き込みは外部変更として鳴らない。
+    func testNoteAfterOwnWriteSuppressesChange() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "v1\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let watcher = ExternalChangeWatcher()
+        let key = ObjectIdentifier(self)
+        var hits = 0
+        watcher.onChange = { _ in hits += 1 }
+        watcher.note(key: key, url: url)
+
+        try "v2\n".write(to: url, atomically: true, encoding: .utf8)   // 自分の保存に相当
+        watcher.note(key: key, url: url)                               // 保存直後の取り込み
+        watcher.tick()
+        watcher.tick()
+        XCTAssertEqual(hits, 0)
+    }
+
+    /// 一覧合わせは、見ている最中のものの版を取り直さない（取り込み前の変更を握り潰さない）。
+    func testSyncKeepsKnownVersionOfWatchedFiles() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "a\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let watcher = ExternalChangeWatcher()
+        let key = ObjectIdentifier(self)
+        var hits = 0
+        watcher.onChange = { _ in hits += 1 }
+        watcher.note(key: key, url: url)
+
+        try "a\nb\n".write(to: url, atomically: true, encoding: .utf8)
+        watcher.sync([(key: key, url: url)])        // 別のドキュメントを開いた等で走る
+        watcher.tick()
+        watcher.tick()
+        XCTAssertEqual(hits, 1)                     // 握り潰されていない
+
+        watcher.sync([])                            // 閉じたら見なくなる
+        XCTAssertTrue(watcher.entries.isEmpty)
+    }
+
+    // MARK: 取り込み（編集ペイン）
+
+    /// 外部の変更を読み込んでも、キャレット位置は保つ（自動で走るので先頭へ飛ばされたら困る）。
+    func testReloadFromDiskKeepsCaret() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "1行目\n2行目\n3行目\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let v = EditableViewer()
+        XCTAssertTrue(v.open(url: url))
+        v._testSelect(NSRange(location: 8, length: 0))
+
+        try "1行目\n2行目 追記\n3行目\n".write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertTrue(v.reloadFromDisk())
+
+        XCTAssertEqual(v._testText, "1行目\n2行目 追記\n3行目\n")
+        XCTAssertEqual(v._testSelection.location, 8)
+        XCTAssertFalse(v.isDirty)                   // ディスクと同じ内容＝未保存ではない
+    }
+
+    /// 短くなったファイルを読み込んでも、キャレットは本文の長さへ丸められる（範囲外にしない）。
+    func testReloadFromDiskClampsCaretWhenFileShrinks() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "aaaa\nbbbb\ncccc\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let v = EditableViewer()
+        XCTAssertTrue(v.open(url: url))
+        v._testSelect(NSRange(location: 12, length: 3))
+
+        try "aa\n".write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertTrue(v.reloadFromDisk())
+        XCTAssertEqual(v._testSelection.location, 3)
+        XCTAssertEqual(v._testSelection.length, 0)
+    }
+
+    /// 「エンコーディングを指定して開き直す」で選んだ文字コードは、読み込み直しでも引き継ぐ
+    /// （自動判定に戻すと、直したはずの文字化けがひとりでに再発する）。
+    func testReloadFromDiskKeepsUserChosenEncoding() throws {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "日本語\n".data(using: .shiftJIS)!.write(to: url)
+
+        let v = EditableViewer()
+        XCTAssertTrue(v.open(url: url, forcedEncoding: .utf8))    // わざと誤って開く
+        XCTAssertTrue(v.reopen(withEncoding: .shiftJIS))          // 指定して直す
+
+        try "日本語 追記\n".data(using: .shiftJIS)!.write(to: url)
+        XCTAssertTrue(v.reloadFromDisk())
+        XCTAssertEqual(v._testEncoding, .shiftJIS)
+        XCTAssertEqual(v._testText, "日本語 追記\n")
+    }
+
+    func testReloadFromDiskFailsWithoutFile() {
+        let v = EditableViewer()
+        v.newDocument()
+        XCTAssertFalse(v.reloadFromDisk())
+    }
+
+    // MARK: 取り込み（巨大ファイルペイン＝追記は索引を伸ばすだけ）
+
+    /// ログに追記された分を取り込んだあとで編集しても、追記分が消えない。
+    ///
+    /// piece table は生成時の原本の長さを焼き込んでいるので、索引だけ伸ばすと
+    /// **編集を始めた瞬間に追記分が本文から消える**（保存すればディスクからも消える）。
+    /// 追記の取り込みで piece table を張り直しているのは、そこを塞ぐため。
+    func testGrowthReloadKeepsAppendedLinesAfterEdit() throws {
+        let url = tempURL("log")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try "a\nb\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let v = PieceTableViewer()
+        XCTAssertTrue(v.open(url: url))
+        // 索引が完成すると piece table が作られる（編集が有効になる）。
+        let ready = XCTNSPredicateExpectation(predicate: NSPredicate { _, _ in v._testLineCount > 0 },
+                                              object: nil)
+        wait(for: [ready], timeout: 5)
+
+        // 他のアプリが末尾へ追記した（同じ inode のまま伸びる＝追従と同じ形）。
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("c\n".utf8))
+        try handle.close()
+
+        XCTAssertTrue(v.reloadFromDisk())
+
+        v._testSetCaret(0)
+        v._testInsert("X")                       // ここで表示の真実が piece table へ移る
+        XCTAssertEqual(v._testDocString, "Xa\nb\nc\n")
+    }
+}


### PR DESCRIPTION
他のアプリでファイルが書き換わったら、その場で取り込む。

## 動き
- 開いているファイルを 0.5 秒ごとに `stat` だけで見張る（内容は読まないので 10GB を開いていてもコストは無視できる）。同じ版を 2 回見てから取り込む＝書き込み途中を掴まない。書かれ続けるログは 4 tick で観念して取り込む。
- **未保存でなければ黙って読み込み直す。** キャレット・スクロール位置は保つ（自動で走るので毎回先頭へ飛ばされたら使い物にならない）。ステータスバーに数秒だけ「他のアプリでの変更を読み込みました」。
- **未保存・整形/絞り込み中は潰さない。** 本文下端のバナーで知らせ、「読み込む」→確認シート→取り込み。× は今回だけ無視（次に変わればまた知らせる）。上端は検索バー・読み取り専用・構造化バナーが取り合っているので下端に置いた。
- **巨大ファイルは追記なら索引を伸ばすだけ**（tail -f と同じ経路）。10GB を張り直せば 8 秒級で、1 行増えるたびにそれをやるのは論外。丸ごと書き換わったときだけ開き直し、見ていた行へ戻す。
- 自分の保存は「知っている版」を更新するので誤検知しない（これを忘れると保存のたびにアンドゥ履歴が飛ぶ）。
- 環境設定＞一般でオフにできる。**オフでもバナーは出す**（古い内容を黙って見せ続けない）。

## ついでに直した穴
追記を取り込んだ後に編集すると追記分が消える（保存すればディスクからも消える）。piece table は生成時の原本長を焼き込んでいるため、索引を伸ばしたら張り直す必要がある。**末尾追従にも前からあった**ので、両者を `extendForGrowth` に集約して塞いだ。回帰テスト付き。

## 検証
- 465 green（+15）。
- 配布 .app で 4 経路とも実機確認: ①非アクティブのまま外部変更→自動反映 ②未保存中に外部変更→未保存の本文が残りバナー（3 回続けて変更しても潰れない） ③バナー→確認シート→取り込み ④⌘S 後に誤検知なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)