### PR TITLE
絞り込んだまま、前後 N 行（grep -C）

### DIFF
--- a/Sources/MrEditorCore/AppDelegate.swift
+++ b/Sources/MrEditorCore/AppDelegate.swift
@@ -153,6 +153,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSMenu
     @objc private func performFindNext(_ sender: Any?) { windowController?.findNext() }
     @objc private func performFindPrev(_ sender: Any?) { windowController?.findPrev() }
 
+    // 一致行の前後に出す行数（grep -C）。1 行ずつ伸ばして「もう 1 行前が見たい」に応える。
+    @objc private func increaseFilterContext(_ sender: Any?) {
+        guard let c = windowController else { return }
+        c.setFilterContextLines(c.filterContextLines + 1)
+    }
+    @objc private func decreaseFilterContext(_ sender: Any?) {
+        guard let c = windowController else { return }
+        c.setFilterContextLines(c.filterContextLines - 1)
+    }
+
     @objc private func performCloseDocument(_ sender: Any?) {
         if let c = windowController { c.closeActiveDocument() } else { NSApp.keyWindow?.performClose(nil) }
     }
@@ -335,6 +345,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSMenu
             return c.canSave
         case #selector(performFind(_:)), #selector(performFindNext(_:)), #selector(performFindPrev(_:)):
             return c.canSearch
+        case #selector(increaseFilterContext(_:)):
+            return c.canFilter && c.filterContextLines < FilterContext.maxContext
+        case #selector(decreaseFilterContext(_:)):
+            return c.canFilter && c.filterContextLines > 0
         case #selector(performFollow(_:)):
             item.state = c.isFollowingActive ? .on : .off
             return c.canFollow
@@ -539,6 +553,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSMenu
         findPrevItem.keyEquivalentModifierMask = [.command, .shift]
         findPrevItem.target = self
         editMenu.addItem(findPrevItem)
