### PR TITLE
証明書が2枚あるときの署名方法を手順書に足す

### DIFF
--- a/scripts/make_dmg.sh
+++ b/scripts/make_dmg.sh
@@ -18,6 +18,20 @@
 #     NOTARY_PROFILE=mreditor \
 #     sh scripts/make_dmg.sh
 #
+#   ■ 証明書が 2 枚あるときは、名前ではなくハッシュで指す
+#     同名の証明書が別々のキーチェーン（login と System）にあると、codesign は
+#     名前を解決できずに `ambiguous (matches …)` で止まる。1.12.6 のビルドが
+#     ここで落ちた。40 桁の SHA-1 で指せば曖昧さは無くなる:
+#
+#       security find-identity -v -p codesigning   # 行頭の 40 桁がハッシュ
+#       SIGN_IDENTITY=CB470780A956A25E8DAE448646A06235156EDC38 \
+#       NOTARY_PROFILE=mreditor sh scripts/make_dmg.sh
+#
+#     どちらを使うかは失効日で決める（`security find-certificate -a -Z -c \
+#     "Developer ID Application" <keychain> | openssl x509 -noout -dates`）。
+#     署名済みのバイナリは、公証とタイムスタンプが付いていれば**証明書が切れた
+#     あとも検証を通る**ので、慌てて作り直す必要はない。切れる前に次を用意する。
+#
 #   公証は Apple のサーバへ送って審査を待つ（数分）。成功したら staple で
 #   チケットを dmg に焼き付ける。これでオフラインでも Gatekeeper を通る。
 set -e


### PR DESCRIPTION
## 何を

`scripts/make_dmg.sh` の手順書に、**Developer ID 証明書が複数あるとき**の指定方法を足す。

## なぜ

1.12.6 のビルドがここで落ちた。

```
Developer ID Application: Hitoshi TABATA (G8E27F3U7R): ambiguous
  (matches "…" in /Library/Keychains/System.keychain
   and "…" in /Users/hitoshi/Library/Keychains/login.keychain-db)
```

同名の証明書が login と System の両方にあると、`codesign` は名前を解決できずに止まる。手順書には名前で書く例しか無いので、**次のリリースでも同じ場所で止まる**。

## 足したこと

- 40 桁の SHA-1 で指せること（`security find-identity -v -p codesigning` の行頭）
- どちらを使うかは**失効日**で決めること（コマンド付き）。手元の 2 枚は 2027-02 と 2031-07 で、10 分違いで発行されている
- **公証とタイムスタンプが付いた署名は、証明書が切れたあとも検証を通る**こと

最後の 1 点を書いたのは、これが無いと「もうすぐ切れる証明書で署名した版」を作り直したくなるため。Gatekeeper が見るのはタイムスタンプ時点の有効性で、配布済みのものは切れても動く。

## 確かめたこと

- `sh -n scripts/make_dmg.sh`（構文）
- 1.12.6 の dmg は、この手順（ハッシュ指定）で実際に署名・公証まで通っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GboTE2DnQv8z3Vf3QHqcJU
