### PR TITLE
固定長の項目定義（C）

### DIFF
--- a/Sources/MrEditorCore/AppDelegate.swift
+++ b/Sources/MrEditorCore/AppDelegate.swift
@@ -200,6 +200,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         windowController?.toggleActiveColumnRuler()
     }
 
+    @objc private func editColumnFields(_ sender: NSMenuItem) {
+        windowController?.editActiveColumnFields()
+    }
+
     @objc private func clearColumnGuides(_ sender: NSMenuItem) {
         windowController?.clearActiveColumnGuides()
     }
@@ -340,6 +344,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return c.canJsonQuery
         case #selector(toggleColumnRuler(_:)):
             item.state = c.columnRulerIsVisible ? .on : .off
+            return c.canColumnRuler
+        case #selector(editColumnFields(_:)):
             return c.canColumnRuler
         case #selector(clearColumnGuides(_:)):
             return c.hasColumnGuides
@@ -626,6 +632,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         rulerItem.keyEquivalentModifierMask = [.command, .option]
         rulerItem.target = self
         viewMenu.addItem(rulerItem)
+        // 仕様書を持っている人のための入口（クリックで置くのは仕様書が無いとき）。
+        let fieldsItem = NSMenuItem(title: L("menu.columnRuler.fields"),
+                                    action: #selector(editColumnFields(_:)), keyEquivalent: "k")
+        fieldsItem.keyEquivalentModifierMask = [.command, .option, .shift]
+        fieldsItem.target = self
+        viewMenu.addItem(fieldsItem)
         let clearGuidesItem = NSMenuItem(title: L("menu.columnRuler.clearGuides"),
                                          action: #selector(clearColumnGuides(_:)), keyEquivalent: "")
         clearGuidesItem.target = self

--- a/Sources/MrEditorCore/AppSettings.swift
+++ b/Sources/MrEditorCore/AppSettings.swift
@@ -149,6 +149,7 @@ enum AppSettings {
     private static let autoReloadKey = "MrEditor.autoReloadExternalChanges"
     private static let autoUpdateCheckKey = "MrEditor.automaticUpdateChecks"
     private static let lastUpdateCheckKey = "MrEditor.lastUpdateCheck"
+    private static let columnFieldsKey = "MrEditor.columnFields"
     private static let aiProviderKey = "MrEditor.ai.provider"
     private static let aiModelKey = "MrEditor.ai.model"
     private static let aiBaseURLKey = "MrEditor.ai.baseURL"
@@ -218,6 +219,53 @@ enum AppSettings {
                 defaults.removeObject(forKey: sessionKey)
             }
         }
+    }
+
+    // MARK: - 固定長の項目定義（ファイルごと）
+
+    /// 覚えておくファイル数の上限。超えたら**古いものから**捨てる。
+    private static let columnFieldsCapacity = 200
+
+    /// 固定長の項目定義（境界の桁）をファイルごとに覚える。
+    ///
+    /// **名前を付けて別のファイルにも当てる（プロファイル）ことはしない**——それは Pro の線。
+    /// ここでやるのは「さっき開いていたファイルを開き直したら、さっきの定義のまま」だけで、
+    /// セッション復元と同じ性質（[[CONTRIBUTING.md]] の課金境界）。
+    /// 値は `[path, 保存順の連番, 桁…]` ではなく、桁の配列と最終使用時刻を持つ小さな辞書。
+    private struct ColumnFieldsEntry: Codable {
+        var columns: [Int]
+        var usedAt: Date
+    }
+
+    private static func columnFieldsMap() -> [String: ColumnFieldsEntry] {
+        guard let data = defaults.data(forKey: columnFieldsKey),
+              let map = try? JSONDecoder().decode([String: ColumnFieldsEntry].self, from: data) else { return [:] }
+        return map
+    }
+
+    /// そのファイルに覚えてある項目定義（無ければ空）。
+    static func columnGuides(for url: URL?) -> [Int] {
+        guard let url else { return [] }
+        return columnFieldsMap()[url.path]?.columns ?? []
+    }
+
+    /// そのファイルの項目定義を覚える（空配列＝忘れる）。
+    static func setColumnGuides(_ columns: [Int], for url: URL?) {
+        guard let url else { return }
+        var map = columnFieldsMap()
+        if columns.isEmpty {
+            guard map.removeValue(forKey: url.path) != nil else { return }
+        } else {
+            let entry = ColumnFieldsEntry(columns: columns, usedAt: Date())
+            if map[url.path]?.columns == columns { map[url.path]?.usedAt = entry.usedAt } else { map[url.path] = entry }
+            if map.count > columnFieldsCapacity {
+                for key in map.sorted(by: { $0.value.usedAt < $1.value.usedAt })
+                    .prefix(map.count - columnFieldsCapacity).map(\.key) {
+                    map.removeValue(forKey: key)
+                }
+            }
+        }
+        if let data = try? JSONEncoder().encode(map) { defaults.set(data, forKey: columnFieldsKey) }
     }
 
     /// 他のアプリでファイルが書き換わったとき、自動で読み込み直すか。既定 true。

--- a/Sources/MrEditorCore/Core/ColumnRuler.swift
+++ b/Sources/MrEditorCore/Core/ColumnRuler.swift
@@ -66,6 +66,10 @@ struct ColumnGuides: Equatable {
 
     var isEmpty: Bool { columns.isEmpty }
 
+    /// 項目を割る切れ目が 1 つでもあるか。**1 桁目のガイドは切れ目ではない**（そこが先頭）ので、
+    /// `[1]` だけの状態は「定義なし」と同じ＝固定長表示には入れない（列が 1 本では何も分けていない）。
+    var hasFieldBoundaries: Bool { columns.contains { $0 > 1 } }
+
     /// あれば消す、無ければ足す（ルーラーのクリックはこれ）。
     mutating func toggle(_ column: Int) {
         guard column >= 1 else { return }
@@ -89,6 +93,19 @@ struct ColumnGuides: Equatable {
 
     mutating func removeAll() {
         columns.removeAll()
+    }
+
+    /// ガイドを `column` から `newColumn` へ動かす（ルーラーのドラッグ）。動いたら true。
+    ///
+    /// **1 桁ずらすのに消して置き直させない**ためにある。行き先に既にガイドがあるときは
+    /// 動かさない（2 本を重ねると片方が消えたように見え、離したときに戻せない）。
+    @discardableResult
+    mutating func move(_ column: Int, to newColumn: Int) -> Bool {
+        guard newColumn >= 1, newColumn != column,
+              let i = columns.firstIndex(of: column), !columns.contains(newColumn) else { return false }
+        columns[i] = newColumn
+        columns.sort()
+        return true
     }
 
     /// `column` から `tolerance` 桁以内で最も近いガイド。クリックの当たり判定に使う
@@ -118,5 +135,115 @@ struct ColumnGuides: Equatable {
             ranges.append(start...last)
         }
         return ranges
+    }
+}
+
+extension ColumnGuides {
+    /// サンプル行に合わせた項目の桁範囲。**最後の項目は一番長い行の末尾で閉じる**。
+    ///
+    /// ガイドは切れ目しか持たないので「最後の項目がどこで終わるか」はデータが決める。
+    /// 幅は文字数ではなく**見えている桁**（全角＝2）で測る。ガイド線は画面上の位置に
+    /// 引かれるので、ここを文字数で測ると全角を含む行で線と項目がズレる。
+    func fieldRanges(fitting sampleLines: [String]) -> [ClosedRange<Int>] {
+        // 定義が data より右まで伸びていても（`…15-40` を 30 桁のデータに当てるなど）、
+        // 閉じるのはデータの端。空の列を 1 本増やさない。
+        let widest = sampleLines.reduce(0) { max($0, TabularFormatter.displayWidth($1)) }
+        guard widest >= 1 else { return [] }
+        return fieldRanges(lastColumn: widest)
+    }
+}
+
+/// 固定長の項目定義（`1-8,9-14,15-40`）の読み書き。
+///
+/// **固定長を扱う人はたいてい仕様書を持っている**＝境界をクリックで置くだけでは苦行になる。
+/// 逆に仕様書が無いときは境界を探すことが本体なのでクリックも要る。両方を同じ 1 つの状態
+/// （`ColumnGuides`）に落とすのがここ。**ガイド＝項目の切れ目**なので、文字列との往復は
+/// 「境界の桁の集合」を経由する（[[ColumnGuides.fieldRanges]] の裏返し）。
+enum ColumnFieldSpec {
+    /// 受け付ける区切り（半角/全角のカンマ・読点・空白）。
+    private static let separators = CharacterSet(charactersIn: ",，、 \u{3000}\t\n")
+    /// 受け付ける範囲記号（半角/全角ハイフン・各種ダッシュ・波ダッシュ）。
+    private static let dashes: Set<Character> = ["-", "\u{2010}", "\u{2011}", "\u{2012}", "\u{2013}",
+                                                 "\u{2014}", "\u{2015}", "\u{FF0D}", "\u{FF5E}",
+                                                 "\u{301C}", "~", "\u{30FC}"]
+    /// 桁数の上限（打ち間違いで巨大な配列を作らせない）。
+    static let maxColumn = 100_000
+    /// 項目数の上限。
+    static let maxFields = 512
+
+    /// `1-8,9-14,15-40` を**境界の桁**（1 始まり・昇順・重複なし）に読む。
+    ///
+    /// - `a-b`＝a 桁目から b 桁目まで、`a-`＝a 桁目から行末まで、`a` 単独＝a 桁目から次の境界まで。
+    /// - 空文字列は「定義なし」＝空配列（エラーではない）。
+    /// - 桁が戻る／重なる／0 以下／上限超えは nil（黙って一部だけ通さない）。
+    static func parse(_ text: String) -> [Int]? {
+        let tokens = text
+            .components(separatedBy: separators)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !tokens.isEmpty else { return [] }
+        guard tokens.count <= maxFields else { return nil }
+
+        var boundaries: [Int] = []
+        var prevEnd = 0            // 直前の項目が閉じた桁（0＝まだ無い）
+        for token in tokens {
+            guard let field = parseToken(token) else { return nil }
+            guard field.start > prevEnd else { return nil }        // 桁が戻る／重なる
+            if let end = field.end {
+                guard end >= field.start, end <= maxColumn else { return nil }
+                prevEnd = end
+            } else {
+                prevEnd = field.start                              // 開いた項目＝以降は書けない
+            }
+            if field.start > 1 { boundaries.append(field.start) }
+            if let end = field.end { boundaries.append(end + 1) }
+        }
+        // 末尾が閉じている（`…-40`）ときの 41 は「そこで終わり」の印。行末までの項目が
+        // 続く定義（`41-`）と区別するために残す。
+        let unique = Array(Set(boundaries.filter { $0 >= 2 && $0 <= maxColumn + 1 })).sorted()
+        return unique
+    }
+
+    /// 1 トークン → (開始桁, 終了桁 or nil＝行末まで)。
+    private static func parseToken(_ token: String) -> (start: Int, end: Int?)? {
+        let chars = Array(token)
+        guard let dashIndex = chars.firstIndex(where: { dashes.contains($0) }) else {
+            guard let n = number(String(chars)) else { return nil }
+            return (n, nil)
+        }
+        guard let start = number(String(chars[chars.startIndex..<dashIndex])) else { return nil }
+        let tail = String(chars[chars.index(after: dashIndex)...])
+        if tail.isEmpty { return (start, nil) }
+        guard let end = number(tail) else { return nil }
+        return (start, end)
+    }
+
+    /// 半角/全角の数字だけからなる 1 以上の整数。
+    private static func number(_ s: String) -> Int? {
+        let normalized = String(s.map { ch -> Character in
+            guard let v = ch.unicodeScalars.first?.value, (0xFF10...0xFF19).contains(v) else { return ch }
+            return Character(UnicodeScalar(v - 0xFF10 + 0x30)!)
+        })
+        guard !normalized.isEmpty, normalized.allSatisfy({ $0.isASCII && $0.isNumber }),
+              let n = Int(normalized),
+              n >= 1, n <= maxColumn else { return nil }
+        return n
+    }
+
+    /// いまのガイドを `1-8,9-14,15-` の形で書き出す（ダイアログの初期値）。
+    ///
+    /// 最後の項目は**行末まで開いている**。ガイドは切れ目しか持たないので、
+    /// 「どこで終わるか」を勝手に決めない。
+    static func text(for guides: ColumnGuides) -> String {
+        let bounds = guides.columns.filter { $0 > 1 }
+        guard !bounds.isEmpty else { return "" }
+        var parts: [String] = []
+        var start = 1
+        for b in bounds {
+            if b - 1 >= start { parts.append("\(start)-\(b - 1)") }
+            start = b
+        }
+        parts.append("\(start)-")
+        return parts.joined(separator: ",")
     }
 }

--- a/Sources/MrEditorCore/Core/TabularFormatter.swift
+++ b/Sources/MrEditorCore/Core/TabularFormatter.swift
@@ -3,8 +3,20 @@ import Foundation
 /// 構造化表示のモード。CSV/TSV は区切り整形、NDJSON はキー投影、JSON は単一
 /// ドキュメントの字下げ整形（後者は列指向でないため `TabularFormatter` は通らず、
 /// ビューア側で `JsonFormatter` に委譲する。ここには乗らない）。
+///
+/// `fixedWidth` だけは**中身から自動判定できない**。区切り文字が無いのだから、
+/// どこが項目の切れ目かは人間（＝桁ガイド）が決めるしかない。定義が無ければ
+/// このモードには入れない（呼ぶ側が先に定義を訊く）。
 public enum StructuredMode: String, CaseIterable, Sendable {
-    case csv, tsv, ndjson, json
+    case csv, tsv, ndjson, json, fixedWidth
+
+    /// バナーやメニューに出す名前。`rawValue.uppercased()` だと `FIXEDWIDTH` になる。
+    public var displayName: String {
+        switch self {
+        case .csv, .tsv, .ndjson, .json: return rawValue.uppercased()
+        case .fixedWidth: return L("structured.fixedWidth")
+        }
+    }
 }
 
 /// 生の1行文字列を、等幅カラムに桁揃えした表示文字列へ整形する純ロジック（UI 非依存）。
@@ -18,6 +30,8 @@ public struct TabularFormatter {
 
     let mode: StructuredMode
     let columns: [Column]
+    /// 固定長のときの項目の桁範囲（1 始まり・閉区間）。他のモードでは空。
+    let fields: [ClosedRange<Int>]
     /// セルの区切り。
     static let separator = " │ "
 
@@ -26,9 +40,25 @@ public struct TabularFormatter {
     // MARK: - 構築
 
     /// サンプル行（生文字列・先頭〜1000 行想定）から列（名前＋固定幅）を確定する。
-    static func build(mode: StructuredMode, sampleLines: [String], widthCap: Int = 40) -> TabularFormatter {
+    ///
+    /// `fields` は固定長のときだけ意味を持つ（桁ガイドから来る項目の範囲）。
+    /// 空のまま `.fixedWidth` を渡すと列が 0 になる＝**呼ぶ側が先に定義を持つこと**。
+    static func build(mode: StructuredMode, sampleLines: [String], widthCap: Int = 40,
+                      fields: [ClosedRange<Int>] = []) -> TabularFormatter {
         let rows = sampleLines.filter { !$0.isEmpty }
         switch mode {
+        case .fixedWidth:
+            let fmt = TabularFormatter(mode: mode, columns: [], fields: fields)
+            var widths = fields.map { displayWidth(label(of: $0)) }
+            for line in rows {
+                for (j, cell) in fmt.fixedCells(of: line).enumerated() where j < widths.count {
+                    widths[j] = max(widths[j], displayWidth(cell))
+                }
+            }
+            // 幅の上限は掛けない。項目の幅は定義で決まっていて、切り詰めると
+            // 「桁を数えるために出した表示」で桁が落ちる。
+            let cols = zip(fields, widths).map { Column(key: label(of: $0), width: max(1, $1)) }
+            return TabularFormatter(mode: mode, columns: cols, fields: fields)
         case .csv, .tsv:
             let sep: Character = (mode == .csv) ? "," : "\t"
             let parsed = rows.map { splitDelimited($0, sep: sep, csvQuotes: mode == .csv) }
@@ -41,7 +71,7 @@ public struct TabularFormatter {
                 for cells in parsed where j < cells.count { w = max(w, displayWidth(cells[j])) }
                 cols.append(Column(key: name, width: clampWidth(w, cap: widthCap)))
             }
-            return TabularFormatter(mode: mode, columns: cols)
+            return TabularFormatter(mode: mode, columns: cols, fields: [])
         case .ndjson:
             var order: [String] = []
             var seen = Set<String>()
@@ -55,10 +85,10 @@ public struct TabularFormatter {
                 }
             }
             let cols = order.map { Column(key: $0, width: clampWidth(maxW[$0] ?? displayWidth($0), cap: widthCap)) }
-            return TabularFormatter(mode: mode, columns: cols)
+            return TabularFormatter(mode: mode, columns: cols, fields: [])
         case .json:
             // JSON はビューアが JsonFormatter に委譲するため、ここへは来ない（保険で空列）。
-            return TabularFormatter(mode: mode, columns: [])
+            return TabularFormatter(mode: mode, columns: [], fields: [])
         }
     }
 
@@ -89,8 +119,41 @@ public struct TabularFormatter {
         case .ndjson:
             guard let obj = Self.jsonObject(rawLine) else { return [rawLine] }
             return columns.map { Self.valueString(obj[$0.key] ?? NSNull()) }
+        case .fixedWidth:
+            return fixedCells(of: rawLine)
         case .json:
             return [rawLine]   // JSON はビューア側で整形。ここは保険。
+        }
+    }
+
+    // MARK: - 固定長（桁で切る）
+
+    /// 項目の見出し（`1-8`）。固定長には列名が無いので**桁そのもの**を名前にする。
+    /// 分析（Pro）の列選択にもこの名前が出るので、見て何桁目か分かる形にしておく。
+    static func label(of range: ClosedRange<Int>) -> String { "\(range.lowerBound)-\(range.upperBound)" }
+
+    /// 1 行を項目の桁範囲で切る。
+    ///
+    /// **切る単位は「文字」ではなく「見えている桁」**（全角は 2 桁）。桁ルーラーとガイド線は
+    /// 画面上の位置に引かれるので、文字数で切ると全角を含む行だけ線と中身がズレる。
+    /// 桁をまたぐ全角文字は**始まった側の項目**に入れる（1 文字を割らない）。
+    /// 項目の余白（右端の空白）は落とす＝値そのものを見せる。
+    func fixedCells(of rawLine: String) -> [String] {
+        guard !fields.isEmpty else { return [rawLine] }
+        var cells = [String](repeating: "", count: fields.count)
+        var column = 1                      // いま見ている文字が始まる桁（1 始まり）
+        var f = 0                           // いま入れている項目
+        for ch in rawLine {
+            let w = Self.charWidth(ch)
+            while f < fields.count, column > fields[f].upperBound { f += 1 }
+            if f >= fields.count { break }   // 定義の外（右）に出た
+            if column >= fields[f].lowerBound { cells[f].append(ch) }
+            column += w
+        }
+        return cells.map { cell in
+            var s = cell
+            while s.hasSuffix(" ") { s.removeLast() }
+            return s
         }
     }
 

--- a/Sources/MrEditorCore/MainWindowController.swift
+++ b/Sources/MrEditorCore/MainWindowController.swift
@@ -699,6 +699,55 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
     func clearActiveColumnGuides() {
         activeViewer?.clearColumnGuides()
     }
+
+    /// 固定長の項目定義を数値で打つ（`1-8,9-14,15-40`）。
+    ///
+    /// **クリックで置くだけでは足りない。** 固定長を扱う人はたいてい仕様書を持っていて、
+    /// 32 項目を目視で置かせるのは苦行。逆に仕様書が無いときは境界を探すことが本体なので、
+    /// クリックとドラッグも要る。どちらも同じ 1 つの状態（桁ガイド）を書き換える。
+    func editActiveColumnFields(completion: ((Bool) -> Void)? = nil) {
+        guard let v = activeViewer, v.supportsColumnRuler else { NSSound.beep(); completion?(false); return }
+        let current = ColumnFieldSpec.text(for: ColumnGuides(v.columnGuideColumns))
+        promptForColumnFields(initial: current) { [weak self] columns in
+            guard let columns else { completion?(false); return }        // キャンセル
+            v.setColumnGuides(columns)
+            // 打ったのに何も見えない、を作らない（線とルーラーは同時に出す）。
+            if !columns.isEmpty, !v.columnRulerVisible { v.setColumnRulerVisible(true) }
+            _ = self
+            completion?(!columns.isEmpty)
+        }
+    }
+
+    /// 項目定義を訊くシート。OK なら境界の桁（空＝定義なし）、キャンセルなら nil。
+    /// 読めない書き方は**黙って一部だけ通さない**（直してもらうまで同じシートに戻る）。
+    private func promptForColumnFields(initial: String, completion: @escaping ([Int]?) -> Void) {
+        guard let win = window else { completion(nil); return }
+        let alert = NSAlert()
+        alert.messageText = L("columnFields.prompt")
+        alert.informativeText = L("columnFields.message")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 360, height: 24))
+        field.placeholderString = "1-8,9-14,15-40"
+        field.stringValue = initial
+        alert.accessoryView = field
+        alert.addButton(withTitle: L("common.ok"))
+        alert.addButton(withTitle: L("common.cancel"))
+        alert.window.initialFirstResponder = field
+        alert.beginSheetModal(for: win) { [weak self] resp in
+            guard resp == .alertFirstButtonReturn else { completion(nil); return }
+            let text = field.stringValue
+            guard let columns = ColumnFieldSpec.parse(text) else {
+                let bad = NSAlert()
+                bad.alertStyle = .warning
+                bad.messageText = L("columnFields.invalid")
+                bad.informativeText = L("columnFields.message")
+                bad.beginSheetModal(for: win) { _ in
+                    self?.promptForColumnFields(initial: text, completion: completion)
+                }
+                return
+            }
+            completion(columns)
+        }
+    }
     /// アクティブなドキュメントが編集可能か（編集ツールボックスのメニュー有効化に使う）。
     var canTransformText: Bool { activeViewer?.canEdit ?? false }
     /// アクティブなドキュメントの選択に編集ツールボックスの変換を適用する。
@@ -1006,8 +1055,22 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
     /// アクティブなドキュメントの構造化表示モード（メニューのチェック用）。
     var activeStructuredMode: StructuredMode? { activeViewer?.structuredMode }
     /// アクティブなドキュメントの構造化表示モードを設定する。
+    ///
+    /// 固定長だけは中身から列を割り出せない（区切り文字が無い）。**定義が無いまま選んだら
+    /// その場で訊く**——「構造化モードだが列が未定義」という説明のつかない状態を作らない。
     func setActiveStructuredMode(_ mode: StructuredMode?) {
         guard let v = activeViewer, v.supportsStructured else { NSSound.beep(); return }
+        if mode == .fixedWidth, !ColumnGuides(v.columnGuideColumns).hasFieldBoundaries {
+            editActiveColumnFields { [weak self] defined in
+                guard defined else { return }        // 定義しなかった＝切り替えない
+                self?.applyStructuredMode(.fixedWidth, to: v)
+            }
+            return
+        }
+        applyStructuredMode(mode, to: v)
+    }
+
+    private func applyStructuredMode(_ mode: StructuredMode?, to v: DocumentPane) {
         v.setStructuredMode(mode)
         // 巨大ファイル側は構造化中でも検索・フィルタが効く（桁を揃えたまま grep する）ので閉じない。
         // 小ファイル側は本文が整形後に差し替わり検索できないので、そちらだけ閉じる。

--- a/Sources/MrEditorCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditorCore/Resources/en.lproj/Localizable.strings
@@ -84,12 +84,18 @@
 "menu.structured.tsv" = "TSV";
 "menu.structured.ndjson" = "NDJSON";
 "menu.structured.json" = "JSON";
+"menu.structured.fixedWidth" = "Fixed-width";
 "structured.banner" = "Structured view (read-only)";
 "structured.revert" = "Back to raw text";
 "structured.hint" = "Display-only formatting. Your file is never modified (saving keeps the original CSV/JSON).";
 "menu.jsonquery" = "JSON Query…";
 "menu.columnRuler" = "Column Ruler";
+"menu.columnRuler.fields" = "Column Fields…";
 "menu.columnRuler.clearGuides" = "Clear Column Guides";
+"structured.fixedWidth" = "Fixed-width";
+"columnFields.prompt" = "Fixed-width fields";
+"columnFields.message" = "List each field as a column range, separated by commas (e.g. 1-8,9-14,15-40). Write 41- to run to the end of the line. Leave empty to clear the definition.";
+"columnFields.invalid" = "Cannot read that field definition";
 "jsonquery.placeholder" = "e.g. items[?age >= 30].name";
 "jsonquery.error" = "Invalid query or JSON";
 

--- a/Sources/MrEditorCore/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditorCore/Resources/ja.lproj/Localizable.strings
@@ -84,12 +84,18 @@
 "menu.structured.tsv" = "TSV";
 "menu.structured.ndjson" = "NDJSON";
 "menu.structured.json" = "JSON";
+"menu.structured.fixedWidth" = "固定長";
 "structured.banner" = "構造化表示（読み取り専用）";
 "structured.revert" = "元のテキストに戻す";
 "structured.hint" = "表示だけの整形です。ファイルは変更されません（保存しても元の CSV/JSON のまま）。";
 "menu.jsonquery" = "JSON クエリ…";
 "menu.columnRuler" = "桁ルーラー";
+"menu.columnRuler.fields" = "桁の項目定義…";
 "menu.columnRuler.clearGuides" = "桁ガイドを消す";
+"structured.fixedWidth" = "固定長";
+"columnFields.prompt" = "固定長の項目定義";
+"columnFields.message" = "何桁目から何桁目までかを、カンマ区切りで書きます（例: 1-8,9-14,15-40）。最後を 41- と書くと行末までです。空にすると定義を消します。";
+"columnFields.invalid" = "項目定義を読めません";
 "jsonquery.placeholder" = "例: items[?age >= 30].name";
 "jsonquery.error" = "式または JSON が不正";
 

--- a/Sources/MrEditorCore/UI/ColumnRulerView.swift
+++ b/Sources/MrEditorCore/UI/ColumnRulerView.swift
@@ -25,6 +25,9 @@ final class ColumnRulerView: NSView {
     var horizontalOffset: CGFloat = 0 { didSet { if horizontalOffset != oldValue { needsDisplay = true } } }
     /// 引いてあるガイド。
     var guides = ColumnGuides() { didSet { if guides != oldValue { needsDisplay = true } } }
+    /// 項目定義をいじれるか。**構造化表示中は false**——整形後の表示では画面の桁と
+    /// 定義の桁が別物なので、印を出すのも掴ませるのも嘘になる（目盛りは表示の桁として有効）。
+    var guidesEditable = true { didSet { if guidesEditable != oldValue { needsDisplay = true } } }
     /// キャレットのある桁（1 始まり）。nil なら強調しない。
     var currentColumn: Int? { didSet { if currentColumn != oldValue { needsDisplay = true } } }
     /// 選択の桁範囲（1 始まり・閉区間）。nil なら帯を出さない。
@@ -32,9 +35,18 @@ final class ColumnRulerView: NSView {
 
     /// ルーラーをクリックしてガイドを足す／消す。
     var onToggleGuide: ((Int) -> Void)?
+    /// ガイドを掴んで動かす（from, to）。動かせたら true を返すこと（行き先が埋まっていたら false）。
+    var onMoveGuide: ((Int, Int) -> Bool)?
 
     /// 数字ラベルの当たり判定を緩める許容幅（桁）。細い線をピクセル単位で狙わせない。
     private let hitTolerance = 1
+
+    /// 掴んでいるガイドの桁（ドラッグ中のみ）。
+    private var draggingColumn: Int?
+    /// 掴んだのが**既にあったガイド**か（そうでなければ mouseDown で足したばかり）。
+    private var draggingExisting = false
+    /// 掴んでから 1 桁でも動いたか（動かなければクリック＝トグル）。
+    private var didDrag = false
 
     override var isFlipped: Bool { true }
     override var isOpaque: Bool { EditorTheme.isOpaqueBackground }
@@ -130,7 +142,7 @@ final class ColumnRulerView: NSView {
     }
 
     private func drawGuideMarkers(theme: EditorColorTheme) {
-        guard !guides.isEmpty else { return }
+        guard !guides.isEmpty, guidesEditable else { return }
         theme.columnGuide(alpha: 0.85).setFill()
         for col in guides.columns {
             let x = floor(viewX(ofColumn: col))
@@ -141,13 +153,46 @@ final class ColumnRulerView: NSView {
 
     // MARK: - 操作
 
+    /// クリックで置く／消す、掴んで動かす。
+    ///
+    /// **1 桁ずらすのに「消して置き直す」をさせない。** 既にあるガイドの上で押したら
+    /// そのまま掴んだ状態にし、動かさずに離したときだけ消す。何も無い所で押したら
+    /// その場で 1 本置き、**そのまま続けて動かせる**（置いてから微調整、が 1 操作で済む）。
     override func mouseDown(with event: NSEvent) {
         let p = convert(event.locationInWindow, from: nil)
-        guard p.x >= contentInset else { return }
+        guard guidesEditable, p.x >= contentInset else { return }
         let col = column(atViewX: p.x)
-        // 近くに既にあるならそれを消す（細い線を正確に狙わせない）。
-        let target = guides.nearest(to: col, within: hitTolerance) ?? col
-        onToggleGuide?(target)
+        didDrag = false
+        if let hit = guides.nearest(to: col, within: hitTolerance) {
+            draggingColumn = hit
+            draggingExisting = true
+        } else {
+            draggingColumn = col
+            draggingExisting = false
+            onToggleGuide?(col)      // 置くのは押した時点（動かすなら続けてドラッグ）
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let from = draggingColumn else { return }
+        let p = convert(event.locationInWindow, from: nil)
+        let to = column(atViewX: max(contentInset, p.x))
+        guard to != from else { return }
+        if onMoveGuide?(from, to) == true {
+            draggingColumn = to
+            didDrag = true
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        defer { draggingColumn = nil; draggingExisting = false; didDrag = false }
+        guard let col = draggingColumn, draggingExisting, !didDrag else { return }
+        // 離した場所が押した桁と違うなら、途中の drag イベントが届かなかっただけ＝動かす。
+        // ここを見ずに消すと、素早く掴んで動かしたときにガイドが消える。
+        let p = convert(event.locationInWindow, from: nil)
+        let to = column(atViewX: max(contentInset, p.x))
+        if to != col, onMoveGuide?(col, to) == true { return }
+        onToggleGuide?(col)          // 既にあるガイドを動かさず離した＝消す
     }
 
     override func resetCursorRects() {

--- a/Sources/MrEditorCore/UI/StructuredBanner.swift
+++ b/Sources/MrEditorCore/UI/StructuredBanner.swift
@@ -57,7 +57,7 @@ final class StructuredBanner: NSView {
 
     /// モード名（CSV/TSV/NDJSON）を反映する。
     func configure(mode: StructuredMode) {
-        label.stringValue = L("structured.banner") + " · " + mode.rawValue.uppercased()
+        label.stringValue = L("structured.banner") + " · " + mode.displayName
         applyBackground()   // テーマが変わっていることがある
     }
 

--- a/Sources/MrEditorCore/Viewer/DocumentPane.swift
+++ b/Sources/MrEditorCore/Viewer/DocumentPane.swift
@@ -175,6 +175,14 @@ protocol DocumentPane: NSView {
     var hasColumnGuides: Bool { get }
     /// 桁ガイドを全部消す。
     func clearColumnGuides()
+
+    // MARK: - 固定長の項目定義（C）
+
+    /// いま引いてあるガイドの桁（1 始まり・昇順）＝項目の切れ目。
+    var columnGuideColumns: [Int] { get }
+    /// 項目定義（境界の桁）をまとめて置き換える。数値入力ダイアログと、ファイルごとの
+    /// 記憶の復元がここを通る。**空配列＝定義なし。**
+    func setColumnGuides(_ columns: [Int])
 }
 
 extension DocumentPane {
@@ -257,6 +265,8 @@ extension DocumentPane {
     func setColumnRulerVisible(_ on: Bool) {}
     var hasColumnGuides: Bool { false }
     func clearColumnGuides() {}
+    var columnGuideColumns: [Int] { [] }
+    func setColumnGuides(_ columns: [Int]) {}
 
     func applyLineWrap() {}
     func ensureVisibleLayout() {}

--- a/Sources/MrEditorCore/Viewer/DocumentView.swift
+++ b/Sources/MrEditorCore/Viewer/DocumentView.swift
@@ -71,6 +71,9 @@ final class DocumentView: NSView {
 
     /// 桁ガイド線を引く桁（1 始まり）。空なら描かない。
     var columnGuides = ColumnGuides() { didSet { if columnGuides != oldValue { needsDisplay = true } } }
+    /// ガイド線を伏せる（構造化表示中）。**定義は生の本文の桁**なので、整形後の表示に
+    /// 重ねると別の場所を指す。定義そのものは消さずに描画だけ止める。
+    var columnGuidesHidden = false { didSet { if columnGuidesHidden != oldValue { needsDisplay = true } } }
     /// 等幅フォント 1 桁の幅（`configure(font:)` が更新）。ルーラーと共有する値。
     private(set) var columnWidth: CGFloat = 8
 
@@ -305,7 +308,7 @@ final class DocumentView: NSView {
     /// 行の帯（diff・現在行）を塗った**後**に重ねる。背景として先に描くと帯に消される。
     /// 細い半透明の線なので、文字の上に乗っても読めなくならない。
     private func drawColumnGuides(xOffset: CGFloat) {
-        guard !columnGuides.isEmpty, !wrapEnabled else { return }   // 折り返し中は桁が定まらない
+        guard !columnGuides.isEmpty, !columnGuidesHidden, !wrapEnabled else { return }   // 折り返し中は桁が定まらない
         NSGraphicsContext.saveGraphicsState()
         defer { NSGraphicsContext.restoreGraphicsState() }
         NSBezierPath(rect: NSRect(x: gutterWidth, y: 0,

--- a/Sources/MrEditorCore/Viewer/EditableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/EditableViewer.swift
@@ -192,6 +192,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         columnRuler.translatesAutoresizingMaskIntoConstraints = false
         columnRuler.isHidden = true
         columnRuler.onToggleGuide = { [weak self] col in self?.toggleColumnGuide(col) }
+        columnRuler.onMoveGuide = { [weak self] from, to in self?.moveColumnGuide(from, to: to) ?? false }
         addSubview(columnRuler)
 
         // 上から [クエリバー][桁ルーラー][本文]。出ているものだけが場所を取る。
@@ -244,12 +245,47 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     func clearColumnGuides() {
         guard !textView.columnGuides.isEmpty else { return }
         textView.columnGuides.removeAll()
-        columnRuler.guides = textView.columnGuides
+        columnGuidesChanged()
+    }
+
+    var columnGuideColumns: [Int] { textView.columnGuides.columns }
+
+    func setColumnGuides(_ columns: [Int]) {
+        let next = ColumnGuides(columns)
+        guard next != textView.columnGuides else { return }
+        textView.columnGuides = next
+        columnGuidesChanged()
     }
 
     private func toggleColumnGuide(_ column: Int) {
         textView.columnGuides.toggle(column)
+        columnGuidesChanged()
+    }
+
+    private func moveColumnGuide(_ from: Int, to: Int) -> Bool {
+        guard textView.columnGuides.move(from, to: to) else { return false }
+        columnGuidesChanged()
+        return true
+    }
+
+    /// ガイドが変わったら、ルーラー・本文・**そのファイルの記憶**を揃える。
+    /// 固定長表示中なら列の切れ目そのものが変わったので整形し直す。
+    private func columnGuidesChanged() {
         columnRuler.guides = textView.columnGuides
+        updateColumnGuideVisibility()
+        textView.needsDisplay = true
+        AppSettings.setColumnGuides(textView.columnGuides.columns, for: fileURL)
+        if structuredFormatter?.mode == .fixedWidth { setStructuredMode(.fixedWidth) }
+    }
+
+    /// 開いたファイルに覚えてある項目定義を戻す。**覚えていたときはルーラーも出す**
+    /// （黙って縦線だけが引かれていると、何の線か分からない）。
+    private func restoreColumnGuides() {
+        let remembered = AppSettings.columnGuides(for: fileURL)
+        textView.columnGuides = ColumnGuides(remembered)
+        columnRuler.guides = textView.columnGuides
+        updateColumnGuideVisibility()
+        if !remembered.isEmpty, !columnRulerOn { setColumnRulerVisible(true) }
     }
 
     /// クエリバー／桁ルーラーの有無に応じて本文の上端を張り替える。
@@ -266,6 +302,17 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         } else {
             (bar ? scrollTopToBar : scrollTopToContainer)?.isActive = true
         }
+    }
+
+    /// 整形後の表示にガイド線を重ねない。
+    ///
+    /// **項目定義は「生の本文の桁」**。構造化表示に入ると本文は区切り記号ごと組み直されるので、
+    /// 同じ桁に線を引くと項目の切れ目でない所を指す（実機で気づいた）。定義は保ったまま
+    /// 描画と操作だけ止め、抜ければそのまま戻る。
+    private func updateColumnGuideVisibility() {
+        let structured = structuredFormatter != nil || jsonPrettyActive || jsonQueryActive
+        textView.columnGuidesHidden = structured
+        columnRuler.guidesEditable = !structured
     }
 
     /// ルーラーへ現在の桁幅・原点・スクロール量・キャレット桁を送る。
@@ -380,6 +427,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         textView.undoManager?.removeAllActions()   // 読み込みはアンドゥ対象にしない
         textView.setSelectedRange(NSRange(location: 0, length: 0))
         setDirty(false)
+        restoreColumnGuides()
         emitState()
         return true
     }
@@ -949,6 +997,11 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     // MARK: - 構造化表示
 
     func setStructuredMode(_ mode: StructuredMode?) {
+        applyStructuredMode(mode)
+        updateColumnGuideVisibility()   // 整形後の表示にガイド線を残さない（入口が多いのでここで一括）
+    }
+
+    private func applyStructuredMode(_ mode: StructuredMode?) {
         if jsonQueryActive { closeJsonQuery() }   // クエリ中に構造化へ切替えるならまず畳む
         guard let mode else {
             // OFF: 本文復元・編集可・折り返し復帰。
@@ -984,8 +1037,6 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             invalidateLineIndex()
             return
         }
-        preStructuredText = source
-        jsonPrettyActive = false
         var lines = source.components(separatedBy: "\n")
         if lines.last == "" { lines.removeLast() }   // 末尾改行の余り
         // 先頭だけでは後半で桁が伸びる列を取りこぼすため、両端をサンプルする
@@ -993,7 +1044,16 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         let sample = lines.count > 2000
             ? Array(lines.prefix(1000)) + Array(lines.suffix(1000))
             : lines
-        let fmt = TabularFormatter.build(mode: mode, sampleLines: sample)
+        // 固定長は中身から列を割り出せない。桁ガイド（＝人間が置いた切れ目）が定義そのもの。
+        var fields: [ClosedRange<Int>] = []
+        if mode == .fixedWidth {
+            guard textView.columnGuides.hasFieldBoundaries else { NSSound.beep(); return }
+            fields = textView.columnGuides.fieldRanges(fitting: sample)
+            guard !fields.isEmpty else { NSSound.beep(); return }
+        }
+        preStructuredText = source
+        jsonPrettyActive = false
+        let fmt = TabularFormatter.build(mode: mode, sampleLines: sample, fields: fields)
         structuredFormatter = fmt
         textView.isEditable = false
         setWrapMode(wrapped: false)
@@ -1015,7 +1075,8 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
         let out = NSMutableAttributedString()
         for (i, line) in lines.enumerated() {
             var attrs = base
-            if formatter.mode != .ndjson, i == 0 { attrs[.font] = bold }
+            // 先頭行が列名なのは CSV/TSV だけ（NDJSON はキー投影、固定長は見出しが無い）。
+            if formatter.mode == .csv || formatter.mode == .tsv, i == 0 { attrs[.font] = bold }
             out.append(NSAttributedString(string: formatter.format(line), attributes: attrs))
             out.append(NSAttributedString(string: "\n", attributes: base))
         }
@@ -1038,6 +1099,11 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
 
     /// クエリバーを開閉する。開くには本文が妥当な JSON であること（不正なら beep）。
     func toggleJsonQuery() {
+        applyToggleJsonQuery()
+        updateColumnGuideVisibility()
+    }
+
+    private func applyToggleJsonQuery() {
         if jsonQueryActive { closeJsonQuery(); return }
         let source = preStructuredText ?? textView.string
         guard JsonFormatter.pretty(source) != nil else { NSSound.beep(); return }   // 妥当な JSON のみ
@@ -1210,6 +1276,8 @@ extension EditableViewer {
     }
     /// ルーラーをクリックしたのと同じこと（当たり判定は `ColumnGuides.nearest` 側でテスト済み）。
     func _testToggleColumnGuide(_ column: Int) { toggleColumnGuide(column) }
+    @discardableResult func _testMoveColumnGuide(_ from: Int, to: Int) -> Bool { moveColumnGuide(from, to: to) }
+    var _testColumnGuidesHidden: Bool { textView.columnGuidesHidden }
     var _testMatchCount: Int { matches.count }
     var _testMatchesCapped: Bool { matchesCapped }
     static var _testMatchCap: Int { matchCap }

--- a/Sources/MrEditorCore/Viewer/EditorTextView.swift
+++ b/Sources/MrEditorCore/Viewer/EditorTextView.swift
@@ -18,6 +18,9 @@ final class EditorTextView: NSTextView {
 
     /// 桁ガイド線を引く桁（1 始まり）。空なら描かない。桁の計算は `ColumnRuler` と共有する。
     var columnGuides = ColumnGuides() { didSet { if columnGuides != oldValue { needsDisplay = true } } }
+    /// ガイド線を伏せる（構造化表示中）。**定義は生の本文の桁**なので、整形後の表示に
+    /// 重ねると別の場所を指す。定義そのものは消さずに描画だけ止める。
+    var columnGuidesHidden = false { didSet { if columnGuidesHidden != oldValue { needsDisplay = true } } }
 
     override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
@@ -28,7 +31,8 @@ final class EditorTextView: NSTextView {
     /// 桁ガイド線。**本文より下（背景段階）に描く。** 小ファイル側は文字の描画を
     /// AppKit に任せているので、後から重ねる口が無い代わりに帯に消される心配も無い。
     private func drawColumnGuides(in rect: NSRect) {
-        guard !columnGuides.isEmpty, let tc = textContainer, !tc.widthTracksTextView else { return }
+        guard !columnGuides.isEmpty, !columnGuidesHidden,
+              let tc = textContainer, !tc.widthTracksTextView else { return }
         let width = EditorStyle.columnWidth(for: font ?? EditorFont.current())
         let originX = textContainerOrigin.x + tc.lineFragmentPadding
         EditorTheme.current().columnGuide(alpha: 0.45).setStroke()

--- a/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
@@ -178,6 +178,7 @@ final class PieceTableViewer: NSView, DocumentPane {
 
         columnRuler.isHidden = true
         columnRuler.onToggleGuide = { [weak self] col in self?.toggleColumnGuide(col) }
+        columnRuler.onMoveGuide = { [weak self] from, to in self?.moveColumnGuide(from, to: to) ?? false }
         addSubview(columnRuler)
 
         // キャレット点滅。
@@ -217,6 +218,11 @@ final class PieceTableViewer: NSView, DocumentPane {
     // MARK: - 構造化表示の切替
 
     func setStructuredMode(_ mode: StructuredMode?) {
+        applyStructuredMode(mode)
+        updateColumnGuideVisibility()   // 整形後の表示にガイド線を残さない
+    }
+
+    private func applyStructuredMode(_ mode: StructuredMode?) {
         guard let mode else {
             structuredFormatter = nil
             // フィルタ中は一致行だけの非連続な並びなので、編集入力は戻さない。
@@ -231,7 +237,14 @@ final class PieceTableViewer: NSView, DocumentPane {
         if mode == .json { NSSound.beep(); return }
         // フィルタとは排他にしない。一致行だけを桁揃えして出す＝「桁を揃えたまま grep する」。
         let sample = structuredSampleLines(1000)
-        structuredFormatter = TabularFormatter.build(mode: mode, sampleLines: sample)
+        // 固定長は中身から列を割り出せない。桁ガイド（＝人間が置いた切れ目）が定義そのもの。
+        var fields: [ClosedRange<Int>] = []
+        if mode == .fixedWidth {
+            guard documentView.columnGuides.hasFieldBoundaries else { NSSound.beep(); return }
+            fields = documentView.columnGuides.fieldRanges(fitting: sample)
+            guard !fields.isEmpty else { NSSound.beep(); return }
+        }
+        structuredFormatter = TabularFormatter.build(mode: mode, sampleLines: sample, fields: fields)
         documentView.inputHandler = nil                  // 読み取り専用
         documentView.wrapEnabled = false                 // 横スクロール（列を折り返さない）
         documentView.setHorizontalOffset(0)
@@ -314,17 +327,61 @@ final class PieceTableViewer: NSView, DocumentPane {
     func clearColumnGuides() {
         guard !documentView.columnGuides.isEmpty else { return }
         documentView.columnGuides.removeAll()
-        columnRuler.guides = documentView.columnGuides
+        columnGuidesChanged()
+    }
+
+    var columnGuideColumns: [Int] { documentView.columnGuides.columns }
+
+    func setColumnGuides(_ columns: [Int]) {
+        let next = ColumnGuides(columns)
+        guard next != documentView.columnGuides else { return }
+        documentView.columnGuides = next
+        columnGuidesChanged()
     }
 
     private func toggleColumnGuide(_ column: Int) {
         documentView.columnGuides.toggle(column)
+        columnGuidesChanged()
+    }
+
+    private func moveColumnGuide(_ from: Int, to: Int) -> Bool {
+        guard documentView.columnGuides.move(from, to: to) else { return false }
+        columnGuidesChanged()
+        return true
+    }
+
+    /// ガイドが変わったら、ルーラー・本文・**そのファイルの記憶**を揃える。
+    /// 固定長表示中なら列の切れ目そのものが変わったので整形し直す。
+    private func columnGuidesChanged() {
         columnRuler.guides = documentView.columnGuides
+        updateColumnGuideVisibility()
+        AppSettings.setColumnGuides(documentView.columnGuides.columns, for: fileURL)
+        if structuredFormatter?.mode == .fixedWidth { setStructuredMode(.fixedWidth) } else { refresh() }
+    }
+
+    /// 開いたファイルに覚えてある項目定義を戻す。**覚えていたときはルーラーも出す**
+    /// （黙って縦線だけが引かれていると、何の線か分からない）。
+    private func restoreColumnGuides() {
+        let remembered = AppSettings.columnGuides(for: fileURL)
+        documentView.columnGuides = ColumnGuides(remembered)
+        columnRuler.guides = documentView.columnGuides
+        updateColumnGuideVisibility()
+        if !remembered.isEmpty, !columnRulerOn { setColumnRulerVisible(true) }
     }
 
     /// ルーラーへ現在の桁幅・原点・スクロール量・キャレット桁を送る。
     /// **原点と横スクロール量は `DocumentView` が本文を描くときに使うものと同じ値**を渡す
     /// （別々に計算すると目盛りと本文が 1 桁ずれる）。
+    /// 整形後の表示にガイド線を重ねない。
+    ///
+    /// **項目定義は「生の本文の桁」**。構造化表示に入ると本文は区切り記号ごと組み直されるので、
+    /// 同じ桁に線を引くと項目の切れ目でない所を指す（実機で気づいた）。定義は保ったまま
+    /// 描画と操作だけ止め、抜ければそのまま戻る。
+    private func updateColumnGuideVisibility() {
+        documentView.columnGuidesHidden = structuredFormatter != nil
+        columnRuler.guidesEditable = structuredFormatter == nil
+    }
+
     private func syncColumnRuler() {
         guard columnRulerOn else { return }
         columnRuler.columnWidth = documentView.columnWidth
@@ -423,6 +480,7 @@ final class PieceTableViewer: NSView, DocumentPane {
         didEncodingFallback = false
         setDirty(false)
         undoMgr.removeAllActions()   // 別ファイルの編集履歴を持ち越さない
+        restoreColumnGuides()        // このファイルに覚えてある固定長の項目定義
         refresh()
 
         idx.buildInBackground(progress: { [weak self] p in
@@ -1750,6 +1808,8 @@ extension PieceTableViewer {
     var _testFirstGlyphX: CGFloat { documentView.contentOriginX }
     /// ルーラーをクリックしたのと同じこと。
     func _testToggleColumnGuide(_ column: Int) { toggleColumnGuide(column) }
+    @discardableResult func _testMoveColumnGuide(_ from: Int, to: Int) -> Bool { moveColumnGuide(from, to: to) }
+    var _testColumnGuidesHidden: Bool { documentView.columnGuidesHidden }
     var _testCaret: Int { caretByte }
     var _testLineCount: Int { pieceTable?.lineCount ?? 0 }
 

--- a/Tests/MrEditorTests/ColumnFieldSpecTests.swift
+++ b/Tests/MrEditorTests/ColumnFieldSpecTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import MrEditorCore
+
+/// 固定長の項目定義（C）の純ロジック——文字列 ↔ 境界の桁、桁で切る、幅を測る。
+///
+/// **ここが「仕様書を持っている人」の入口**なので、読めない書き方を黙って一部だけ
+/// 通さないこと（半端に通ると、ずれた項目定義でデータを読み違える）を一番厚く見る。
+final class ColumnFieldSpecTests: XCTestCase {
+
+    // MARK: - 文字列 → 境界の桁
+
+    func testParsesClosedFields() {
+        // 1-8 / 9-14 / 15-40 の切れ目は 9・15、そして 40 で閉じる印の 41。
+        XCTAssertEqual(ColumnFieldSpec.parse("1-8,9-14,15-40"), [9, 15, 41])
+    }
+
+    func testParsesOpenLastField() {
+        XCTAssertEqual(ColumnFieldSpec.parse("1-8,9-14,15-"), [9, 15])
+    }
+
+    func testBareNumbersAreFieldStarts() {
+        XCTAssertEqual(ColumnFieldSpec.parse("1,9,15"), [9, 15])
+    }
+
+    func testAcceptsSpacesAndFullWidthPunctuation() {
+        XCTAssertEqual(ColumnFieldSpec.parse(" 1-8 , 9-14 "), ColumnFieldSpec.parse("1-8,9-14"))
+        XCTAssertEqual(ColumnFieldSpec.parse("１-８，９-１４"), ColumnFieldSpec.parse("1-8,9-14"))
+        XCTAssertEqual(ColumnFieldSpec.parse("1〜8、9〜14"), ColumnFieldSpec.parse("1-8,9-14"))
+    }
+
+    func testGapBecomesItsOwnField() {
+        // 1-8 と 15-20 の間（9-14）は捨てず、独立した項目として残す。
+        XCTAssertEqual(ColumnFieldSpec.parse("1-8,15-20"), [9, 15, 21])
+    }
+
+    func testEmptyMeansNoDefinition() {
+        XCTAssertEqual(ColumnFieldSpec.parse(""), [])
+        XCTAssertEqual(ColumnFieldSpec.parse("   "), [])
+    }
+
+    /// 読めないものは nil。**一部だけ通さない。**
+    func testRejectsMalformed() {
+        XCTAssertNil(ColumnFieldSpec.parse("abc"))
+        XCTAssertNil(ColumnFieldSpec.parse("1-8,x-14"))
+        XCTAssertNil(ColumnFieldSpec.parse("-8"))
+        XCTAssertNil(ColumnFieldSpec.parse("0-8"))
+        XCTAssertNil(ColumnFieldSpec.parse("8-1"))          // 逆向き
+        XCTAssertNil(ColumnFieldSpec.parse("1-8,5-12"))     // 重なり
+        XCTAssertNil(ColumnFieldSpec.parse("9-14,1-8"))     // 桁が戻る
+        XCTAssertNil(ColumnFieldSpec.parse("1-999999"))     // 上限超え
+    }
+
+    // MARK: - 境界の桁 → 文字列（往復）
+
+    func testTextForGuidesLeavesLastFieldOpen() {
+        XCTAssertEqual(ColumnFieldSpec.text(for: ColumnGuides([9, 15])), "1-8,9-14,15-")
+        XCTAssertEqual(ColumnFieldSpec.text(for: ColumnGuides()), "")
+    }
+
+    /// ダイアログを開いて何も直さず OK を押しても定義が動かないこと。
+    func testRoundTripThroughText() {
+        for columns in [[9, 15], [9, 15, 41], [2], [3, 4, 5]] {
+            let text = ColumnFieldSpec.text(for: ColumnGuides(columns))
+            XCTAssertEqual(ColumnFieldSpec.parse(text), columns, "『\(text)』で往復が壊れた")
+        }
+    }
+
+    // MARK: - 項目の範囲（データに合わせて最後を閉じる）
+
+    func testFieldRangesFitSampleLines() {
+        let guides = ColumnGuides([9, 15])
+        XCTAssertEqual(guides.fieldRanges(fitting: ["12345678ABCDEF0123456789"]), [1...8, 9...14, 15...24])
+    }
+
+    /// 幅は文字数ではなく**見えている桁**（全角＝2）。ここを文字数で測るとガイド線とズレる。
+    func testFieldRangesMeasureDisplayColumns() {
+        let guides = ColumnGuides([5])
+        XCTAssertEqual(guides.fieldRanges(fitting: ["日本語"]), [1...4, 5...6])
+    }
+
+    // MARK: - 桁で切る
+
+    private func formatter(_ guides: [Int], _ lines: [String]) -> TabularFormatter {
+        TabularFormatter.build(mode: .fixedWidth, sampleLines: lines,
+                               fields: ColumnGuides(guides).fieldRanges(fitting: lines))
+    }
+
+    func testFixedCellsSliceByColumns() {
+        let line = "00012345TOKYO 20260815"
+        let fmt = formatter([9, 15], [line])
+        XCTAssertEqual(fmt.cells(of: line), ["00012345", "TOKYO", "20260815"])
+    }
+
+    func testShortLineGivesEmptyTrailingCells() {
+        let fmt = formatter([9, 15], ["00012345TOKYO 20260815"])
+        XCTAssertEqual(fmt.cells(of: "0001"), ["0001", "", ""])
+    }
+
+    /// 全角は 2 桁。桁をまたぐ 1 文字は**始まった側**の項目に入れる（文字を割らない）。
+    func testWideCharactersCountAsTwoColumns() {
+        let fmt = formatter([5], ["日本語です"])
+        XCTAssertEqual(fmt.cells(of: "日本語です"), ["日本", "語です"])
+        // 3 桁目から始まる全角（2 桁め〜3 桁め）は、境界 5 の手前側に残る。
+        XCTAssertEqual(fmt.cells(of: "A日本語"), ["A日本", "語"])
+    }
+
+    func testColumnNamesAreTheColumnsThemselves() {
+        let fmt = formatter([9, 15], ["00012345TOKYO 20260815"])
+        XCTAssertEqual(fmt.columns.map(\.key), ["1-8", "9-14", "15-22"])
+    }
+
+    /// 定義が無ければ列は作らない（呼ぶ側が先に訊く）。
+    func testNoFieldsMeansNoColumns() {
+        let fmt = TabularFormatter.build(mode: .fixedWidth, sampleLines: ["abc"], fields: [])
+        XCTAssertEqual(fmt.columnCount, 0)
+    }
+
+    /// 桁を数えるための表示なので、幅の上限で切り詰めない（CSV は 40 桁で省略する）。
+    func testWideFieldIsNotTruncated() {
+        let long = String(repeating: "A", count: 60)
+        let fmt = TabularFormatter.build(mode: .fixedWidth, sampleLines: [long], fields: [1...60])
+        XCTAssertEqual(fmt.format(long), long)
+    }
+
+    /// 定義がデータより右まで伸びていても、空の列を 1 本増やさない。
+    func testDefinitionBeyondDataDoesNotAddEmptyColumn() {
+        let guides = ColumnGuides([9, 15, 41])       // 1-8,9-14,15-40 と打った状態
+        XCTAssertEqual(guides.fieldRanges(fitting: [String(repeating: "X", count: 40)]),
+                       [1...8, 9...14, 15...40])
+    }
+
+    func testFormatAlignsCellsWithSeparator() {
+        let lines = ["00012345TOKYO 20260815", "00000007OSAKA 20260101"]
+        let fmt = formatter([9, 15], lines)
+        XCTAssertEqual(fmt.format(lines[0]), "00012345 │ TOKYO │ 20260815")
+        XCTAssertEqual(fmt.format(lines[1]), "00000007 │ OSAKA │ 20260101")
+    }
+
+    // MARK: - ガイドを掴んで動かす
+
+    func testMoveGuide() {
+        var g = ColumnGuides([9, 15])
+        XCTAssertTrue(g.move(9, to: 10))
+        XCTAssertEqual(g.columns, [10, 15])
+    }
+
+    /// 行き先が埋まっていたら動かさない（重ねると片方が消えて戻せなくなる）。
+    func testMoveOntoExistingGuideIsRefused() {
+        var g = ColumnGuides([9, 15])
+        XCTAssertFalse(g.move(9, to: 15))
+        XCTAssertEqual(g.columns, [9, 15])
+    }
+
+    func testMoveUnknownOrInvalidColumnIsRefused() {
+        var g = ColumnGuides([9])
+        XCTAssertFalse(g.move(8, to: 12))
+        XCTAssertFalse(g.move(9, to: 0))
+        XCTAssertEqual(g.columns, [9])
+    }
+}

--- a/Tests/MrEditorTests/ColumnRulerPaneTests.swift
+++ b/Tests/MrEditorTests/ColumnRulerPaneTests.swift
@@ -188,6 +188,148 @@ final class ColumnRulerPaneTests: XCTestCase {
                        "ガターの出し入れに原点が追従していない")
     }
 
+    // MARK: - 掴んで動かす（C）
+    //
+    // ドラッグが無いと 1 桁ずらすのに「消して置き直す」になる（B の実地で分かったこと）。
+
+    func testDragMovesGuideInBothPanes() {
+        let small = smallPane(), large = largePane()
+        small._testToggleColumnGuide(9); large._testToggleColumnGuide(9)
+        XCTAssertTrue(small._testMoveColumnGuide(9, to: 10))
+        XCTAssertTrue(large._testMoveColumnGuide(9, to: 10))
+        XCTAssertEqual(small._testColumnGuides, [10])
+        XCTAssertEqual(large._testColumnGuides, [10])
+    }
+
+    func testDragOntoAnotherGuideIsRefusedInBothPanes() {
+        let small = smallPane(), large = largePane()
+        for col in [9, 15] { small._testToggleColumnGuide(col); large._testToggleColumnGuide(col) }
+        XCTAssertFalse(small._testMoveColumnGuide(9, to: 15))
+        XCTAssertFalse(large._testMoveColumnGuide(9, to: 15))
+        XCTAssertEqual(small._testColumnGuides, [9, 15])
+        XCTAssertEqual(large._testColumnGuides, [9, 15])
+    }
+
+    // MARK: - 数値で打つ（C）
+
+    func testSetColumnGuidesReplacesTheWholeDefinition() {
+        let small = smallPane(), large = largePane()
+        small._testToggleColumnGuide(4); large._testToggleColumnGuide(4)
+        small.setColumnGuides([9, 15]); large.setColumnGuides([9, 15])
+        XCTAssertEqual(small.columnGuideColumns, [9, 15])
+        XCTAssertEqual(large.columnGuideColumns, [9, 15])
+        small.setColumnGuides([]); large.setColumnGuides([])
+        XCTAssertFalse(small.hasColumnGuides)
+        XCTAssertFalse(large.hasColumnGuides)
+    }
+
+    // MARK: - ファイルごとに覚える（C）
+
+    private func tempFile(_ text: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mreditor-fields-\(UUID().uuidString).txt")
+        try text.data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    /// 開き直したら**さっきの項目定義のまま**。ルーラーも一緒に出す
+    /// （縦線だけが黙って引かれていると、何の線か分からない）。
+    func testFieldsAreRememberedPerFile() throws {
+        let a = try tempFile("00012345TOKYO 20260815\n")
+        let b = try tempFile("plain text\n")
+        defer {
+            AppSettings.setColumnGuides([], for: a)
+            try? FileManager.default.removeItem(at: a)
+            try? FileManager.default.removeItem(at: b)
+        }
+
+        let v = EditableViewer(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        XCTAssertTrue(v.open(url: a))
+        v.setColumnGuides([9, 15])
+
+        XCTAssertTrue(v.open(url: b))
+        XCTAssertTrue(v.columnGuideColumns.isEmpty, "別のファイルに前のファイルの定義を当てない")
+
+        XCTAssertTrue(v.open(url: a))
+        XCTAssertEqual(v.columnGuideColumns, [9, 15])
+        XCTAssertTrue(v.columnRulerVisible, "覚えていた定義はルーラーごと戻す")
+    }
+
+    func testClearingGuidesForgetsThem() throws {
+        let url = try tempFile("00012345TOKYO\n")
+        defer { AppSettings.setColumnGuides([], for: url); try? FileManager.default.removeItem(at: url) }
+
+        let v = EditableViewer(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        XCTAssertTrue(v.open(url: url))
+        v.setColumnGuides([9])
+        v.clearColumnGuides()
+        XCTAssertTrue(AppSettings.columnGuides(for: url).isEmpty)
+    }
+
+    // MARK: - 構造化表示の 5 つ目＝固定長（C）
+
+    func testFixedWidthStructuredViewInSmallPane() {
+        let v = smallPane("00012345TOKYO 20260815\n00000007OSAKA 20260101\n")
+        v.setColumnGuides([9, 15])
+        v.setStructuredMode(.fixedWidth)
+        XCTAssertEqual(v.structuredMode, .fixedWidth)
+        XCTAssertEqual(v.structuredColumnNames, ["1-8", "9-14", "15-22"])
+        XCTAssertTrue(v._testText.contains("00012345 │ TOKYO │ 20260815"))
+        XCTAssertFalse(v.canEdit, "構造化中は読み取り専用")
+
+        v.setStructuredMode(nil)
+        XCTAssertEqual(v._testText, "00012345TOKYO 20260815\n00000007OSAKA 20260101\n", "元の本文に戻る")
+    }
+
+    func testFixedWidthStructuredViewInLargePane() {
+        let v = largePane("00012345TOKYO 20260815\n00000007OSAKA 20260101\n")
+        v.setColumnGuides([9, 15])
+        v.setStructuredMode(.fixedWidth)
+        XCTAssertEqual(v.structuredMode, .fixedWidth)
+        XCTAssertEqual(v.structuredColumnNames, ["1-8", "9-14", "15-22"])
+    }
+
+    /// 定義が無ければ固定長には入れない（区切り文字が無いのだから中身から列は割り出せない）。
+    func testFixedWidthNeedsADefinitionInBothPanes() {
+        let small = smallPane("00012345TOKYO\n"), large = largePane("00012345TOKYO\n")
+        small.setStructuredMode(.fixedWidth)
+        large.setStructuredMode(.fixedWidth)
+        XCTAssertNil(small.structuredMode)
+        XCTAssertNil(large.structuredMode)
+    }
+
+    /// 固定長で見ている最中に境界を動かしたら、列そのものが変わる＝組み直す。
+    func testMovingAGuideRebuildsTheFixedWidthView() {
+        let v = smallPane("00012345TOKYO 20260815\n")
+        v.setColumnGuides([9, 15])
+        v.setStructuredMode(.fixedWidth)
+        v._testMoveColumnGuide(9, to: 8)
+        XCTAssertEqual(v.structuredColumnNames, ["1-7", "8-14", "15-22"])
+        XCTAssertTrue(v._testText.contains("0001234 │ 5TOKYO │ 20260815"))
+    }
+
+    /// 整形後の表示にガイド線を残さない（定義は**生の本文の桁**なので別の場所を指す）。
+    /// 定義そのものは消さず、構造化を抜ければ戻る。
+    func testGuidesAreHiddenWhileStructuredInBothPanes() {
+        let small = smallPane("00012345TOKYO 20260815\n")
+        let large = largePane("00012345TOKYO 20260815\n")
+        for v in [small as DocumentPane, large as DocumentPane] { v.setColumnGuides([9, 15]) }
+        XCTAssertFalse(small._testColumnGuidesHidden)
+        XCTAssertFalse(large._testColumnGuidesHidden)
+
+        small.setStructuredMode(.fixedWidth)
+        large.setStructuredMode(.fixedWidth)
+        XCTAssertTrue(small._testColumnGuidesHidden)
+        XCTAssertTrue(large._testColumnGuidesHidden)
+        XCTAssertEqual(small.columnGuideColumns, [9, 15], "描画だけ止める（定義は保つ）")
+        XCTAssertEqual(large.columnGuideColumns, [9, 15])
+
+        small.setStructuredMode(nil)
+        large.setStructuredMode(nil)
+        XCTAssertFalse(small._testColumnGuidesHidden)
+        XCTAssertFalse(large._testColumnGuidesHidden)
+    }
+
     // MARK: - 対応しないペイン
 
     func testDiffViewerDoesNotSupportColumnRuler() {


### PR DESCRIPTION
桁ルーラー（A）と桁ガイド（B・PR #61）の続き。ガイドを「項目の切れ目」として使い切る。

## 入るもの

- **数値で打つ**: 表示 ▸ 桁の項目定義…（⇧⌥⌘K）で `1-8,9-14,15-40`。全角の数字・カンマ・波ダッシュも受ける（仕様書からの写しは全角で来る）。読めない書き方は**一部だけ通さない**——半端に通すと、ずれた定義でデータを読み違える。
- **掴んで動かす**: ルーラーのガイドをドラッグ。無いと 1 桁ずらすのに「消して置き直す」になる（B の実地で分かったこと）。何も無い所で押したら 1 本置き、そのまま続けて動かせる。
- **ファイルごとに覚える**: `AppSettings.columnFields`（LRU 200）。セッション復元と同じ性質。**名前を付けて他のファイルにも当てる（プロファイル）は作らない**＝CONTRIBUTING に書いてある Pro の線。
- **構造化表示の 5 つ目＝固定長**: 列名は `1-8` など桁そのもの。桁揃え・構造化中の検索/フィルタ・`structuredColumnNames`（Pro の列統計の口）がそのまま効く。**固定長だけは中身から列を割り出せない**ので、定義が無いまま選んだらその場で訊く。

桁は文字数でなく**表示幅**（全角＝2）で切る。ガイド線は画面上の位置に引かれるので、文字数で切ると全角を含む行だけ線と中身がズレる。

## 実機で見つけて直したもの

- 整形後の本文にガイド線が残り、区切り記号ぶんズレて項目の切れ目でない所を指していた → 構造化中は線と印を伏せる（定義は保ったまま、抜ければ戻る）。
- 離した場所が押した桁と違うなら、途中の drag イベントが届いていなくても「動かす」と読む。ここを見ずに消すと、素早く掴んで動かしたときにガイドが消える。

## 検証

537 green。配布 .app で両ペイン:

- 小ファイル＝ダイアログで定義 → ルーラーごと線が出る／ドラッグで桁 9→11→9／**アプリを終了して開き直しても定義が戻る**／固定長で `00012345 │ TOKYO │ 20260815`
- 巨大 40 万行＝同じ定義で整形・ガイド線は伏せる
- 定義なしで固定長を選ぶと定義ダイアログ

🤖 Generated with [Claude Code](https://claude.com/claude-code)