+
+        // 一致行の前後も出す（grep -C）。絞り込んだまま前後を伸び縮みさせられるように
+        // キーボードからも触れる（検索バーの「±」欄と同じ値を動かす）。
+        let moreContext = NSMenuItem(title: L("menu.contextMore"),
+                                     action: #selector(increaseFilterContext(_:)), keyEquivalent: "]")
+        moreContext.keyEquivalentModifierMask = [.command, .option]
+        moreContext.target = self
+        editMenu.addItem(moreContext)
+        let lessContext = NSMenuItem(title: L("menu.contextLess"),
+                                     action: #selector(decreaseFilterContext(_:)), keyEquivalent: "[")
+        lessContext.keyEquivalentModifierMask = [.command, .option]
+        lessContext.target = self
+        editMenu.addItem(lessContext)
 
         // マルチカーソル（小ファイルの編集ペインのみ。⌘クリックでも足せる）。
         editMenu.addItem(.separator())

--- a/Sources/MrEditorCore/AppSettings.swift
+++ b/Sources/MrEditorCore/AppSettings.swift
@@ -140,6 +140,7 @@ enum AppSettings {
     private static let saveProgressKey = "MrEditor.saveProgressStyle"
     private static let lineWrapKey = "MrEditor.lineWrap"
     private static let tabWidthKey = "MrEditor.tabWidth"
+    private static let filterContextKey = "MrEditor.filterContextLines"
     private static let lineSpacingKey = "MrEditor.lineSpacing"
     private static let highlightCurrentLineKey = "MrEditor.highlightCurrentLine"
     private static let showLineNumbersKey = "MrEditor.showLineNumbers"
@@ -167,6 +168,13 @@ enum AppSettings {
     static var lineWrap: Bool {
         get { defaults.bool(forKey: lineWrapKey) }
         set { defaults.set(newValue, forKey: lineWrapKey); NotificationCenter.default.post(name: .mrEditorLineWrapChanged, object: nil) }
+    }
+
+    /// 一致行だけ表示のとき、前後に足す行数（`grep -C` 相当）。既定 0。
+    /// ファイルごとではなくアプリの設定として覚える（一度決めたら次のファイルでも同じ見え方になる）。
+    static var filterContextLines: Int {
+        get { min(max(0, defaults.integer(forKey: filterContextKey)), FilterContext.maxContext) }
+        set { defaults.set(min(max(0, newValue), FilterContext.maxContext), forKey: filterContextKey) }
     }
 
     /// タブの表示幅（文字数）。既定 4。選択肢は 2/4/8。

--- a/Sources/MrEditorCore/Core/FilterContext.swift
+++ b/Sources/MrEditorCore/Core/FilterContext.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// 一致行の前後 N 行を表示に足す（`grep -C` 相当）。
+///
+/// 絞り込みは「その行だけ」を見せるが、調査は往復する。エラー行の直前に何が起きたか、
+/// 直後にどう転んだかは、たいてい隣の行にある。前後が見えないと絞り込んだ瞬間に
+/// 文脈を失い、フィルタを解除して行番号を頼りに探し直すことになる。
+///
+/// 出力は **昇順・重複なし**。一致が近いと窓が重なるので、単純に足すのではなく
+/// 走査済みの位置（`next`）から先だけを足して潰す（`grep` が `--` で区切って
+/// まとめるのと同じ考え方）。区切り線は入れない——行番号のガターに元の行番号が
+/// 出ているので、飛んでいることはそこで分かる。
+enum FilterContext {
+    /// 前後に出せる行数の上限（UI 側の入力もここで丸める）。
+    static let maxContext = 100
+
+    /// 展開後の表示行数の上限。一致行そのものが `SearchEngine` の 100 万件で
+    /// 打ち切られているので、その先の展開でメモリを増やしても意味がない。
+    /// （100 万件 × 前後 100 行＝2 億行分の配列＝1.6GB。ここで止める。）
+    static let displayCap = 1_000_000
+
+    /// `matches`（昇順・0 始まり）に前後 `context` 行を足した表示行の並びを返す。
+    /// `context` が 0 なら `matches` をそのまま返す（配列を作り直さない）。
+    static func expand(matches: [Int], context: Int, lineCount: Int) -> [Int] {
+        guard context > 0, !matches.isEmpty, lineCount > 0 else { return matches }
+        var out: [Int] = []
+        out.reserveCapacity(min(matches.count * (2 * context + 1), displayCap))
+        var next = 0                       // まだ出していない最小の行（重複を潰す境界）
+        for m in matches {
+            let lo = max(m - context, next, 0)
+            let hi = min(m + context, lineCount - 1)
+            guard lo <= hi else { continue }   // 窓が丸ごと既出／範囲外
+            for line in lo...hi {
+                out.append(line)
+                if out.count >= displayCap { return out }
+            }
+            next = hi + 1
+        }
+        return out
+    }
+}

--- a/Sources/MrEditorCore/MainWindowController.swift
+++ b/Sources/MrEditorCore/MainWindowController.swift
@@ -183,7 +183,8 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
         let searchTrailing = searchBar.trailingAnchor.constraint(equalTo: viewerContainer.trailingAnchor, constant: -28)
         NSLayoutConstraint.activate([
             searchTop, searchTrailing,
-            searchBar.widthAnchor.constraint(equalToConstant: 440),
+            // 「±N」の欄を足したぶん広げてある（440 のままだと「Aa」が「…」に潰れる）。
+            searchBar.widthAnchor.constraint(equalToConstant: 512),
             searchBar.heightAnchor.constraint(equalToConstant: SearchBarView.height),
         ])
         searchOverlay = addDraggable("search", searchBar, horizontal: searchTrailing, .trailing, vertical: searchTop, .leading)
@@ -197,6 +198,7 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
             self?.activeViewer?.setFilterMode(on)
             self?.refreshSearchBarCapabilities()   // 絞り込み中は置換を落とす
         }
+        searchBar.onContextChange = { [weak self] n in self?.activeViewer?.setFilterContextLines(n) }
         searchBar.onReplace = { [weak self] r in self?.activeViewer?.replaceCurrent(with: r) }
         searchBar.onReplaceAll = { [weak self] r in self?.activeViewer?.replaceAll(with: r) }
         searchBar.onPreserveCaseToggle = { [weak self] on in self?.activeViewer?.setPreserveCase(on) }
@@ -681,6 +683,8 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
     var canSearch: Bool { activeViewer?.supportsSearch ?? false }
     /// 末尾追従できるドキュメントが開いているか。
     var canFollow: Bool { activeViewer?.supportsFollow ?? false }
+    /// 一致行だけ表示ができるドキュメントが開いているか（前後 N 行の増減もこれに従う）。
+    var canFilter: Bool { (activeViewer?.supportsSearch ?? false) && (activeViewer?.supportsSearchFilter ?? false) }
     /// 何かドキュメントが開いているか。
     var hasActiveDocument: Bool { activeIndex >= 0 }
     /// アクティブなドキュメントが末尾追従中か。
@@ -1583,7 +1587,19 @@ public final class MainWindowController: NSWindowController, NSWindowDelegate {
         guard let v = activeViewer else { return }
         searchBar.setFilterAvailable(v.supportsSearchFilter)
         searchBar.setReplaceAvailable(v.supportsReplace)
+        searchBar.setContextLines(v.filterContextLines)
     }
+
+    /// 一致行の前後に出す行数を変える（検索バーの「±」欄・メニューの増減）。
+    /// 見えていない検索バーの表示も合わせておく（次に開いたとき値が食い違わない）。
+    func setFilterContextLines(_ n: Int) {
+        guard let v = activeViewer else { NSSound.beep(); return }
+        v.setFilterContextLines(n)
+        searchBar.setContextLines(v.filterContextLines)
+    }
+
+    /// いまのペインの前後行数（メニューの表示・増減の起点）。
+    var filterContextLines: Int { activeViewer?.filterContextLines ?? AppSettings.filterContextLines }
 
     // MARK: - 分析（Pro）の口
     //

--- a/Sources/MrEditorCore/Resources/en.lproj/Localizable.strings
+++ b/Sources/MrEditorCore/Resources/en.lproj/Localizable.strings
@@ -236,6 +236,8 @@
 "menu.find" = "Find…";
 "menu.findNext" = "Find Next";
 "menu.findPrev" = "Find Previous";
+"menu.contextMore" = "More Context Lines";
+"menu.contextLess" = "Fewer Context Lines";
 "menu.addCaretAbove" = "Add Cursor Above";
 "menu.addCaretBelow" = "Add Cursor Below";
 "menu.selectNextOccurrence" = "Add Next Occurrence to Selection";

--- a/Sources/MrEditorCore/Resources/ja.lproj/Localizable.strings
+++ b/Sources/MrEditorCore/Resources/ja.lproj/Localizable.strings
@@ -236,6 +236,8 @@
 "menu.find" = "検索…";
 "menu.findNext" = "次を検索";
 "menu.findPrev" = "前を検索";
+"menu.contextMore" = "前後の行を増やす";
+"menu.contextLess" = "前後の行を減らす";
 "menu.addCaretAbove" = "上の行にカーソルを追加";
 "menu.addCaretBelow" = "下の行にカーソルを追加";
 "menu.selectNextOccurrence" = "次の同じ語を選択に追加";

--- a/Sources/MrEditorCore/UI/SearchBarView.swift
+++ b/Sources/MrEditorCore/UI/SearchBarView.swift
@@ -14,6 +14,10 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     private let caseToggle = NSButton()
     private let regexToggle = NSButton()
     private let filterToggle = NSButton()
+    /// 前後 N 行（`grep -C`）。**アイコンでなく文字と数字**にしてある——
+    /// 絞り込んだ画面に「±2」と出ていれば何が起きているか読めるが、記号だけだと気づかれない。
+    private let contextLabel = NSTextField(labelWithString: "±")
+    private let contextField = NSTextField()
 
     private let replaceField = NSTextField()
     private let replaceButton = NSButton()
@@ -27,6 +31,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     var onCaseToggle: ((Bool) -> Void)?
     var onRegexToggle: ((Bool) -> Void)?
     var onFilterToggle: ((Bool) -> Void)?
+    var onContextChange: ((Int) -> Void)?
     var onReplace: ((String) -> Void)?
     var onReplaceAll: ((String) -> Void)?
     var onPreserveCaseToggle: ((Bool) -> Void)?
@@ -88,11 +93,27 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         filterToggle.toolTip = "一致行だけ表示 / Show matching lines only"
         filterToggle.setContentHuggingPriority(.required, for: .horizontal)
 
+        // 前後 N 行（grep -C）。絞り込みの隣に置く＝絞り込んだ人の目に入る位置。
+        contextLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .semibold)
+        contextLabel.setContentHuggingPriority(.required, for: .horizontal)
+        contextField.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        contextField.alignment = .right
+        contextField.placeholderString = "0"
+        contextField.target = self
+        contextField.action = #selector(contextEdited)   // Enter・フォーカスを外したとき
+        contextField.toolTip = "一致行の前後も出す（grep -C） / Also show N lines around each match"
+        contextField.setContentHuggingPriority(.required, for: .horizontal)
+
         let prev = iconButton("chevron.up", #selector(prevTapped))
         let next = iconButton("chevron.down", #selector(nextTapped))
         let close = iconButton("xmark", #selector(closeTapped))
 
-        let findRow = NSStackView(views: [field, caseToggle, regexToggle, filterToggle, countLabel, prev, next, close])
+        // 件数（「18 件中 1 件目」）も縮めさせない。末尾が切れると何件目か読めない。
+        keepIntrinsicWidth([caseToggle, regexToggle, filterToggle, contextLabel, countLabel,
+                            preserveCaseToggle, replaceButton, replaceAllButton])
+
+        let findRow = NSStackView(views: [field, caseToggle, regexToggle, filterToggle,
+                                          contextLabel, contextField, countLabel, prev, next, close])
         findRow.orientation = .horizontal
         findRow.spacing = 6
 
@@ -141,9 +162,21 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
             stack.centerYAnchor.constraint(equalTo: centerYAnchor),
             findRow.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -18),
             replaceRow.widthAnchor.constraint(equalTo: findRow.widthAnchor),
-            field.widthAnchor.constraint(greaterThanOrEqualToConstant: 180),
+            // 詰まったときに縮むのは検索欄（打った語は自分で覚えているが、
+            // 件数やトグルは読めなくなると困る）。
+            field.widthAnchor.constraint(greaterThanOrEqualToConstant: 120),
+            contextField.widthAnchor.constraint(equalToConstant: 30),
             countLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 56),
         ])
+    }
+
+    /// 文字のトグル（Aa / .*）は縮めさせない。詰まると「…」に化けて何のボタンか読めなくなる
+    /// （±N の欄を足したときに実際そうなった）。狭いときに縮むのは検索欄の側でよい。
+    private func keepIntrinsicWidth(_ views: [NSView]) {
+        for v in views {
+            v.setContentCompressionResistancePriority(.required, for: .horizontal)
+            v.setContentHuggingPriority(.required, for: .horizontal)
+        }
     }
 
     private func iconButton(_ symbol: String, _ action: Selector) -> NSButton {
@@ -161,6 +194,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         layer?.backgroundColor = EditorTheme.withBackgroundOpacity(theme.chromeBackground).cgColor
         layer?.borderColor = theme.separator.cgColor
         countLabel.textColor = theme.chromeSecondaryText
+        syncContextEnabled()   // 「±」の色は使える／使えないで変わる
     }
     /// 配色（テーマ）を検索パネルへ適用する（内部の検索フィールド・ボタンは窓アピアランスに追従）。
     func applyTheme() { applyColors() }
