### PR TITLE
隣の Pro がまだビルドできるかを、リリース前に確かめる

### DIFF
--- a/.consistency.json
+++ b/.consistency.json
@@ -110,5 +110,9 @@
     "code_dir": "Sources",
     "free_main": "Sources/MrEditor/main.swift",
     "free_main_must_contain": "MrEditorApp.main()"
+  },
+  "downstream_build": {
+    "path": "../MrkEditor",
+    "label": "MrkEditor (Pro)"
   }
 }

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -18,6 +18,7 @@
   5. release_docs   … 公開したタグが文書に載っているか
   6. measured       … 公表値が文書間で食い違っていないか
   7. pro_gate       … 無料版に未ゲートの有償機能が載っていないか
+  8. downstream_build … path 依存で繋がっている Pro 側が、まだビルドできるか
 """
 
 import hashlib
@@ -298,6 +299,59 @@ def check_pro_gate(cfg: dict) -> None:
         print("  無料版に未ゲートの有償機能なし ✅")
 
 
+# 8. 下流のビルド -------------------------------------------------------------
+
+def check_downstream_build(cfg: dict) -> None:
+    """**core を直すと、path 依存で繋がっている Pro 側が黙って壊れる。**
+
+    2026-09-05 に `StructuredMode` へ `.fixedWidth` を足したら、Pro 側の switch 2 箇所が
+    網羅でなくなってビルド不能になり、**6 日間気づかなかった**。公開リポの CI は公開リポ
+    しか見ないので、この破損はここでしか捕まらない。
+
+    **壊れた瞬間ではなく「リリースの準備を始めるとき」に知ればよい**と決めてここに置いて
+    いる。push ごとにビルドすると 30〜60 秒が毎回乗り、やがて `--no-verify` で迂回される
+    ——迂回されるゲートは無いのと同じなので、回数の少ない側に寄せた。
+
+    隣に無ければ飛ばす。ただし**飛ばしたことは必ず言う**（黙って通る検査は、半年後に
+    「動いていたつもり」になる）。CI では常に飛ぶ。
+    """
+    head(f"下流のビルド（{cfg['label']}）")
+
+    path = (ROOT / cfg["path"]).resolve()
+    if not (path / "Package.swift").exists():
+        print(f"  ⏭  飛ばした — {path} が無い（CI では常にこうなる）")
+        return
+
+    print(f"  swift build: {path} …", flush=True)
+    try:
+        proc = subprocess.run(["swift", "build"], cwd=path,
+                              capture_output=True, text=True, timeout=900)
+    except FileNotFoundError:
+        WARN.append(f"{cfg['label']} を確かめられない（swift が無い）")
+        print("  ⏭  飛ばした — swift が見つからない")
+        return
+    except subprocess.TimeoutExpired:
+        FAIL.append(f"{cfg['label']} のビルドが 15 分で終わらなかった")
+        return
+
+    if proc.returncode == 0:
+        print("  通った ✅")
+        return
+
+    # 診断は stdout / stderr のどちらにも出る（SwiftPM の版で変わる）。
+    errors = [l for l in (proc.stdout + proc.stderr).splitlines() if ": error:" in l]
+    seen: list[str] = []
+    for line in errors:                       # 同じ行が 2 回出る（対象ごとに 1 回）
+        if line not in seen:
+            seen.append(line)
+    FAIL.append(f"{cfg['label']} がビルドできない＝core の変更が届いていない"
+                + (f"（先頭: {seen[0]}）" if seen else f"（exit {proc.returncode}）"))
+    for line in seen[:5]:
+        print(f"    {line}")
+    if len(seen) > 5:
+        print(f"    … ほか {len(seen) - 5} 件")
+
+
 def main() -> int:
     cfg = load_config()
     print(f"整合性チェック: {cfg.get('product', ROOT.name)}")
@@ -309,6 +363,7 @@ def main() -> int:
     if cfg.get("release_docs"):   check_release_coverage(cfg["release_docs"])
     if cfg.get("measured"):       check_measured_numbers(cfg["measured"], cfg.get("docs", []))
     if cfg.get("pro_gate"):       check_pro_gate(cfg["pro_gate"])
+    if cfg.get("downstream_build"): check_downstream_build(cfg["downstream_build"])
 
     print()
     for w in WARN:


### PR DESCRIPTION
## なぜ

core を直すと、path 依存で繋がっている Pro 側（MrkEditor）が黙って壊れる。

実際に壊れていた。`StructuredMode` に `.fixedWidth` を足した 9/5 から **6 日間、Pro は
ビルド不能**だったのに誰も気づかなかった（`MrkPro` の switch 2 箇所が網羅でなくなっていた）。
このリポジトリの CI はこのリポジトリしか見ないので、**この種の破損はここでしか捕まらない。**

## 何をするか

`check_consistency.py` に §8「下流のビルド」を足した。隣に `../MrkEditor` があれば
`swift build` を通し、無ければ飛ばす。

```
──── 下流のビルド（MrkEditor (Pro)）
  swift build: /Users/hitoshi/Git/MrkEditor …
  通った ✅
```

壊れているときは `FAIL` に積んで exit 1（手元で確認済み）。

```
❌ 1 件の不整合:
   - MrkEditor (Pro) がビルドできない＝core の変更が届いていない（先頭: …error: …）
```

## 置き場所を「リリース前」にした理由

`pre-push` フックにする案は採らなかった。`git push` ごとに 30〜60 秒が乗り、やがて
`--no-verify` で迂回される ── **迂回されるゲートは無いのと同じ**なので、回数の少ない側へ寄せた。

代償は「壊れた瞬間には気づかない」こと。修理はいつも switch に case を足すだけで機械的
（今回も 2 行）なので、それは受け入れる。

## CI では常に飛ぶ

Actions には隣のリポジトリが無いので、この節は毎回 skip になる。ただし
**飛ばしたことは必ず出力する** ── 黙って通る検査は、半年後に「動いていたつもり」になる。

```
  ⏭  飛ばした — /path/to/MrkEditor が無い（CI では常にこうなる）
```

## 確認したこと

- 手元で `python3 scripts/check_consistency.py` を全節通した（版・日英パリティ・i18n・
  公表値・課金境界・下流のビルド、すべて緑）
- Pro 側にわざと壊れたファイルを置いて、**赤くなることも確認**した
- 設定キー（`downstream_build`）が無い製品では節ごと飛ぶので、このスクリプトを
  MRDown 側へコピーしても何も起きない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6RA4gCmuCwRcngrDd1p1o