### PR TITLE
Pro が BYOK の AI を使えるように、口を 1 つ開ける

### DIFF
--- a/Sources/MrEditorCore/Pro/Pro.swift
+++ b/Sources/MrEditorCore/Pro/Pro.swift
@@ -75,6 +75,50 @@ public extension ProProvider {
     func perform(_ feature: ProFeature, in window: NSWindow?) -> Bool { false }
 }
 
+/// Pro が**無料コアの BYOK AI**を使うための口。
+///
+/// ## なぜこの形か
+///
+/// AI の配線（プロバイダ 3 つ・キーの保管・SSE の受信）は元から**無料側の機能**で、Pro 固有の
+/// ものではない。Pro 側にもう 1 本書くと、実装が二重になるうえ**キーの置き場も二重**になる
+/// （Pro は別バンドル ID ＝ Keychain が別なので、利用者がキーを入れ直すことになる）。
+///
+/// かといって `AIClient` / `AIConfig` / `AIProvider` を `public` にはしない。**モデルの一覧は
+/// 版ごとに変わる場所**で、公開 API にすると直せなくなる（`gemini-2.5-flash` は確認した時点で
+/// 既に 404 だった、という類のことが起きる）。
+///
+/// そこで**公開するのはこの struct だけ**にする。中の型は internal のまま、core が実装を
+/// 持ち、Pro は呼ぶだけ。**キーは Pro に渡らない。**
+public struct ProAIBridge {
+
+    /// 使える見込みがあるか（＝プロバイダが選ばれているか）。
+    ///
+    /// ⚠️ **キーチェーンを読まない。** ここでキーの有無まで確かめると、Pro は別バンドル ID
+    /// ＝別アプリなので **macOS が「キーチェーンの機密情報を使おうとしています」と
+    /// パスワードを聞く。** 画面を描くために聞かれるのは筋が悪い（実機で踏んだ ──
+    /// 俯瞰タブを開いただけでダイアログが出た）。
+    /// **キーを触るのは実際に送るときだけ**にして、無ければ `ask` が `notConfigured` を返す。
+    public let isConfigured: () -> Bool
+
+    /// 画面に出す名前（「Anthropic (Claude)」など）。未設定なら nil。
+    public let providerName: () -> String?
+
+    /// 一往復。`completion` はメインスレッド。
+    ///
+    /// ストリーミングではなく**一往復**にしてある。Pro 側の用途（俯瞰に 1 つ聞く）は
+    /// 「聞いて、答えが出る」で足り、途中経過を出す必要が無い ── 口は小さいほど直しやすい。
+    public let ask: (_ system: String, _ user: String, _ maxTokens: Int,
+                     _ completion: @escaping (Result<String, Error>) -> Void) -> Void
+
+    public init(isConfigured: @escaping () -> Bool,
+                providerName: @escaping () -> String?,
+                ask: @escaping (String, String, Int, @escaping (Result<String, Error>) -> Void) -> Void) {
+        self.isConfigured = isConfigured
+        self.providerName = providerName
+        self.ask = ask
+    }
+}
+
 /// 機能ゲート。UI からはこれだけを見る。
 public enum Pro {
     /// 差し込まれた Pro 層（無料ビルドでは nil のまま）。
@@ -107,6 +151,19 @@ public enum Pro {
         guard allows(feature), let provider else { return false }
         return provider.perform(feature, in: window)
     }
+
+    /// BYOK の AI を Pro から使う口。**core が実装を持ち、Pro は呼ぶだけ。**
+    ///
+    /// 無料ビルドでもここは存在するが、**誰も呼ばない**（無料側の AI はメニューから直に
+    /// `AIClient` を使う）。Pro 側が使うかどうかは Pro 側が決める。
+    public static let ai = ProAIBridge(
+        isConfigured: { true },     // プロバイダは必ず選ばれている（既定あり）。キーは見ない
+        providerName: { AppSettings.aiConfig.provider.displayName },
+        ask: { system, user, maxTokens, completion in
+            AIClient.send(AIPrompt(system: system, user: user, maxTokens: maxTokens)) { result in
+                completion(result.mapError { $0 as Error })
+            }
+        })
 
     /// テスト用。差し込みを外す。
     static func resetForTesting() {


### PR DESCRIPTION
## なぜ

C4（AI 俯瞰）で、**どの AI に聞くかを利用者が選べるようにする**ため。選択肢は 2 つ。

- **端末内**（`FoundationModels`）── キー不要・ログが Mac から出ない・ただし答えが弱い
- **BYOK**（Claude / OpenAI / Gemini）── 質は良い・キーが要る

後者は無料コアの配線を使う必要がある。AI の配線（プロバイダ 3 つ・キーの保管・SSE の受信）は
元から**無料側の機能**で、Pro 固有のものではない。

## 何を公開するか

`ProAIBridge` という struct 1 つだけ。`AIClient` / `AIConfig` / `AIProvider` は internal のまま。

```swift
public struct ProAIBridge {
    public let isConfigured: () -> Bool
    public let providerName: () -> String?
    public let ask: (String, String, Int, @escaping (Result<String, Error>) -> Void) -> Void
}
```

`PRO.md` の「core 側に穴を開けるときは `Sources/MrEditorCore/Pro/` の型だけを増やす」に沿っている。

## 採らなかった案

| | 理由 |
| :--- | :--- |
| `AIClient` を public に | **モデルの一覧が公開 API になる。**版ごとに変わる場所なので固定されると困る |
| Pro 側にクライアントをもう 1 本 | 実装が二重。**Keychain も別**になり、利用者がキーを入れ直すことになる |
| `@_spi(Pro)` | 近いが、出荷済みファイル 4 本に注釈を撒くことになる。core が主導権を持てない |

## キーチェーンを読まない理由（実機で踏んだ）

最初 `isConfigured` でキーの有無まで確かめていたら、**俯瞰タブを開いただけで**
macOS が「MrkEditor がキーチェーン内の "MrEditor.AI" に保存されている機密情報を使用しようと
しています」とパスワードを聞いた。Pro は別バンドル ID ＝ 別アプリだから。

画面を描くために聞かれるのは筋が悪いので、**キーを触るのは実際に送るときだけ**にした。
無ければ `ask` が `notConfigured` を返し、無料側が既に持っている
「AI が未設定です。環境設定の「AI」で…」がそのまま出る。

## 確認したこと

- `swift test` 782 件緑
- `python3 scripts/check_consistency.py` 全節緑（課金境界・下流のビルド含む）
- 実機（Pro の配布 .app）で、俯瞰タブを開いてもキーチェーンのダイアログが出ないこと

無料ビルドの動きは変わらない。`Pro.ai` は存在するが、無料側の AI はメニューから直に
`AIClient` を使うので、**誰も呼ばない**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6RA4gCmuCwRcngrDd1p1o