### PR TITLE
絞り込みと構造化表示の食い違いを直す

### DIFF
--- a/Sources/MrEditorCore/Viewer/EditableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/EditableViewer.swift
@@ -1231,6 +1231,11 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             return
         }
         // ON: 現在の本文から整形（読み取り専用）。
+        // フィルタ中なら先に畳む。小ファイルは**本文そのもの**を整形後のテキストへ
+        // 差し替えるので、絞り込んだ本文の上に整形を重ねられない。重ねると、あとから
+        // 走るフィルタ解除（`hideSearch` → `setFilterMode(false)`）が元の全文で本文を
+        // 上書きし、整形結果だけが消えて列名の帯と行数だけが残っていた（2026-08-21）。
+        if preFilterText != nil { setFilterMode(false) }
         let source = preStructuredText ?? textView.string
         // JSON 整形は単一ドキュメントの字下げ（列指向でない）。不正 JSON なら切り替えず beep。
         if mode == .json {

--- a/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
@@ -264,13 +264,48 @@ final class PieceTableViewer: NSView, DocumentPane {
     /// 581 万行の CSV で 1 列目が `581…` と切れたのが実例。全行走査はできないので、
     /// 両端を見て列幅を決める。中間で更に伸びる列は依然として切れるが、
     /// 単調増加する列はこれで拾える。
+    ///
+    /// **フィルタ中は一致行だけを見る。** 桁を揃えたまま grep するのが目的なので、
+    /// 絞り込んだ結果が読めなければ意味がない。長い値が中間にしか無いファイルでは
+    /// 全体の両端をいくら見ても拾えず、一致行が `con…` と潰れていた（2026-08-21）。
     private func structuredSampleLines(_ n: Int) -> [String] {
+        if filterMode {
+            let matches = searchResults.lines
+            guard !matches.isEmpty else { return [] }   // 0 件では測り直さない（呼び側が今の桁を保つ）
+            // 一致行はファイル全体に散らばるので 1 行ずつ引くことになる（連続読みが効かない）。
+            // 10GB 実測で 2000 行 = 0.419 秒 / 400 行 = 0.084 秒（2026-08-21）。フィルタが
+            // 確定した瞬間に払うので、多いときは両端 200 行ずつで止める。
+            // 一致が 400 行以下＝ふつうの絞り込みは全部見るので、そこは近似ですらない。
+            let cap = 200
+            var picked = matches.count > 2 * cap
+                ? Array(matches.prefix(cap)) + Array(matches.suffix(cap))
+                : matches
+            // CSV/TSV の列名は**サンプルの 1 行目**から取る。一致行だけを渡すと
+            // 最初の一致がそのまま列名になってしまうので、先頭行（＝見出し行）を必ず足す。
+            if picked.first != 0 { picked.insert(0, at: 0) }
+            return picked.map { decodeLineString(lineRanges(from: $0, count: 1).first ?? (0..<0)) }
+        }
         let head = lineRanges(from: 0, count: n).map { decodeLineString($0) }
         let total = displayCount
         guard total > n else { return head }
         let tailStart = max(n, total - n)
         let tail = lineRanges(from: tailStart, count: total - tailStart).map { decodeLineString($0) }
         return head + tail
+    }
+
+    /// いま表示している行から列幅を決め直す（構造化中だけ）。
+    ///
+    /// 表示する行の集合が変わったら呼ぶ＝フィルタの ON/OFF・一致の確定・時間帯の選択。
+    /// **項目の切れ目（固定長の `fields`）は人が置いたものなので引き継ぐ**。列幅だけを測り直す。
+    /// ドラッグで変えた列幅はここで捨てる（見えている行に合わせ直すのがこの関数の仕事）。
+    private func rebuildStructuredColumns() {
+        guard let fmt = structuredFormatter else { return }
+        let sample = structuredSampleLines(1000)
+        // 一致 0 件のときに測り直すと列が消える。打っている途中で一瞬 0 件になるのは
+        // ふつうなので、そこで列名の帯を空にしない＝いまの桁を保つ。
+        guard !sample.isEmpty else { return }
+        structuredFormatter = TabularFormatter.build(mode: fmt.mode, sampleLines: sample, fields: fmt.fields)
+        syncStructuredHeader()   // 列名の帯も新しい桁に合わせる
     }
 
     /// 表示設定（タブ幅・行間・現在行ハイライト・カーソル形状）を反映する。
@@ -1485,7 +1520,7 @@ final class PieceTableViewer: NSView, DocumentPane {
         }, completion: { [weak self] res in
             guard let self, self.searchEpoch == epoch else { return }
             self.searchResults = res
-            if self.filterMode { self.refresh() }
+            if self.filterMode { self.rebuildStructuredColumns(); self.refresh() }
             else { self.emitSearchState(searching: false, progress: 100, invalid: false) }
         })
     }