@@ -180,6 +214,23 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
             onFilterToggle?(false)
         }
         filterToggle.isHidden = !available
+        contextLabel.isHidden = !available
+        contextField.isHidden = !available
+        syncContextEnabled()
+    }
+
+    /// 前後 N 行の欄は**絞り込んでいる間だけ**触れる（絞っていないときは前後も何もない）。
+    private func syncContextEnabled() {
+        let on = !filterToggle.isHidden && filterToggle.state == .on
+        contextField.isEnabled = on
+        contextLabel.textColor = on ? EditorTheme.current().chromeText
+                                    : EditorTheme.current().chromeSecondaryText
+    }
+
+    /// 前後 N 行を外から立てる（メニューの増減・ペインを切り替えたとき）。
+    func setContextLines(_ n: Int) {
+        contextField.stringValue = n > 0 ? String(n) : ""
+        syncContextEnabled()
     }
 
     /// 置換できないペイン（構造化表示中・一致行だけ表示中）では置換の行を触れなくする。
@@ -196,6 +247,7 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     func setFilterOn(_ on: Bool) {
         guard !filterToggle.isHidden else { return }
         filterToggle.state = on ? .on : .off
+        syncContextEnabled()
     }
 
     func focusField() {
@@ -248,7 +300,15 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
     @objc private func closeTapped() { onClose?() }
     @objc private func caseTapped() { onCaseToggle?(caseToggle.state == .on) }
     @objc private func regexTapped() { onRegexToggle?(regexToggle.state == .on) }
-    @objc private func filterTapped() { onFilterToggle?(filterToggle.state == .on) }
+    @objc private func filterTapped() {
+        syncContextEnabled()
+        onFilterToggle?(filterToggle.state == .on)
+    }
+    @objc private func contextEdited() {
+        let n = min(max(0, Int(contextField.stringValue) ?? 0), FilterContext.maxContext)
+        contextField.stringValue = n > 0 ? String(n) : ""   // 入力を丸めた結果を見せる
+        onContextChange?(n)
+    }
     @objc private func preserveCaseTapped() { onPreserveCaseToggle?(preserveCaseToggle.state == .on) }
     @objc private func replaceTapped() { onReplace?(replaceField.stringValue) }
     @objc private func replaceAllTapped() { onReplaceAll?(replaceField.stringValue) }
@@ -262,6 +322,8 @@ final class SearchBarView: NSView, NSSearchFieldDelegate {
         filterToggle.state = .off
         preserveCaseToggle.state = .off
         countLabel.stringValue = ""
+        // 前後 N 行は消さない（アプリの設定として覚えている値なので、閉じるたびに 0 へ戻さない）。
+        syncContextEnabled()
     }
 
     /// Esc でバーを閉じる。

--- a/Sources/MrEditorCore/Viewer/DocumentPane.swift
+++ b/Sources/MrEditorCore/Viewer/DocumentPane.swift
@@ -130,6 +130,10 @@ protocol DocumentPane: NSView {
     func setCaseSensitive(_ on: Bool)
     func setRegexMode(_ on: Bool)
     func setFilterMode(_ on: Bool)
+    /// 一致行の前後に足して表示する行数（`grep -C` 相当）。0＝一致行だけ。
+    func setFilterContextLines(_ n: Int)
+    /// いま設定されている前後行数（検索バー・メニューの表示用）。
+    var filterContextLines: Int { get }
     /// **検索とは無関係に**、指定した行だけを表示する（0 始まり・昇順）。
     /// 時間分布で時間帯をドラッグしたときの受け皿。空配列なら解除。
     func showOnlyLines(_ lines: [Int])
@@ -233,6 +237,8 @@ extension DocumentPane {
     func setCaseSensitive(_ on: Bool) {}
     func setRegexMode(_ on: Bool) {}
     func setFilterMode(_ on: Bool) {}
+    func setFilterContextLines(_ n: Int) {}
+    var filterContextLines: Int { 0 }
     func showOnlyLines(_ lines: [Int]) { NSSound.beep() }
     func findNext() {}
     func findPrev() {}

--- a/Sources/MrEditorCore/Viewer/EditableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/EditableViewer.swift
@@ -101,13 +101,21 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
     /// フィルタ ON 前の本文（OFF で復元）。nil ならフィルタしていない。
     private var preFilterText: String?
     /// 表示している各行が、元の本文の何行目だったか（0 始まり）。ガターに元の番号を出すため。
+    /// 前後 N 行を出しているときは文脈行も含む＝**一致行とは限らない**。
     private var filterLineNumbers: [Int] = []
+    /// そのうち実際に一致した行（0 始まり）。分析（値で絞る）はこちらを見る。
+    private var filterMatchedLineNumbers: [Int] = []
+    /// 一致行の前後に足す行数（`grep -C`）。
+    private var contextLines = AppSettings.filterContextLines
+    /// いまの絞り込みが時間帯の指定（`showOnlyLines`）由来か。真なら前後 N 行を足さない。
+    private var filterIsExplicit = false
     var supportsStructured: Bool { true }
     var supportsJsonReformat: Bool { true }   // 全文を保持する小ファイルペインなので単一 JSON 整形が可能
     var structuredMode: StructuredMode? { jsonPrettyActive ? .json : structuredFormatter?.mode }
     var structuredColumnNames: [String] { structuredFormatter?.columns.map(\.key) ?? [] }
-    /// フィルタ中の一致行（0 始まり）。`filterLineNumbers` がそのまま元の行番号。
-    var filterMatchLines: [Int]? { preFilterText != nil ? filterLineNumbers : nil }
+    /// フィルタ中の一致行（0 始まり）。**表示行ではなく一致行**を返す
+    /// （前後 N 行の文脈まで「一致」として数えると、分析の件数が水増しされる）。
+    var filterMatchLines: [Int]? { preFilterText != nil ? filterMatchedLineNumbers : nil }
 
     // MARK: - 検索・置換の状態
     //
@@ -912,6 +920,7 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             guard let original = preFilterText else { return }
             preFilterText = nil
             filterLineNumbers = []
+            filterMatchedLineNumbers = []
             lineNumberRuler?.displayLineNumber = nil
             lineNumberRuler?.maxLineNumberOverride = nil
             textView.isEditable = true
@@ -924,6 +933,18 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
             recomputeMatches()
             emitState()
         }
+    }
+
+    var filterContextLines: Int { contextLines }
+
+    /// 一致行の前後に足す行数を変える。絞り込み中なら本文を載せ直す。
+    func setFilterContextLines(_ n: Int) {
+        let clamped = min(max(0, n), FilterContext.maxContext)
+        guard clamped != contextLines else { return }
+        contextLines = clamped
+        AppSettings.filterContextLines = clamped
+        // 時間帯で絞っている最中は載せ直さない（載せ直すと検索由来の絞り込みに化ける）。
+        if preFilterText != nil, !filterIsExplicit { applyFilteredText() }
     }
 
     /// 指定した行だけを表示する（時間分布のドラッグ選択から）。空配列なら解除。
@@ -942,19 +963,26 @@ final class EditableViewer: NSView, DocumentPane, NSTextViewDelegate {
 
     /// 元の本文から一致行だけを抜き出して表示に載せ直す。クエリを変えるたびに呼ぶ。
     /// クエリが空なら一致は 0 件＝何も出ない（巨大ファイル側のフィルタと同じ振る舞い）。
+    ///
+    /// 前後 N 行の設定があれば、一致行の周りの行も一緒に載せる（`grep -C` 相当）。
+    /// **時間帯を指定された絞り込み（`explicit`）には足さない**——選んだ範囲の外の行が
+    /// 混ざると「選んだ時間帯」が嘘になる。
     private func applyFilteredText(only explicit: Set<Int>? = nil) {
         guard let source = preFilterText else { return }
         var lines = source.components(separatedBy: "\n")
         if lines.last == "" { lines.removeLast() }   // 末尾改行の余り（幻の空行を作らない）
-        var kept: [String] = []
-        var numbers: [Int] = []
+        var matched: [Int] = []
         for (i, line) in lines.enumerated() {
             // 行を指定されていればそれに従う（時間分布からの絞り込み）。無ければ検索の一致行。
             let keep = explicit.map { $0.contains(i) } ?? !matchRanges(in: line).isEmpty
-            guard keep else { continue }
-            kept.append(line)
-            numbers.append(i)
+            if keep { matched.append(i) }
         }
+        let numbers = explicit == nil
+            ? FilterContext.expand(matches: matched, context: contextLines, lineCount: lines.count)
+            : matched
+        let kept = numbers.map { lines[$0] }
+        filterIsExplicit = explicit != nil
+        filterMatchedLineNumbers = matched
         filterLineNumbers = numbers
         // ガターは表示順ではなく**元の行番号**を出す（飛び飛びであることが分かるように）。
         lineNumberRuler?.displayLineNumber = { [weak self] row in

--- a/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
+++ b/Sources/MrEditorCore/Viewer/PieceTableViewer.swift
@@ -130,6 +130,14 @@ final class PieceTableViewer: NSView, DocumentPane {
     /// 置換で一致した語の大文字小文字を置換文字列へ引き継ぐか（`CasePreserving`）。
     private var preserveCase = false
     private var filterMode = false
+    /// 一致行の前後に足す行数（`grep -C`）。`filterDisplayLines` の材料。
+    private var contextLines = AppSettings.filterContextLines
+    /// フィルタ中に実際に並べる行（＝一致行を前後へ広げたもの・昇順）。
+    /// `contextLines` が 0 なら `searchResults.lines` と同じ内容。
+    private var filterDisplayLines: [Int] = []
+    /// 表示行が検索由来でない（時間分布のドラッグ選択）＝前後行は足さない。
+    /// 選んだ時間帯の外の行が混ざると「選んだ範囲」が嘘になる。
+    private var filterIsExplicit = false
     private var matchHighlight = EditorTheme.current().searchMatch
     /// ANSI 着色用パレット（テーマ変更で更新）。
     private var ansiPalette = ANSIPalette.from(theme: EditorTheme.current())
@@ -265,12 +273,13 @@ final class PieceTableViewer: NSView, DocumentPane {
     /// 両端を見て列幅を決める。中間で更に伸びる列は依然として切れるが、
     /// 単調増加する列はこれで拾える。
     ///
-    /// **フィルタ中は一致行だけを見る。** 桁を揃えたまま grep するのが目的なので、
-    /// 絞り込んだ結果が読めなければ意味がない。長い値が中間にしか無いファイルでは
-    /// 全体の両端をいくら見ても拾えず、一致行が `con…` と潰れていた（2026-08-21）。
+    /// **フィルタ中は表示している行だけを見る**（一致行＋前後 N 行）。桁を揃えたまま
+    /// grep するのが目的なので、絞り込んだ結果が読めなければ意味がない。長い値が
+    /// 中間にしか無いファイルでは全体の両端をいくら見ても拾えず、一致行が `con…` と
+    /// 潰れていた（2026-08-21）。文脈行も同じ表に並ぶので同じように測る。
     private func structuredSampleLines(_ n: Int) -> [String] {
         if filterMode {
-            let matches = searchResults.lines
+            let matches = filterDisplayLines
             guard !matches.isEmpty else { return [] }   // 0 件では測り直さない（呼び側が今の桁を保つ）
             // 一致行はファイル全体に散らばるので 1 行ずつ引くことになる（連続読みが効かない）。
             // 10GB 実測で 2000 行 = 0.419 秒 / 400 行 = 0.084 秒（2026-08-21）。フィルタが
@@ -478,9 +487,9 @@ final class PieceTableViewer: NSView, DocumentPane {
         max(1, Int(ceil(documentView.bounds.height / documentView.lineHeight)))
     }
 
-    /// 表示空間の総行数。フィルタ表示＝一致行数、クリーン＝LineIndex、編集後＝piece table。
+    /// 表示空間の総行数。フィルタ表示＝並べた行数（一致行＋前後）、クリーン＝LineIndex、編集後＝piece table。
     private var displayCount: Int {
-        if filterMode { return searchResults.lines.count }
+        if filterMode { return filterDisplayLines.count }
         if readsFromOriginal { return lineIndex?.displayLineCount ?? pieceTable?.lineCount ?? 0 }
         return pieceTable?.lineCount ?? 0
     }
@@ -591,7 +600,8 @@ final class PieceTableViewer: NSView, DocumentPane {
 
         if filterMode {
             // 一致行だけを表示（非連続・クリーン時のみ）。キャレット編集は使わない。
-            let matches = searchResults.lines
+            // 前後 N 行を出しているときは、この並びに文脈行も混じっている。
+            let matches = filterDisplayLines
             var numbers: [Int] = []
             var k = 0
             while k < needed, topLine + k < matches.count {
@@ -603,7 +613,11 @@ final class PieceTableViewer: NSView, DocumentPane {
             }
             visibleRanges = []
             documentView.lineNumbers = numbers
-            documentView.activeRow = nil
+            // 前後 N 行を出しているときだけ、いまの一致行に帯を敷く。文脈行と一致行が
+            // 同じ見た目で並ぶと、どれが引っかかった行なのか分からなくなる
+            // （構造化中は行内のハイライトが出せないので、帯だけが手がかりになる）。
+            documentView.activeRow = (contextLines > 0 && !filterIsExplicit)
+                ? numbers.firstIndex(of: currentMatchLine) : nil
             documentView.lines = attributed
             documentView.caret = nil
             documentView.selectionByRow = [:]
@@ -1488,6 +1502,7 @@ final class PieceTableViewer: NSView, DocumentPane {
         currentMatchLine = -1
         searchTerms = []
         searchRegex = nil
+        filterIsExplicit = false     // 語で絞り直した＝時間帯の選択ではなくなった
         var invalid = false
         if regexMode {
             if !searchQuery.isEmpty {
@@ -1499,10 +1514,14 @@ final class PieceTableViewer: NSView, DocumentPane {
         }
         refresh()
         if searchQuery.isEmpty {
-            searchResults = .init(); emitSearchState(searching: false, progress: 0, invalid: false); return
+            searchResults = .init(); filterDisplayLines = []
+            if filterMode { refresh() }
+            emitSearchState(searching: false, progress: 0, invalid: false); return
         }
         if invalid {
-            searchResults = .init(); emitSearchState(searching: false, progress: 0, invalid: true); return
+            searchResults = .init(); filterDisplayLines = []
+            if filterMode { refresh() }
+            emitSearchState(searching: false, progress: 0, invalid: true); return
         }
         let mode: SearchMode = regexMode ? .regex(searchRegex!) : .terms(searchTerms)
         emitSearchState(searching: true, progress: 0, invalid: false)
@@ -1515,12 +1534,12 @@ final class PieceTableViewer: NSView, DocumentPane {
         searchEngine?.search(mode, caseSensitive: caseSensitive, progress: { [weak self] res, p in
             guard let self, self.searchEpoch == epoch else { return }
             self.searchResults = res
-            if self.filterMode { self.refresh() }
+            if self.filterMode { self.rebuildFilterDisplayLines(); self.refresh() }
             else { self.emitSearchState(searching: true, progress: Int(p * 100), invalid: false) }
         }, completion: { [weak self] res in
             guard let self, self.searchEpoch == epoch else { return }
             self.searchResults = res
-            if self.filterMode { self.rebuildStructuredColumns(); self.refresh() }
+            if self.filterMode { self.rebuildFilterDisplayLines(); self.rebuildStructuredColumns(); self.refresh() }
             else { self.emitSearchState(searching: false, progress: 100, invalid: false) }
         })
     }
@@ -1528,6 +1547,7 @@ final class PieceTableViewer: NSView, DocumentPane {
     private func clearSearchState() {
         searchQuery = ""; searchTerms = []; searchRegex = nil
         filterMode = false; searchResults = .init()
+        filterDisplayLines = []; filterIsExplicit = false
         currentMatchIdx = -1; currentMatchLine = -1
         searchEpoch += 1
         searchDebounce?.cancel()
@@ -1548,6 +1568,8 @@ final class PieceTableViewer: NSView, DocumentPane {
         guard !lines.isEmpty else {
             if filterMode { setFilterMode(false) }
             searchResults = .init()
+            filterIsExplicit = false
+            filterDisplayLines = []
             refresh()
             return
         }
@@ -1556,8 +1578,10 @@ final class PieceTableViewer: NSView, DocumentPane {
         result.lineCount = lines.count
         result.isComplete = true
         searchResults = result
+        filterIsExplicit = true      // 選んだ時間帯の外は出さない（前後 N 行を足さない）
         currentMatchIdx = 0
         currentMatchLine = lines[0]
+        rebuildFilterDisplayLines()
         if filterMode {
             topLine = 0
             rebuildStructuredColumns()
@@ -1567,16 +1591,82 @@ final class PieceTableViewer: NSView, DocumentPane {
         }
     }
 
+    /// 並べる行を組み直す（一致行＋前後 N 行）。
+    /// 一致が変わったとき・前後行数を変えたとき・フィルタに入るときに呼ぶ。
+    private func rebuildFilterDisplayLines() {
+        let matches = searchResults.lines
+        // 一致が入れ替わったら「いまの一致」も選び直す（前のクエリの行に帯が残らないように）。
+        if !filterIsExplicit {
+            let stillValid = currentMatchIdx >= 0 && currentMatchIdx < matches.count
+                && matches[currentMatchIdx] == currentMatchLine
+            if !stillValid {
+                currentMatchIdx = matches.isEmpty ? -1 : 0
+                currentMatchLine = matches.first ?? -1
+            }
+        }
+        guard !filterIsExplicit, contextLines > 0 else { filterDisplayLines = matches; return }
+        filterDisplayLines = FilterContext.expand(matches: matches,
+                                                  context: contextLines,
+                                                  lineCount: displayLineCountForContext)
+    }
+
+    /// 前後行を広げてよい範囲＝ファイルの総行数。フィルタ中は `displayCount` が
+    /// 絞り込み後の数を返すので、そちらを使うと末尾を切り落としてしまう。
+    private var displayLineCountForContext: Int {
+        if readsFromOriginal { return lineIndex?.displayLineCount ?? pieceTable?.lineCount ?? 0 }
+        return pieceTable?.lineCount ?? 0
+    }
+
+    /// 一致行を見せるときの先頭行。**前後を出しているときは前の行のぶんだけ上に寄せる。**
+    /// 一致行を最上部に置くと、せっかく出した「直前の行」が画面の上に隠れる
+    /// （前が見たくて前後を出しているので、それでは意味がない）。
+    private func filterTopRow(forFileLine line: Int) -> Int {
+        let idx = displayIndex(ofFileLine: line)
+        guard contextLines > 0, !filterIsExplicit else { return idx }
+        return max(0, idx - contextLines)
+    }
+
+    /// 表示の並びの中で、指定したファイル行がある位置（無ければその直後）。
+    private func displayIndex(ofFileLine line: Int) -> Int {
+        var lo = 0, hi = filterDisplayLines.count
+        while lo < hi { let mid = (lo + hi) / 2; if filterDisplayLines[mid] < line { lo = mid + 1 } else { hi = mid } }
+        return lo
+    }
+
+    var filterContextLines: Int { contextLines }
+
+    /// 一致行の前後に足す行数を変える。フィルタ中なら、いま見ている行を見失わない
+    /// ように**同じファイル行が先頭に残る**ように並べ直す。
+    func setFilterContextLines(_ n: Int) {
+        let clamped = min(max(0, n), FilterContext.maxContext)
+        guard clamped != contextLines else { return }
+        contextLines = clamped
+        AppSettings.filterContextLines = clamped
+        guard filterMode else { return }
+        let keep = (topLine >= 0 && topLine < filterDisplayLines.count) ? filterDisplayLines[topLine] : -1
+        rebuildFilterDisplayLines()
+        topLine = keep >= 0 ? displayIndex(ofFileLine: keep) : 0
+        scrollAccumulator = 0
+        rebuildStructuredColumns()   // 並べる行が増減する＝桁を測り直す
+        refresh()
+    }
+
     func setFilterMode(_ on: Bool) {
         guard on != filterMode else { return }
-        let matches = searchResults.lines
         if on {
             filterMode = true
-            topLine = max(0, currentMatchIdx)
+            rebuildFilterDisplayLines()
+            // 直前に見ていた一致行の位置へ。文脈行が混じると一致の番号と行番号がずれる。
+            topLine = currentMatchLine >= 0 ? filterTopRow(forFileLine: currentMatchLine) : 0
         } else {
-            let fileLine = (topLine >= 0 && topLine < matches.count) ? matches[topLine] : topLine
+            let fileLine = (topLine >= 0 && topLine < filterDisplayLines.count)
+                ? filterDisplayLines[topLine] : topLine
             filterMode = false
             topLine = fileLine
+            // 解除後の「何件目」を、いま見ている行に合わせ直す（フィルタ中に動いた分を引き継ぐ）。
+            let i = firstMatchIndex(after: fileLine) - 1
+            currentMatchIdx = i
+            currentMatchLine = i >= 0 ? searchResults.lines[i] : -1
         }
         scrollAccumulator = 0
         rebuildStructuredColumns()   // 見えている行が入れ替わる＝桁を測り直す
@@ -1587,12 +1677,44 @@ final class PieceTableViewer: NSView, DocumentPane {
         let total = searchResults.lineCount
         let current: Int
         if filterMode {
-            current = searchResults.lines.isEmpty ? 0 : min(topLine + 1, total)
+            let matches = searchResults.lines
+            if matches.isEmpty {
+                current = 0
+            } else if contextLines == 0 || filterIsExplicit {
+                current = min(topLine + 1, total)      // 表示行＝一致行なので位置がそのまま件目
+            } else {
+                // 文脈行が混じる＝表示位置と件目がずれる。先頭行までに何件通ったかを数える。
+                let fl = (topLine >= 0 && topLine < filterDisplayLines.count) ? filterDisplayLines[topLine] : 0
+                current = min(max(1, firstMatchIndex(after: fl)), total)
+            }
         } else {
             current = currentMatchIdx >= 0 ? currentMatchIdx + 1 : 0
         }
         // 総数は上限超過も数えているので正確（上限がかかるのは「移動できる一致行」だけ）。
         onSearchState?(current, total, searching, progress, invalid, false)
+    }
+
+    /// フィルタ中の「次／前の一致」の表示行。前後 N 行を出していないときは 1 行ずつの
+    /// 移動がそのまま一致の移動なので nil を返し、呼び側の既定に任せる。
+    private func filterMatchRow(forward: Bool) -> Int? {
+        guard contextLines > 0, !filterIsExplicit else { return nil }
+        let matches = searchResults.lines
+        let idx: Int
+        if currentMatchIdx >= 0, currentMatchIdx < matches.count {
+            // **表示の先頭行ではなく「いまの一致」から数える。** 末尾付近の一致は
+            // 画面の最下部に出たまま先頭には来ない（スクロールが止まる）ので、
+            // 先頭行を起点にすると最後の数件へ進めなくなる。
+            idx = forward ? (currentMatchIdx + 1) % matches.count
+                          : (currentMatchIdx - 1 + matches.count) % matches.count
+        } else {
+            // まだどの一致も指していない＝いま見えている位置から探す。
+            let fl = (topLine >= 0 && topLine < filterDisplayLines.count) ? filterDisplayLines[topLine] : -1
+            idx = forward ? min(firstMatchIndex(after: fl), matches.count - 1)
+                          : max(firstMatchIndex(after: fl - 1) - 1, 0)
+        }
+        currentMatchIdx = idx
+        currentMatchLine = matches[idx]
+        return filterTopRow(forFileLine: matches[idx])
     }
 
     private func firstMatchIndex(after line: Int) -> Int {
@@ -1603,7 +1725,11 @@ final class PieceTableViewer: NSView, DocumentPane {
     }
 
     func findNext() {
-        if filterMode { guard !searchResults.lines.isEmpty else { NSSound.beep(); return }; setTopLine(topLine + 1); return }
+        if filterMode {
+            guard !searchResults.lines.isEmpty else { NSSound.beep(); return }
+            if let row = filterMatchRow(forward: true) { setTopLine(row) } else { setTopLine(topLine + 1) }
+            return
+        }
         let lines = searchResults.lines
         guard !lines.isEmpty else { NSSound.beep(); return }
         let idx = currentMatchIdx >= 0 ? (currentMatchIdx + 1) % lines.count
@@ -1612,7 +1738,11 @@ final class PieceTableViewer: NSView, DocumentPane {
     }
 
     func findPrev() {
-        if filterMode { guard !searchResults.lines.isEmpty else { NSSound.beep(); return }; setTopLine(topLine - 1); return }
+        if filterMode {
+            guard !searchResults.lines.isEmpty else { NSSound.beep(); return }
+            if let row = filterMatchRow(forward: false) { setTopLine(row) } else { setTopLine(topLine - 1) }
+            return
+        }
         let lines = searchResults.lines
         guard !lines.isEmpty else { NSSound.beep(); return }
         let idx = currentMatchIdx >= 0 ? (currentMatchIdx - 1 + lines.count) % lines.count
@@ -1917,6 +2047,11 @@ extension PieceTableViewer {
     func _testReplaceCurrent(_ s: String) { replaceCurrent(with: s) }
     /// 一致行だけ表示が生きているか（構造化と併用できることの検証用）。
     var _testFilterMode: Bool { filterMode }
+    /// フィルタ中に並べている行（一致行＋前後 N 行）。
+    var _testFilterDisplayLines: [Int] { filterDisplayLines }
+    var _testTopLine: Int { topLine }
+    /// いま「何件目」として指している一致行（帯を敷く行）。
+    var _testCurrentMatchLine: Int { currentMatchLine }
     /// いま使っている列幅。フィルタで見えている行に追従しているかの検証用。
     var _testStructuredColumnWidths: [Int] { structuredFormatter?.columns.map(\.width) ?? [] }
     var _testSelection: Range<Int>? { selectionRange }

--- a/Tests/MrEditorTests/FilterContextPaneTests.swift
+++ b/Tests/MrEditorTests/FilterContextPaneTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+import AppKit
+@testable import MrEditorCore
+
+/// 一致行の前後 N 行（`grep -C` 相当）が、両方のペインで同じように効くこと。
+///
+/// `AppSettings.filterContextLines`（UserDefaults.standard）を触るので、
+/// 各テストで元の値へ復元する。
+final class FilterContextPaneTests: XCTestCase {
+
+    private var savedContext = 0
+
+    override func setUp() {
+        super.setUp()
+        savedContext = AppSettings.filterContextLines
+        AppSettings.filterContextLines = 0    // ペインは init でこの値を読む
+    }
+
+    override func tearDown() {
+        AppSettings.filterContextLines = savedContext
+        super.tearDown()
+    }
+
+    // MARK: - 小ファイル（EditableViewer）
+
+    private func editable(_ text: String) -> EditableViewer {
+        let v = EditableViewer()
+        v.newDocument()
+        v._testSetText(text)
+        v._testSelect(NSRange(location: 0, length: 0))
+        return v
+    }
+
+    private let log = "a0\na1\nERROR here\na3\na4\na5\na6\nERROR again\na8\n"
+
+    /// 既定（0）は今までどおり一致行だけ。
+    func testEditableFilterWithoutContextShowsOnlyMatches() {
+        let v = editable(log)
+        v.setSearchQuery("ERROR")
+        v.setFilterMode(true)
+        XCTAssertEqual(v._testText, "ERROR here\nERROR again\n")
+    }
+
+    /// ±1 で前後の行が付いてくる（塊は離れているので混ざらない）。
+    func testEditableFilterWithContextShowsNeighbours() {
+        let v = editable(log)
+        v.setSearchQuery("ERROR")
+        v.setFilterMode(true)
+        v.setFilterContextLines(1)
+        XCTAssertEqual(v._testText, "a1\nERROR here\na3\na6\nERROR again\na8\n")
+    }
+
+    /// 前後行を出しても「一致行」は一致した行だけ（分析の件数を水増ししない）。
+    func testEditableMatchLinesExcludeContext() {
+        let v = editable(log)
+        v.setSearchQuery("ERROR")
+        v.setFilterMode(true)
+        v.setFilterContextLines(2)
+        XCTAssertEqual(v.filterMatchLines ?? [], [2, 7], "文脈行を一致に数えないこと")
+    }
+
+    /// 0 に戻せば元どおり（伸ばしたら縮められる）。
+    func testEditableContextCanBeTurnedBackOff() {
+        let v = editable(log)
+        v.setSearchQuery("ERROR")
+        v.setFilterMode(true)
+        v.setFilterContextLines(3)
+        v.setFilterContextLines(0)
+        XCTAssertEqual(v._testText, "ERROR here\nERROR again\n")
+    }
+
+    /// 時間帯を指定した絞り込み（時間分布のドラッグ）には前後行を足さない。
+    /// 選んだ範囲の外の行が混ざると「選んだ時間帯」が嘘になる。
+    func testEditableExplicitLinesIgnoreContext() {
+        let v = editable(log)
+        v.setFilterContextLines(2)
+        v.showOnlyLines([4])
+        XCTAssertEqual(v._testText, "a4\n")
+        XCTAssertEqual(v.filterMatchLines ?? [], [4])
+    }
+
+    /// 上限で丸める（青天井にすると全文が出て絞り込みの意味が無くなる）。
+    func testContextIsClamped() {
+        let v = editable(log)
+        v.setFilterContextLines(-5)
+        XCTAssertEqual(v.filterContextLines, 0)
+        v.setFilterContextLines(9999)
+        XCTAssertEqual(v.filterContextLines, FilterContext.maxContext)
+    }
+
+    /// 設定として覚える（次に開いたファイルでも同じ見え方になる）。
+    func testContextPersists() {
+        editable(log).setFilterContextLines(4)
+        XCTAssertEqual(AppSettings.filterContextLines, 4)
+        XCTAssertEqual(editable(log).filterContextLines, 4, "新しいペインも覚えている値で始まる")
+    }
+
+    // MARK: - 巨大ファイル（PieceTableViewer）
+    //
+    // `_testLoad` はインメモリ原本＝`fileBuffer` を持たないので `refresh()` が
+    // 描画まで進まない。確かめるのは**並べる行の決まり方**（`filterDisplayLines`）と
+    // 「いまの一致」の動き。実画面の見え方は .app で確認する。
+
+    private func big(_ text: String) -> PieceTableViewer {
+        let v = PieceTableViewer(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        v._testLoad(Array(text.utf8))
+        return v
+    }
+
+    /// 400 行のログ。10 行ごとに `ERROR`（＝一致行は 10, 20, … 390）。
+    /// 短いログだと絞り込んだ結果が 1 画面に収まってしまい、先頭行が常に 0 へ
+    /// 丸められてスクロールの検証にならない。
+    private func longLog() -> (text: String, matches: [Int]) {
+        var lines: [String] = []
+        var matches: [Int] = []
+        for i in 0..<400 {
+            if i > 0, i % 10 == 0 { lines.append("ERROR \(i)"); matches.append(i) }
+            else { lines.append("line \(i)") }
+        }
+        return (lines.joined(separator: "\n") + "\n", matches)
+    }
+
+    func testBigFileFilterWithoutContextShowsOnlyMatches() {
+        let v = big(log)
+        v._testSetSearch(terms: ["ERROR"], matchLines: [2, 7])
+        v.setFilterMode(true)
+        XCTAssertEqual(v._testFilterDisplayLines, [2, 7])
+    }
+
+    func testBigFileFilterWithContextShowsNeighbours() {
+        let v = big(log)
+        v._testSetSearch(terms: ["ERROR"], matchLines: [2, 7])
+        v.setFilterMode(true)
+        v.setFilterContextLines(1)
+        XCTAssertEqual(v._testFilterDisplayLines, [1, 2, 3, 6, 7, 8])
+    }
+
+    /// ファイルの端で範囲外へ行かない（最終行の先を出そうとしない）。
+    func testBigFileContextClampsAtFileEnd() {
+        let v = big(log)                       // 9 行（0…8）
+        v._testSetSearch(terms: ["a8"], matchLines: [8])
+        v.setFilterMode(true)
+        v.setFilterContextLines(3)
+        XCTAssertEqual(v._testFilterDisplayLines, [5, 6, 7, 8])
+    }
+
+    /// 絞り込みに入った時点で最初の一致を指す（帯を敷く行が決まる）。
+    func testBigFileEnteringFilterSelectsFirstMatch() {
+        let v = big(log)
+        v._testSetSearch(terms: ["ERROR"], matchLines: [2, 7])
+        v.setFilterMode(true)
+        v.setFilterContextLines(1)
+        XCTAssertEqual(v._testCurrentMatchLine, 2)
+    }
+
+    /// 「次を検索」は文脈行を飛ばして次の一致まで進む
+    /// （1 行ずつスクロールすると、前後を広げるほど次の一致に着かなくなる）。
+    func testBigFileFindNextSkipsContextLines() {
+        let (text, matches) = longLog()
+        let v = big(text)
+        v._testSetSearch(terms: ["ERROR"], matchLines: matches)
+        v.setFilterMode(true)
+        v.setFilterContextLines(1)
+        XCTAssertEqual(v._testCurrentMatchLine, 10, "最初の一致")
+        v.findNext()
+        XCTAssertEqual(v._testCurrentMatchLine, 20, "次の一致行へ（間の文脈行では止まらない）")
+        XCTAssertEqual(v._testFilterDisplayLines[v._testTopLine], 19,
+                       "先頭は一致行そのものでなく前の行（出した「直前」を画面の上に隠さない）")
+        v.findPrev()
+        XCTAssertEqual(v._testCurrentMatchLine, 10, "前の一致行へ")
+    }
+
+    /// 末尾の次は先頭へ回る（前後行を出していても一巡できる）。
+    func testBigFileFindNextWrapsAround() {
+        let (text, matches) = longLog()
+        let v = big(text)
+        v._testSetSearch(terms: ["ERROR"], matchLines: matches)
+        v.setFilterMode(true)
+        v.setFilterContextLines(2)
+        for _ in 0..<(matches.count - 1) { v.findNext() }
+        XCTAssertEqual(v._testCurrentMatchLine, matches.last)
+        v.findNext()
+        XCTAssertEqual(v._testCurrentMatchLine, matches.first, "末尾の次は先頭")
+    }
+
+    /// 時間帯の指定（`showOnlyLines`）には前後行を足さない。
+    func testBigFileExplicitLinesIgnoreContext() {
+        let v = big(log)
+        v.setFilterContextLines(2)
+        v.showOnlyLines([4])
+        XCTAssertEqual(v._testFilterDisplayLines, [4])
+    }
+
+    /// 前後行を変えても、いま先頭に見えている行は先頭のまま（見失わせない）。
+    func testBigFileKeepsTopLineWhenContextChanges() {
+        let (text, matches) = longLog()
+        let v = big(text)
+        v._testSetSearch(terms: ["ERROR"], matchLines: matches)
+        v.setFilterMode(true)
+        for _ in 0..<5 { v.findNext() }
+        let top = v._testFilterDisplayLines[v._testTopLine]
+        XCTAssertEqual(top, 60, "前提: 6 件目の一致を先頭に見ている")
+        v.setFilterContextLines(2)
+        XCTAssertEqual(v._testFilterDisplayLines[v._testTopLine], top, "同じ行が先頭に残る")
+    }
+
+    /// 絞り込みを解除したら、いま見ていた行がそのまま本文の位置になる。
+    func testBigFileLeavingFilterKeepsThePlace() {
+        let (text, matches) = longLog()
+        let v = big(text)
+        v._testSetSearch(terms: ["ERROR"], matchLines: matches)
+        v.setFilterMode(true)
+        v.setFilterContextLines(1)
+        for _ in 0..<3 { v.findNext() }
+        let top = v._testFilterDisplayLines[v._testTopLine]
+        v.setFilterMode(false)
+        XCTAssertEqual(v._testTopLine, top, "解除後は元の行番号で同じ場所")
+    }
+}

--- a/Tests/MrEditorTests/FilterContextTests.swift
+++ b/Tests/MrEditorTests/FilterContextTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import MrEditorCore
+
+/// 一致行の前後 N 行（`grep -C` 相当）の展開。
+///
+/// 絞り込みは「その行だけ」を見せるが、調査は往復する。前後が見えないと
+/// フィルタを解除して行番号で探し直すことになる、というのがこの機能の動機。
+final class FilterContextTests: XCTestCase {
+    func testZeroContextReturnsMatchesUnchanged() {
+        let m = [3, 10, 11]
+        XCTAssertEqual(FilterContext.expand(matches: m, context: 0, lineCount: 100), m)
+    }
+
+    func testExpandsAroundEachMatch() {
+        XCTAssertEqual(FilterContext.expand(matches: [5], context: 2, lineCount: 100),
+                       [3, 4, 5, 6, 7])
+    }
+
+    /// 窓が重なっても行を二度出さない（`grep` が続きをまとめるのと同じ）。
+    func testOverlappingWindowsAreMerged() {
+        XCTAssertEqual(FilterContext.expand(matches: [5, 7], context: 2, lineCount: 100),
+                       [3, 4, 5, 6, 7, 8, 9])
+    }
+
+    /// 隣り合う一致は 1 つの塊になる。
+    func testAdjacentMatches() {
+        XCTAssertEqual(FilterContext.expand(matches: [5, 6], context: 1, lineCount: 100),
+                       [4, 5, 6, 7])
+    }
+
+    /// 離れていれば塊は分かれる（間の行は出さない＝ここが飛んでいる所）。
+    func testDistantMatchesStayInSeparateGroups() {
+        XCTAssertEqual(FilterContext.expand(matches: [2, 20], context: 1, lineCount: 100),
+                       [1, 2, 3, 19, 20, 21])
+    }
+
+    /// ファイルの端で範囲外へはみ出さない。
+    func testClampsToFileEnds() {
+        XCTAssertEqual(FilterContext.expand(matches: [0], context: 3, lineCount: 3), [0, 1, 2])
+        XCTAssertEqual(FilterContext.expand(matches: [9], context: 3, lineCount: 10), [6, 7, 8, 9])
+    }
+
+    func testEmptyInputs() {
+        XCTAssertEqual(FilterContext.expand(matches: [], context: 5, lineCount: 100), [])
+        XCTAssertEqual(FilterContext.expand(matches: [1], context: 5, lineCount: 0), [1],
+                       "行数が分からないときは触らない（切り落とすより出さない方が安全）")
+    }
+
+    /// 一致が完全に既出の窓へ埋もれても、順序と重複なしが崩れない。
+    func testResultIsSortedAndUnique() {
+        let out = FilterContext.expand(matches: [4, 5, 6, 7, 30], context: 10, lineCount: 50)
+        XCTAssertEqual(out, Array(0...17) + Array(20...40))
+        XCTAssertEqual(out, out.sorted())
+        XCTAssertEqual(out.count, Set(out).count)
+    }
+
+    /// 上限で止める（100 万一致 × 前後 100 行を素直に展開すると 1.6GB になる）。
+    func testStopsAtDisplayCap() {
+        let matches = Array(stride(from: 0, to: 4_000_000, by: 2))
+        let out = FilterContext.expand(matches: matches, context: 1, lineCount: 4_000_000)
+        XCTAssertEqual(out.count, FilterContext.displayCap)
+        XCTAssertEqual(out.first, 0)
+    }
+}


### PR DESCRIPTION
絞り込みは「その行だけ」を見せるが、調査は往復する。エラー行の直前に何が起きたか、直後にどう転んだかは、たいてい隣の行にある。前後が見えないと絞り込んだ瞬間に文脈を失い、フィルタを解除して行番号を頼りに探し直すことになっていた。

## 中身

- 展開は純関数（`Core/FilterContext.swift`）。窓が重なったら潰して昇順・重複なしで返す。区切り線は入れない — 行番号のガターに元の行番号が出ているので飛びは読める。
- 入口は 2 つ。検索バーの「±」欄と、⌥⌘] / ⌥⌘[ で 1 行ずつ。ボタンやアイコンでなく**文字と数字**（「±2」と出ていれば何が起きているか読める）。値はアプリの設定として覚える。上限 100 行・展開後 100 万行で打ち切り。
- 大ファイル・小ファイルの両ペイン。時間分布のドラッグで絞ったときは足さない（選んだ時間帯の外が混ざると「選んだ範囲」が嘘になる）。
- 前後を出しているときは、いまの一致行に帯を敷く。構造化中は行内のハイライトが出せず、文脈行と一致行が同じ見た目で並ぶとどれが引っかかった行か分からなくなるため。

## 画面で初めて出た 3 件（このPRで修正済み）

- 構造化中の列幅を一致行だけで測っていた → 文脈行が `con…` と潰れる。測る対象を「表示している行」へ。
- 件数（「18 件中 1 件目」）が窓を詰めると末尾から切れて何件目か読めない → 縮むのは検索欄だけに。
- 一致行を最上部に寄せていたので、出した直前の行が画面の上に隠れていた → 前後のぶんだけ上へ寄せる。

## 確認

- `swift test` 641 green（6 skip・0 failure）
- 署名済み .app で 4 経路（大/小ファイル × ± 欄/キーボード）とも実機確認