### PR TITLE
ビルドとテストを CI で回す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# ビルドとテストを CI で回す。
+#
+# これが無かった間、緑かどうかは**作者の Mac でしか確かめられていなかった**。
+# PR に緑の印が付かないので、マージの判断材料が「手元で走らせた」という自己申告
+# だけだった（v1.12.4 まで全部そうだった）。
+#
+# macOS ランナーが要る: AppKit（NSView / NSTextView）を直に組み立てるテストが
+# あるので ubuntu では通らない。
+name: Build and test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# 同じブランチで続けて push したら、古い実行は捨てる。
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Swift の版を記録する
+        run: swift --version
+
+      - name: ビルド（debug）
+        run: swift build
+
+      - name: テスト
+        # 10GB の実ファイルが要るベンチと保存テストは、環境変数が無ければ自分で skip する。
+        run: swift test
+
+      - name: 整合性チェック（版・日英パリティ・i18n キー・公表値）
+        run: python3 scripts/check_consistency.py
+        env:
+          # 「公開した版が文書に載っているか」で gh release を引く。
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
CI が無く、緑かどうかは**作者の Mac でしか確かめられていなかった**。PR に緑の印が付かないので、
マージの判断材料は「手元で走らせた」という自己申告だけだった（v1.12.4 まで全部そう）。

- `pull_request` と main への `push` で **`swift build` / `swift test` / `check_consistency.py`**
- **macOS ランナー**（`macos-15`）。AppKit（`NSView` / `NSTextView`）を直に組み立てるテストがあるので ubuntu では通らない
- 10GB の実ファイルが要るベンチと保存テストは、環境変数が無ければ自分で skip する
- 同じブランチで続けて push したら古い実行は捨てる（`concurrency`）

**この PR 自体が最初の実行になる。** ヘッドレスのランナーで 616 本全部通るかは、走らせてみないと分からない
（AppKit のテストがウィンドウサーバ無しで落ちる可能性がある）。落ちたらここで切り分ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)