@@ -1525,6 +1560,7 @@ final class PieceTableViewer: NSView, DocumentPane {
         currentMatchLine = lines[0]
         if filterMode {
             topLine = 0
+            rebuildStructuredColumns()
             refresh()
         } else {
             setFilterMode(true)
@@ -1543,6 +1579,7 @@ final class PieceTableViewer: NSView, DocumentPane {
             topLine = fileLine
         }
         scrollAccumulator = 0
+        rebuildStructuredColumns()   // 見えている行が入れ替わる＝桁を測り直す
         refresh()
     }
 
@@ -1880,6 +1917,8 @@ extension PieceTableViewer {
     func _testReplaceCurrent(_ s: String) { replaceCurrent(with: s) }
     /// 一致行だけ表示が生きているか（構造化と併用できることの検証用）。
     var _testFilterMode: Bool { filterMode }
+    /// いま使っている列幅。フィルタで見えている行に追従しているかの検証用。
+    var _testStructuredColumnWidths: [Int] { structuredFormatter?.columns.map(\.width) ?? [] }
     var _testSelection: Range<Int>? { selectionRange }
 
     // 選択（B7）

--- a/Tests/MrEditorTests/EditableViewerSearchTests.swift
+++ b/Tests/MrEditorTests/EditableViewerSearchTests.swift
@@ -327,4 +327,37 @@ extension EditableViewerSearchTests {
         v.showOnlyLines([])
         XCTAssertNil(v.filterMatchLines)
     }
+
+    // MARK: フィルタ中に構造化へ入る（順番の罠）
+
+    /// フィルタ ON のまま構造化表示へ切り替えると、整形結果が消えて
+    /// 絞り込み前の生テキストが出ていた（列名の帯と行数だけがフィルタ後のまま残る）。
+    /// 整形の前にフィルタを畳むので、いまは全行の整形結果が出る。
+    func testStructuredFromFilteredShowsFormattedWholeFile() {
+        let csv = "id,level,note\n1,INFO,ok\n2,ERROR,boom\n3,INFO,ok\n"
+        let v = viewer(csv)
+        v.setSearchQuery("ERROR")
+        v.setFilterMode(true)
+        XCTAssertNotNil(v.filterMatchLines, "前提: 絞り込めている")
+
+        v.setStructuredMode(.csv)
+
+        XCTAssertNil(v.filterMatchLines, "整形の前にフィルタを畳むこと")
+        XCTAssertEqual(v.structuredMode, .csv)
+        XCTAssertTrue(v._testText.contains("│"), "整形されていること（生テキストのままにしない）")
+        for row in ["1", "2", "3"] {
+            XCTAssertTrue(v._testText.contains("\(row)  "), "全行が出ていること（\(row) 行目）")
+        }
+    }
+
+    /// 畳んだあと構造化を解除したら、元の本文に戻る（絞り込みの残骸を持ち越さない）。
+    func testTurningStructuredOffAfterFilterRestoresOriginal() {
+        let csv = "id,level,note\n1,INFO,ok\n2,ERROR,boom\n3,INFO,ok\n"
+        let v = viewer(csv)
+        v.setSearchQuery("ERROR")
+        v.setFilterMode(true)
+        v.setStructuredMode(.csv)
+        v.setStructuredMode(nil)
+        XCTAssertEqual(v._testText, csv)
+    }
 }

--- a/Tests/MrEditorTests/StructuredSearchTests.swift
+++ b/Tests/MrEditorTests/StructuredSearchTests.swift
@@ -92,4 +92,55 @@ final class StructuredSearchTests: XCTestCase {
         v._testReplaceCurrent("ERROR")
         XCTAssertEqual(v._testDocString, csv, "構造化中の置換は本文を変えないこと")
     }
+
+    // MARK: 絞り込んだら、絞り込んだ行に桁を合わせる
+
+    /// 長い値が**中間の行にしか無い**ファイル。列幅を先頭と末尾から決めていた頃は、
+    /// `long` で絞り込んだ結果が `x…` に潰れて読めなかった（2026-08-21・実機で確認）。
+    /// 列幅は先頭 1000 行＋末尾 1000 行から決めるので、**両端に入らない行数**にする。
+    private static let middleRow = 1500
+    private func lopsided(_ middle: String) -> String {
+        var lines = ["id,note"]
+        for i in 1...3000 {
+            lines.append(i == Self.middleRow ? "\(i),\(middle)" : "\(i),ok")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    func testColumnWidthFollowsFilteredRows() {
+        let middle = "connection reset by peer"      // 24 桁
+        let v = makeViewer(lopsided(middle))
+        v.setStructuredMode(.csv)
+        let unfiltered = v._testStructuredColumnWidths
+        XCTAssertLessThan(unfiltered[1], middle.count, "全体では 'ok' と見出しで決まる（前提）")
+
+        // 中間の 1 行だけに一致するフィルタ。
+        v._testSetSearch(terms: [middle], matchLines: [Self.middleRow])
+        v.setFilterMode(true)
+        XCTAssertEqual(v._testStructuredColumnWidths[1], middle.count,
+                       "絞り込んだ行が切れずに出ること（桁を揃えたまま grep する）")
+    }
+
+    func testColumnWidthReturnsToWholeFileWhenFilterIsCleared() {
+        let middle = "connection reset by peer"
+        let v = makeViewer(lopsided(middle))
+        v.setStructuredMode(.csv)
+        let unfiltered = v._testStructuredColumnWidths
+        v._testSetSearch(terms: [middle], matchLines: [Self.middleRow])
+        v.setFilterMode(true)
+        v.setFilterMode(false)
+        XCTAssertEqual(v._testStructuredColumnWidths, unfiltered,
+                       "フィルタを解いたら元の桁に戻ること")
+    }
+
+    /// 一致が 0 件でも列が消えたり落ちたりしない。
+    func testEmptyFilterKeepsColumns() {
+        let v = makeViewer(csv)
+        v.setStructuredMode(.csv)
+        let before = v._testStructuredColumnWidths
+        v._testSetSearch(terms: ["nothing"], matchLines: [])
+        v.setFilterMode(true)
+        XCTAssertTrue(v._testFilterMode)
+        XCTAssertEqual(v._testStructuredColumnWidths, before, "0 件でも列名の帯を空にしないこと")
+    }
 }


### PR DESCRIPTION
構造化表示（桁揃え）と絞り込みを併用したときの不具合を 2 件。どちらも配布物と同じ `.app`
（v1.12.3 相当）で再現を確認してから直した。

---

## ① 絞り込むと列が切れる（大ファイル側）

45MB・300 万行の CSV を CSV 表示にして `ERROR` で絞り込む（59 件）と、34 桁の `note` が
**4 桁（`con…`）** に潰れる。列幅を先頭 1000 行＋末尾 1000 行から決めているため、
長い値が中間にしか無いファイルでは拾えない。上限 40 桁のキャップとは無関係。

「桁を揃えたまま grep する」は看板の機能なので、絞り込んだ結果が読めないのは本末転倒だった。

**直し方**: フィルタ中は**一致行から列幅を決め直す**。表示する行の集合が変わるところ
（フィルタの ON/OFF・一致の確定・時間帯の選択）で組み直す。

- **一致が多いときの費用**: 一致行はファイル全体に散らばるので 1 行ずつ引くことになる。
  10GB 実測で **2000 行 0.419 秒 / 400 行 0.084 秒**。確定の瞬間に払うので**両端 200 行ずつ**で
  打ち切る。一致 400 行以下（ふつうの絞り込み）は全部見るので、そこは近似ですらない。
- **一致 0 件では測り直さない**。打っている途中で一瞬 0 件になるのはふつうなので、
  そこで列名の帯を空にしない。
- **列名は先頭行から**。CSV/TSV の列名はサンプルの 1 行目から取るため、先頭行を必ず足す。
  従来はフィルタ中に構造化へ入ると**一致行の 1 本目が列名**になっていた（別口の穴）。

ドラッグで変えた列幅は絞り込むと捨てられる（見えている行に合わせ直すのがこの関数の仕事）。

## ② フィルタ → 構造化 で画面が食い違う（小ファイル側）

4.2MB の CSV でフィルタ ON のまま構造化表示へ切り替えると、3 箇所が食い違っていた。

| | 表示 |
|---|---|
| 本文 | 絞り込み**前**の生テキスト（整形もされない） |
| 列名の帯 | 一致行の 1 本目 |
| ステータス | 絞り込み**後**の行数 |

**順番の問題**だった。整形器をフィルタ後の本文から組んだ直後に、検索バーを閉じる
`hideSearch()` → `setFilterMode(false)` が走り、退避してあった元の全文で本文を上書きする。
整形結果だけが消えて、帯と行数が残る。

**直し方**: 整形の前にフィルタを畳む。小ファイルは本文そのものを整形後のテキストへ
差し替えるので、絞り込んだ本文の上に整形は重ねられない（構造化中は `supportsSearchFilter`
が false なのもこのため）。**仕様として絞り込みは維持されない**——大ファイル側だけが
「桁を揃えたまま grep」できる。

---

## 確認

| 条件 | 結果 |
|---|---|
| 45MB・300 万行 CSV、構造化 → フィルタ | `note` が 34 桁で全部出る |
| 同、フィルタ → 構造化 | 同じ結果・列名も `id / level / note` |
| フィルタ解除 | 元の桁に戻る |
| 10GB・8642 万行、TSV → 5134 万件ヒット | 詰まらない（漏斗を押して 0.30 秒で戻る）・桁は揃ったまま |
| 4.2MB CSV、フィルタ → 構造化 | 本文・帯・行数が一致（全行の整形結果） |

**616 green**（回帰テスト 5 本追加。②のテストは直しを外すと落ちることも確認済み）。
いずれも `.app` で実機確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)